### PR TITLE
feat: add options flow to bypass the remote-control write block per device (issue #54)

### DIFF
--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.selector import (
     TextSelector,
@@ -24,6 +25,7 @@ from .const import (
     CONF_HOST, CONF_PORT,
     CONF_CA_CERT_PEM, CONF_CA_KEY_PEM,
     CONF_LEAF_CERT_PEM, CONF_LEAF_KEY_PEM,
+    CONF_BYPASS_REMOTE_CONTROL,
     PROBE_PORT_RANGE, PREFERRED_PROBE_PORTS, LIVENESS_PROBE_TIMEOUT_S,
     PROBE_GET_TIMEOUT_S,
 )
@@ -300,6 +302,13 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._ca_key_pem: str = ""
         self._pending_info: dict | None = None
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> LocalThingsOptionsFlow:
+        return LocalThingsOptionsFlow()
+
     def _create_entry(self, info: dict) -> FlowResult:
         return self.async_create_entry(
             title=f"Samsung Appliance ({self._host})",
@@ -383,4 +392,32 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders={
                 "one_ui_version": self._pending_info["one_ui_version"] or "(none reported)",
             },
+        )
+
+
+class LocalThingsOptionsFlow(config_entries.OptionsFlow):
+    """Per-device override of the remote-control-off write block (issue
+    #54). The block exists because most devices reject writes outright
+    while remote control is off and a clear error beats a silent
+    device-side rejection -- but not every model actually enforces that,
+    so this lets a user who's confirmed their device accepts writes anyway
+    turn the block off for just that device rather than it being
+    hardcoded on for everyone."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({
+                vol.Required(
+                    CONF_BYPASS_REMOTE_CONTROL,
+                    default=self.config_entry.options.get(
+                        CONF_BYPASS_REMOTE_CONTROL, False
+                    ),
+                ): bool,
+            }),
         )

--- a/custom_components/localthings/const.py
+++ b/custom_components/localthings/const.py
@@ -12,6 +12,16 @@ CONF_CA_KEY_PEM   = "ca_key_pem"
 CONF_LEAF_CERT_PEM = "leaf_cert_pem"
 CONF_LEAF_KEY_PEM  = "leaf_key_pem"
 
+# Options-flow key (entry.options, not entry.data): lets a user override the
+# device-wide remote-control-off write block for a specific device (issue
+# #54). Some devices report remote control off yet still accept certain
+# writes (e.g. default detergent/softener dosing on a washer, applied even
+# to the built-in programs) -- the block exists to give a clear error
+# instead of a silent device-side rejection, but that assumption doesn't
+# hold for every model. Defaults to False (block stays on) everywhere it's
+# read, so devices this doesn't apply to see no behavior change.
+CONF_BYPASS_REMOTE_CONTROL = "bypass_remote_control_lock"
+
 # The DTLS/CoAP local API binds somewhere in this ephemeral range; which port
 # depends on firmware. Newer builds answer on 49154/49155, but older ones have
 # been seen as low as 49153, so we sweep the whole range for a live UDP port

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -31,7 +31,7 @@ from .observe import ObserveManager, MODE_OBSERVE, MODE_POLL, GRACE_PERIOD_S
 
 from .const import (
     DOMAIN, CONF_HOST, CONF_PORT, CONF_LEAF_CERT_PEM, CONF_LEAF_KEY_PEM,
-    DEVICE_SUPPORT_ISSUE_URL, SUMMARY_INTERVAL_S,
+    CONF_BYPASS_REMOTE_CONTROL, DEVICE_SUPPORT_ISSUE_URL, SUMMARY_INTERVAL_S,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -534,7 +534,11 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         user-facing message -- as opposed to write_fn's silent no-op below
         -- is available to every platform for free. The remote-control
         check runs first and applies to every platform unconditionally,
-        ahead of any description-specific validate_fn."""
+        ahead of any description-specific validate_fn -- unless the user has
+        opted this device out of it via CONF_BYPASS_REMOTE_CONTROL (issue
+        #54: some devices accept certain writes, e.g. a washer's default
+        dosing levels, even while reporting remote control off, so the
+        block's assumption doesn't hold for every model)."""
         desc = bound_entity.desc
         write_fn = getattr(desc, 'write_fn', None)
         if write_fn is None:
@@ -542,7 +546,8 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         href = bound_entity.href
         rep = self._cache.get(href or '') or {}
         resources = self._cache.snapshot()
-        if not remote_control_enabled(resources):
+        bypass_remote_control = self._entry.options.get(CONF_BYPASS_REMOTE_CONTROL, False)
+        if not bypass_remote_control and not remote_control_enabled(resources):
             raise ServiceValidationError(_REMOTE_CONTROL_DISABLED_MESSAGE)
         validate_fn = getattr(desc, 'validate_fn', None)
         if validate_fn is not None:

--- a/custom_components/localthings/strings.json
+++ b/custom_components/localthings/strings.json
@@ -246,6 +246,17 @@
       "already_configured": "This device is already configured."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Local Things Options",
+        "description": "Some devices accept certain writes (e.g. default detergent/softener dosing on a washer) even while reporting remote control off. By default, LocalThings blocks every write with a clear error whenever a device reports remote control off, rather than letting the device silently reject it. Only turn this off if you've confirmed writes actually work on this device with remote control off -- otherwise you'll trade that clear error for a silent failure.",
+        "data": {
+          "bypass_remote_control_lock": "Allow writes even when remote control is reported off"
+        }
+      }
+    }
+  },
   "issues": {
     "device_gap": {
       "title": "Incomplete capability coverage for {device_name}",

--- a/custom_components/localthings/strings.json
+++ b/custom_components/localthings/strings.json
@@ -250,7 +250,7 @@
     "step": {
       "init": {
         "title": "Local Things Options",
-        "description": "Some devices accept certain writes (e.g. default detergent/softener dosing on a washer) even while reporting remote control off. By default, LocalThings blocks every write with a clear error whenever a device reports remote control off, rather than letting the device silently reject it. Only turn this off if you've confirmed writes actually work on this device with remote control off -- otherwise you'll trade that clear error for a silent failure.",
+        "description": "Some devices accept certain writes (e.g. default detergent/softener dosing on a washer) even while reporting remote control off. By default, LocalThings blocks every write with a clear error whenever a device reports remote control off, rather than letting the device silently reject it. Only enable this if you've confirmed writes actually work on this device with remote control off -- otherwise you'll trade that clear error for a silent failure.",
         "data": {
           "bypass_remote_control_lock": "Allow writes even when remote control is reported off"
         }

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -246,6 +246,17 @@
       "already_configured": "This device is already configured."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Local Things Options",
+        "description": "Some devices accept certain writes (e.g. default detergent/softener dosing on a washer) even while reporting remote control off. By default, LocalThings blocks every write with a clear error whenever a device reports remote control off, rather than letting the device silently reject it. Only turn this off if you've confirmed writes actually work on this device with remote control off -- otherwise you'll trade that clear error for a silent failure.",
+        "data": {
+          "bypass_remote_control_lock": "Allow writes even when remote control is reported off"
+        }
+      }
+    }
+  },
   "issues": {
     "device_gap": {
       "title": "Incomplete capability coverage for {device_name}",

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -250,7 +250,7 @@
     "step": {
       "init": {
         "title": "Local Things Options",
-        "description": "Some devices accept certain writes (e.g. default detergent/softener dosing on a washer) even while reporting remote control off. By default, LocalThings blocks every write with a clear error whenever a device reports remote control off, rather than letting the device silently reject it. Only turn this off if you've confirmed writes actually work on this device with remote control off -- otherwise you'll trade that clear error for a silent failure.",
+        "description": "Some devices accept certain writes (e.g. default detergent/softener dosing on a washer) even while reporting remote control off. By default, LocalThings blocks every write with a clear error whenever a device reports remote control off, rather than letting the device silently reject it. Only enable this if you've confirmed writes actually work on this device with remote control off -- otherwise you'll trade that clear error for a silent failure.",
         "data": {
           "bypass_remote_control_lock": "Allow writes even when remote control is reported off"
         }

--- a/tests/localthings/test_config_flow.py
+++ b/tests/localthings/test_config_flow.py
@@ -9,7 +9,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.localthings.const import (
-    CONF_CA_CERT_PEM, CONF_CA_KEY_PEM, CONF_HOST, CONF_PORT, DOMAIN,
+    CONF_BYPASS_REMOTE_CONTROL, CONF_CA_CERT_PEM, CONF_CA_KEY_PEM,
+    CONF_HOST, CONF_PORT, DOMAIN,
 )
 
 from .conftest import (
@@ -276,3 +277,45 @@ def test_probe_marks_washer_as_recognized(monkeypatch):
         ) is not None
     )
     assert recognized is True
+
+
+async def test_options_flow_default_is_off(hass: HomeAssistant) -> None:
+    """The bypass defaults to False, so devices that never touch this
+    option see no change in the remote-control write block."""
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, unique_id=f'localthings_{MOCK_SERIAL}')
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result['type'] == FlowResultType.FORM
+    assert result['step_id'] == 'init'
+    assert result['data_schema']({})[CONF_BYPASS_REMOTE_CONTROL] is False
+
+
+async def test_options_flow_can_enable_bypass(hass: HomeAssistant) -> None:
+    """Submitting the form with the toggle on stores it in entry.options,
+    where coordinator.async_send_command reads it (issue #54)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, unique_id=f'localthings_{MOCK_SERIAL}')
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result['flow_id'], user_input={CONF_BYPASS_REMOTE_CONTROL: True}
+    )
+
+    assert result['type'] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_BYPASS_REMOTE_CONTROL] is True
+
+
+async def test_options_flow_reflects_previously_saved_value(hass: HomeAssistant) -> None:
+    """Reopening the form shows the currently-saved choice as the default,
+    not always False."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=ENTRY_DATA, unique_id=f'localthings_{MOCK_SERIAL}',
+        options={CONF_BYPASS_REMOTE_CONTROL: True},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result['data_schema']({})[CONF_BYPASS_REMOTE_CONTROL] is True

--- a/tests/localthings/test_coordinator.py
+++ b/tests/localthings/test_coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import issue_registry as ir
 
 from custom_components.localthings.const import (
-    CONF_HOST, DOMAIN, SUMMARY_INTERVAL_S,
+    CONF_BYPASS_REMOTE_CONTROL, CONF_HOST, DOMAIN, SUMMARY_INTERVAL_S,
 )
 from custom_components.localthings.coordinator import LocalThingsCoordinator
 from custom_components.localthings.registry.capabilities.common import (
@@ -979,3 +979,44 @@ async def test_send_command_remote_control_check_precedes_validate_fn(
 
     with pytest.raises(ServiceValidationError, match="Remote control is turned off"):
         await coordinator.async_send_command(bound, 'On')
+
+
+async def test_send_command_bypasses_remote_control_when_option_enabled(
+    hass: HomeAssistant, mock_coordinator_observe_session
+) -> None:
+    """Issue #54: some devices accept certain writes even while reporting
+    remote control off, so a user who's confirmed that for their device can
+    opt it out of the block entirely via the options flow
+    (CONF_BYPASS_REMOTE_CONTROL, entry.options -- not entry.data)."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.localthings.registry.discovery import BoundEntity
+    from custom_components.localthings.registry.entities import NumberDesc
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=ENTRY_DATA, unique_id=f'localthings_{MOCK_SERIAL}',
+        options={CONF_BYPASS_REMOTE_CONTROL: True},
+    )
+    entry.add_to_hass(hass)
+
+    fake = mock_coordinator_observe_session
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator._cache.apply_rep(
+        '/remotectrl/vs/0',
+        {'x.com.samsung.da.remoteControlEnabled': 'false'},
+        source='test',
+    )
+
+    def _write_fn(payload, rep, href):
+        return (['some', 'path'], {'value': payload})
+
+    desc = NumberDesc(key='test', field='value', write_fn=_write_fn)
+    bound = BoundEntity(href='/test/vs/0', capability=coordinator.bound[0].capability, desc=desc)
+
+    with patch.object(fake, 'subscribe'):
+        fake.post = lambda *a, **k: (0x44, b'')
+        await coordinator.async_send_command(bound, 5)
+
+    assert coordinator._cache.get('/some/path') == {'value': 5}


