### PR TITLE
Bump version to 0.10.1

### DIFF
--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -12,5 +12,5 @@
     "pyOpenSSL>=23.0",
     "smartthings-local>=0.1.0"
   ],
-  "version": "0.10.0"
+  "version": "0.10.1"
 }


### PR DESCRIPTION
## Summary
- Bump `manifest.json` version to `0.10.1`

## Release notes

```md
## 🐛 Fixed
- Changing a switch, select, or number entity (e.g. a fridge's flex-zone/cooler-drawer mode) could take up to 30 seconds to show the correct value in Home Assistant, and would often look like it instantly reverted to the old value right after being changed — even though the command reached the appliance and took effect immediately. The coordinator was discarding its own write confirmation instead of keeping it, so the display now updates immediately and stays correct. (#27)
```

The underlying fix (optimistic cache write before the settle guard) already merged in #50; this PR is just the version bump for the patch release.

## Test plan
- [x] `test_send_command_applies_write_optimistically_before_settling` (added in #50) covers the fix directly
- [x] Existing coordinator/observe test suite unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAYfGDyF8ibaKck39AVS5y)_