### PR TITLE
feat: add AI energy level select and self-check error sensor for TP1X refrigerator

### DIFF
--- a/custom_components/localthings/registry/by_type/refrigerator.py
+++ b/custom_components/localthings/registry/by_type/refrigerator.py
@@ -20,6 +20,7 @@ REGISTRY = DeviceRegistry(
         dishwasher.DIAGNOSIS,
         fridge.ICEMAKER_NIGHTTIME,
         fridge.FLEX_ZONE,
+        fridge.AI_ENERGY_LEVEL,
         fridge.REFRIGERATION,
         fridge.AUTOFILL,
         fridge.WELCOME_LIGHTING,

--- a/custom_components/localthings/registry/capabilities/fridge.py
+++ b/custom_components/localthings/registry/capabilities/fridge.py
@@ -242,6 +242,14 @@ SELF_CHECK = Capability(
         SensorDesc(key='selfcheck_result', field='x.com.samsung.da.result',
                    name='Self-check result', icon='mdi:clipboard-check-outline',
                    entity_category='diagnostic'),
+        # List of error codes from the last self-check; joined for display.
+        # Not every fridge reports the field, hence the exists_fn.
+        SensorDesc(key='selfcheck_error', field='x.com.samsung.da.error',
+                   name='Self-check error', icon='mdi:alert-circle-outline',
+                   entity_category='diagnostic',
+                   exists_fn=lambda rep, resources: (
+                       not rep or 'x.com.samsung.da.error' in rep),
+                   value_fn=lambda v: ', '.join(v) if isinstance(v, list) else v),
         ButtonDesc(key='selfcheck_start', field='', name='Start self-check',
                    payload='Start', icon='mdi:play-circle-outline',
                    entity_category='diagnostic',
@@ -577,6 +585,31 @@ FLEX_ZONE = Capability(
                        rep.get('x.com.samsung.da.supportedOptions')),
                    rep_fn=_flex_zone_current,
                    write_fn=_flex_zone_write),
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# AI energy-saving level
+#
+# supportedAiLevel is a single-entry list ('1' only) on some hardware, where
+# a select would offer no real choice — gated to >1 supported level.
+# ---------------------------------------------------------------------------
+
+AI_ENERGY_LEVEL = Capability(
+    href='/energy/ailevel/vs/0',
+    poll_tier='cold',
+    entities=(
+        SelectDesc(key='ai_energy_level', field='aiLevel',
+                   name='AI energy level', icon='mdi:leaf',
+                   translation_key='ai_energy_level',
+                   entity_category='config',
+                   options_field='supportedAiLevel',
+                   exists_fn=lambda rep, resources: (
+                       not rep or (
+                           isinstance((sl := rep.get('supportedAiLevel')), (list, tuple))
+                           and len(sl) > 1)),
+                   write_fn=lambda p, rep, href=None: (
+                       ['energy', 'ailevel', 'vs', '0'], {'aiLevel': p})),
     ),
 )
 

--- a/custom_components/localthings/registry/capabilities/fridge.py
+++ b/custom_components/localthings/registry/capabilities/fridge.py
@@ -249,7 +249,7 @@ SELF_CHECK = Capability(
                    entity_category='diagnostic',
                    exists_fn=lambda rep, resources: (
                        not rep or 'x.com.samsung.da.error' in rep),
-                   value_fn=lambda v: ', '.join(v) if isinstance(v, list) else v),
+                   value_fn=lambda v: (', '.join(v) if v else None) if isinstance(v, list) else v),
         ButtonDesc(key='selfcheck_start', field='', name='Start self-check',
                    payload='Start', icon='mdi:play-circle-outline',
                    entity_category='diagnostic',
@@ -599,6 +599,8 @@ AI_ENERGY_LEVEL = Capability(
     href='/energy/ailevel/vs/0',
     poll_tier='cold',
     entities=(
+        # Only levels '1'/'2' have translated labels in strings.json/translations;
+        # a higher supportedAiLevel entry renders as its raw value until added.
         SelectDesc(key='ai_energy_level', field='aiLevel',
                    name='AI energy level', icon='mdi:leaf',
                    translation_key='ai_energy_level',

--- a/custom_components/localthings/registry/capabilities/ignored.py
+++ b/custom_components/localthings/registry/capabilities/ignored.py
@@ -85,14 +85,9 @@ IGNORED: list[Capability] = [
     # Warranty/service-plan enrollment status — every field reads "Unknown"
     # on hardware not enrolled in a Samsung Care+ style program.
     Capability(href='/dginformation/vs/0'),
-    # AI energy-saving level; only one value ('1') is ever in
-    # supportedAiLevel on hardware seen so far, so there's no real choice
-    # to expose. Revisit if a device surfaces more than one supported level.
-    Capability(href='/energy/ailevel/vs/0'),
     # OCF-native vacation-mode flag (fridge). Only one value ('RVACATION_OFF')
-    # has ever been seen in `modes` (issue #7's dump), same "no real choice
-    # to expose yet" situation as /energy/ailevel/vs/0 above. Revisit if a
-    # device surfaces it toggled on.
+    # has ever been seen in `modes` (issue #7's dump) -- no real choice to
+    # expose yet. Revisit if a device surfaces it toggled on.
     Capability(href='/mode/0'),
     # Opaque integer with no supportedModes/options list to interpret it
     # against — meaning unclear from the raw resource alone.

--- a/custom_components/localthings/strings.json
+++ b/custom_components/localthings/strings.json
@@ -143,6 +143,12 @@
           "180": "3 hr",
           "240": "4 hr"
         }
+      },
+      "ai_energy_level": {
+        "state": {
+          "1": "Level 1",
+          "2": "Level 2"
+        }
       }
     },
     "sensor": {

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -143,6 +143,12 @@
           "180": "3 hr",
           "240": "4 hr"
         }
+      },
+      "ai_energy_level": {
+        "state": {
+          "1": "Level 1",
+          "2": "Level 2"
+        }
       }
     },
     "sensor": {

--- a/tests/fixtures/golden/refrigerator.json
+++ b/tests/fixtures/golden/refrigerator.json
@@ -1,5 +1,6 @@
 {
   "state_keys": [
+    "ai_energy_level",
     "alarm_code",
     "auto_door_opener",
     "autofill",
@@ -39,11 +40,13 @@
     "rapid_freezing",
     "rapid_fridge",
     "sabbath_mode",
+    "selfcheck_error",
     "selfcheck_result",
     "selfcheck_status",
     "welcome_lighting"
   ],
   "discovery_unique_ids": [
+    "samsung_refrigerator_ai_energy_level",
     "samsung_refrigerator_alarm_code",
     "samsung_refrigerator_auto_door_opener",
     "samsung_refrigerator_autofill",
@@ -83,6 +86,7 @@
     "samsung_refrigerator_rapid_freezing",
     "samsung_refrigerator_rapid_fridge",
     "samsung_refrigerator_sabbath_mode",
+    "samsung_refrigerator_selfcheck_error",
     "samsung_refrigerator_selfcheck_result",
     "samsung_refrigerator_selfcheck_start",
     "samsung_refrigerator_selfcheck_status",

--- a/tests/fixtures/golden/refrigerator_tp1x_ref_21k_us.json
+++ b/tests/fixtures/golden/refrigerator_tp1x_ref_21k_us.json
@@ -28,6 +28,7 @@
     "rapid_freezing",
     "rapid_fridge",
     "sabbath_mode",
+    "selfcheck_error",
     "selfcheck_result",
     "selfcheck_status"
   ]

--- a/tests/fixtures/refrigerator_device.json
+++ b/tests/fixtures/refrigerator_device.json
@@ -279,7 +279,8 @@
       "rep": {
         "aiLevel": "1",
         "supportedAiLevel": [
-          "1"
+          "1",
+          "2"
         ],
         "href": "/energy/ailevel/vs/0"
       }

--- a/tests/test_fridge_capabilities.py
+++ b/tests/test_fridge_capabilities.py
@@ -260,6 +260,12 @@ class TestSelfCheckError:
         desc = self._desc()
         assert desc.value_fn('DA_ERROR_NONE') == 'DA_ERROR_NONE'
 
+    def test_value_none_for_empty_list(self):
+        """An empty error list means no value to show -- None (unknown),
+        not an empty string."""
+        desc = self._desc()
+        assert desc.value_fn([]) is None
+
 
 class TestAiEnergyLevel:
     """AI energy-saving level select on /energy/ailevel/vs/0 -- only

--- a/tests/test_fridge_capabilities.py
+++ b/tests/test_fridge_capabilities.py
@@ -171,6 +171,7 @@ class TestTp1xNativeDuplicateResources:
         assert 'ice_maker_enabled' not in state
         assert state['icemaker_one_enabled'] is True
         assert state['icemaker_two_enabled'] is True
+        assert state['selfcheck_error'] == 'DA_ERROR_NONE'
 
 
 class TestPantryZone:
@@ -228,3 +229,93 @@ class TestArtik051AndTp2xFixturesHaveCompleteCoverage:
         assert unbound == []
         state = flatten(bound, resources)
         assert state['flex_zone_mode'] == 'CV_FDR_BEVERAGE'
+
+
+class TestSelfCheckError:
+    """Self-check diagnostic error list -- surfaced on hardware that reports
+    x.com.samsung.da.error, joined into a single display string."""
+
+    def _desc(self):
+        return next(e for e in fridge.SELF_CHECK.entities if e.key == 'selfcheck_error')
+
+    def test_exists_when_field_present(self):
+        desc = self._desc()
+        assert desc.exists_fn({'x.com.samsung.da.error': ['DA_ERROR_NONE']}, {}) is True
+
+    def test_does_not_exist_when_field_absent(self):
+        desc = self._desc()
+        assert desc.exists_fn({'x.com.samsung.da.status': 'Ready'}, {}) is False
+
+    def test_exists_for_empty_stub_rep(self):
+        """An empty {} rep is /device/0's not-yet-fetched-stub carve-out --
+        must be included-for-now, same as ENERGY_METER's fields."""
+        desc = self._desc()
+        assert desc.exists_fn({}, {}) is True
+
+    def test_value_joins_list(self):
+        desc = self._desc()
+        assert desc.value_fn(['E1', 'E2']) == 'E1, E2'
+
+    def test_value_passes_through_scalar(self):
+        desc = self._desc()
+        assert desc.value_fn('DA_ERROR_NONE') == 'DA_ERROR_NONE'
+
+
+class TestAiEnergyLevel:
+    """AI energy-saving level select on /energy/ailevel/vs/0 -- only
+    exposed when the device actually offers more than one level; hardware
+    that only ever reports a single supported level keeps this ignored
+    (see capabilities/ignored.py)."""
+
+    def test_href(self):
+        assert fridge.AI_ENERGY_LEVEL.href == '/energy/ailevel/vs/0'
+
+    def test_hidden_with_single_supported_level(self):
+        desc = fridge.AI_ENERGY_LEVEL.entities[0]
+        assert desc.exists_fn({'aiLevel': '1', 'supportedAiLevel': ['1']}, {}) is False
+
+    def test_shown_with_multiple_supported_levels(self):
+        desc = fridge.AI_ENERGY_LEVEL.entities[0]
+        assert desc.exists_fn(
+            {'aiLevel': '1', 'supportedAiLevel': ['1', '2']}, {}) is True
+
+    def test_exists_for_empty_stub_rep(self):
+        """An empty {} rep is /device/0's not-yet-fetched-stub carve-out --
+        must be included-for-now, same as ENERGY_METER's fields."""
+        desc = fridge.AI_ENERGY_LEVEL.entities[0]
+        assert desc.exists_fn({}, {}) is True
+
+    def test_hidden_when_supported_level_is_non_list_scalar(self):
+        """A stray scalar (e.g. a string) must not be len()-checked as if it
+        were a list -- a 5-char string would otherwise wrongly pass `> 1`."""
+        desc = fridge.AI_ENERGY_LEVEL.entities[0]
+        assert desc.exists_fn(
+            {'aiLevel': '1', 'supportedAiLevel': '12'}, {}) is False
+
+    def test_write(self):
+        desc = fridge.AI_ENERGY_LEVEL.entities[0]
+        path, body = desc.write_fn('2', {})
+        assert path == ['energy', 'ailevel', 'vs', '0']
+        assert body == {'aiLevel': '2'}
+
+    def test_synthetic_fixture_has_complete_coverage(self):
+        """refrigerator_device.json's supportedAiLevel was extended to two
+        entries (['1', '2']) specifically to exercise this select -- the
+        real captured TP1X_REF_21K_US dump only ever reports one entry, so
+        this capability is synthetic-fixture-only for now."""
+        from custom_components.localthings.registry.adapter import flatten
+        from custom_components.localthings.registry.by_type import refrigerator
+        from custom_components.localthings.registry.discovery import discover
+        from tests.conftest import _load_device
+
+        resources = _load_device('refrigerator')
+        unbound = []
+        bound = discover(
+            resources,
+            refrigerator.REGISTRY.capabilities,
+            refrigerator.REGISTRY.pattern_capabilities,
+            log=unbound.append,
+        )
+        assert unbound == []
+        state = flatten(bound, resources)
+        assert state['ai_energy_level'] == '1'


### PR DESCRIPTION
Adds two small, additive fridge capabilities that were left on the table after #24 added TP1X support.

## What's added

- **AI energy level select** (`/energy/ailevel/vs/0`, `ai_energy_level`): exposes the fridge's AI energy-saving level as a select. This resource was previously in the global ignore list because every dump seen so far only reported one entry in `supportedAiLevel` (no real choice to offer). The capability now binds the href but gates the entity behind `supportedAiLevel` actually containing more than one value, so hardware with only a single level continues to fall through cleanly with no entity created, while hardware that does offer multiple levels gets a usable select instead of a permanently-ignored resource.
- **Self-check error sensor** (existing `SELF_CHECK` capability, `selfcheck_error`): adds a diagnostic sensor for `x.com.samsung.da.error`, the error-code list from the last self-check run. It's gated by `exists_fn` since not every fridge reports the field. Combined with the existing `selfcheck_status`/`selfcheck_result`/`selfcheck_start` entities, this gives a full picture of self-check state instead of an incomplete one.

## Scope

This is purely additive on top of #24. It intentionally does not touch `FLEX_ZONE` / `/mode/vs/0` (that's #32, already fixed on `main`) or `/icemaker/status/0`.

## Test coverage

- `selfcheck_error` is exercised against the real captured `refrigerator_tp1x_ref_21k_us` fixture — that dump's `/selfcheck/vs/0` does include `x.com.samsung.da.error: ["DA_ERROR_NONE"]`, so this is real-fixture coverage. The golden for that fixture (`tests/fixtures/golden/refrigerator_tp1x_ref_21k_us.json`) has been regenerated via real discovery to include the new key, and `TestTp1xNativeDuplicateResources.test_us_fixture_has_complete_coverage` now asserts the value.
- `ai_energy_level` is synthetic-only: the real TP1X_REF_21K_US dump's `supportedAiLevel` only has one entry (`["1"]`), so `exists_fn` correctly hides the select on that hardware and it can't be exercised through the real fixture. The existing scrubbed `tests/fixtures/refrigerator_device.json` synthetic fixture already had a single-entry `/energy/ailevel/vs/0` resource (to exercise the "hidden" path); I extended its `supportedAiLevel` to `["1", "2"]` so it also exercises the "shown" path, and regenerated `tests/fixtures/golden/refrigerator.json` accordingly. `TestAiEnergyLevel.test_synthetic_fixture_has_complete_coverage` documents and asserts this.
- New unit tests in `tests/test_fridge_capabilities.py` (`TestSelfCheckError`, `TestAiEnergyLevel`) cover the `exists_fn` gating, `value_fn`/`write_fn` behavior, and the href for both capabilities directly, plus zero-unbound-hrefs checks against the fixtures above.

`pytest tests/ -q`: 290 passed, 1 failed (`tests/localthings/test_config_flow.py::test_find_live_ports_detects_silent_port`, the pre-existing WSL loopback-socket flake — unrelated to this change).

May need a trivial rebase once other open fridge/energy work lands, but there's currently nothing open that overlaps these two hrefs.