### PR DESCRIPTION
## Summary

Issue #54: a washer reports remote control off, and this integration currently blocks **every** write to that device with a `ServiceValidationError` whenever `remote_control_enabled()` (`registry/capabilities/common.py`) returns False — on the assumption the device would reject the write anyway. The reporter found that assumption doesn't hold universally: their washer accepts default detergent/softener dosing writes even with remote control off, since those apply to the built-in programs too, not just a custom remote-controlled cycle. The maintainer's own comment on the issue proposed exactly this: keep the block on by default, but let a user opt a specific device out via its options.

## What changed

- `const.py`: new `CONF_BYPASS_REMOTE_CONTROL = "bypass_remote_control_lock"` — an **options** key (`entry.options`), not `entry.data`, so it doesn't affect the device's identity/unique_id.
- `config_flow.py`: `LocalThingsConfigFlow.async_get_options_flow` + a new `LocalThingsOptionsFlow` with a single-toggle `init` step ("Allow writes even when remote control is reported off"), defaulting to the entry's currently-saved value. Reachable from Settings > Devices & Services > this device > Configure.
- `coordinator.py`, `async_send_command`: reads the option and skips the `remote_control_enabled()` check entirely when it's set, ahead of any description-level `validate_fn`. Defaults to `False` everywhere it's read, so devices that never touch this option see no behavior change. The bypass only affects the write path — the read-only Smart Control binary_sensor renders from the resource descriptors directly and is unaffected either way.
- `strings.json` / `translations/en.json`: matching `options.step.init` copy (kept byte-identical between the two, per this repo's existing convention).

## Review

Had Opus do an independent review of the diff. It verified (by reading actual HA 2026.2.3 source, not assuming):
- `async_get_options_flow` as a bare `@staticmethod @callback` returning `LocalThingsOptionsFlow()` with no `config_entry` constructor arg is the correct, non-deprecated pattern for this HA version, and `self.config_entry` is safe to read inside `async_step_init`.
- Skipping a reload/update-listener is genuinely safe: traced `OptionsFlowManager.async_finish_flow` → `async_update_entry` down to the in-place `ConfigEntry.options` mutation, confirming the coordinator's existing `self._entry` reference picks up the new value on every write with no reload needed.
- `remote_control_enabled` has exactly one call site (the write guard), so the bypass is correctly scoped and can't leak into the read-only binary_sensor.

It also caught a real bug: the options description originally read "Only turn this off if you've confirmed writes actually work..." — backwards, since the toggle is off by default and turned **on** to bypass the block. Fixed in a follow-up commit.

## Testing

- New: `test_options_flow_default_is_off`, `test_options_flow_can_enable_bypass`, `test_options_flow_reflects_previously_saved_value` (`test_config_flow.py`); `test_send_command_bypasses_remote_control_when_option_enabled` (`test_coordinator.py`).
- Full suite: 417 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lskyz2rrCTjEBbS7NRaG1t)_