### PR TITLE
chore: bump manifest version to 0.2.1

### DIFF
--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -12,5 +12,5 @@
     "pyOpenSSL>=23.0",
     "smartthings-local>=0.1.0"
   ],
-  "version": "0.1.0"
+  "version": "0.2.1"
 }

--- a/tests/localthings/test_diagnostics.py
+++ b/tests/localthings/test_diagnostics.py
@@ -1,11 +1,18 @@
 """Tests for the diagnostics platform."""
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from homeassistant.core import HomeAssistant
 
 from custom_components.localthings.const import DOMAIN
 from custom_components.localthings.diagnostics import async_get_config_entry_diagnostics
 from custom_components.localthings.registry.redact import REDACTED
+
+_MANIFEST_VERSION = json.loads(
+    (Path(__file__).parents[2] / 'custom_components' / 'localthings' / 'manifest.json').read_text()
+)['version']
 
 
 async def test_diagnostics_shape_and_redaction(
@@ -19,7 +26,7 @@ async def test_diagnostics_shape_and_redaction(
     assert diagnostics["device_type"] == 'refrigerator'
     assert diagnostics["one_ui_version"] == '7.0 Refrigerator'
     assert diagnostics["unbound_hrefs"] == []
-    assert diagnostics["integration_version"] == '0.1.0'
+    assert diagnostics["integration_version"] == _MANIFEST_VERSION
     assert diagnostics["smartthings_local_version"]
 
     resources = diagnostics["resources"]


### PR DESCRIPTION
## Summary
- `manifest.json`'s version was still `0.1.0` despite two releases (v0.2.0, v0.2.1) already being cut — bumped it to `0.2.1` to match.
- The diagnostics test hardcoded the expected version as a literal string, which broke as soon as the manifest changed. Fixed it to read `manifest.json` directly so it can't drift out of sync again.

## Test plan
- [x] `pytest tests/ -q` — 206 passed