### PR TITLE
Add cool-only global RAC support: WindFree, Auto mode, and display light

### DIFF
--- a/custom_components/localthings/climate.py
+++ b/custom_components/localthings/climate.py
@@ -24,6 +24,7 @@ from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
+    PRESET_NONE,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
@@ -96,25 +97,17 @@ _DEVICE_TO_SWING: dict[str, str] = {
 }
 _SWING_TO_DEVICE = {v: k for k, v in _DEVICE_TO_SWING.items()}
 
-# Preset (convenient mode): Off/Sleep map onto HA standard presets; Quiet/Smart/
-# Speed and WindFree are custom (translated). On cool-only global RAC variants
-# (e.g. TP1X_DA-AC-RAC-01001) Samsung's WindFree still-air cooling is exposed
-# through this convenient-mode resource under the device code 'Nano' (and
-# 'NanoSleep' for WindFree + sleep) in place of the 'Smart' code seen on other
-# boards -- confirmed empirically by diffing a dump with WindFree off (code
-# 'Off') against one with it on (code 'Nano'). Codes absent from this map are
-# dropped from preset_modes (see _read_modes), so a board that lists neither
-# Smart nor Nano simply won't offer them.
-_DEVICE_TO_PRESET: dict[str, str] = {
-    'Off': 'none',
-    'Sleep': 'sleep',
-    'Quiet': 'quiet',
-    'Smart': 'smart',
-    'Speed': 'speed',
-    'Nano': 'windfree',
-    'NanoSleep': 'windfree_sleep',
-}
-_PRESET_TO_DEVICE = {v: k for k, v in _DEVICE_TO_PRESET.items()}
+# Preset (convenient mode): resolved dynamically from the device's own
+# /mode/convenient/vs/0 supportedModes -- no per-model table. The device 'Off'
+# code maps to HA's PRESET_NONE ("no preset active"); every other code is exposed
+# as its lowercased self and labelled in translations
+# (entity.climate.airconditioner.state_attributes.preset_mode.state.<code>), so
+# any board's convenient modes surface without code changes and an unlabelled
+# code renders as its raw value until a label is added. (Samsung's WindFree
+# still-air cooling shows up here as the 'Nano'/'NanoSleep' codes on cool-only
+# global RAC boards -- that's just a translation label, not a hard-coded mode.)
+def _preset_to_ha(code) -> str:
+    return PRESET_NONE if code == 'Off' else str(code).lower()
 
 
 async def async_setup_entry(
@@ -316,11 +309,12 @@ class LocalThingsClimate(LocalThingsEntity, ClimateEntity):
 
     @property
     def preset_mode(self):
-        return self._read_mode(CONVENIENT_HREF, _DEVICE_TO_PRESET)
+        code = _first(self._rep(CONVENIENT_HREF).get(_MODES_FIELD))
+        return _preset_to_ha(code) if code is not None else None
 
     @property
     def preset_modes(self) -> list[str]:
-        return self._read_modes(CONVENIENT_HREF, _DEVICE_TO_PRESET)
+        return [_preset_to_ha(c) for c in self._supported(CONVENIENT_HREF)]
 
     # -- writes -------------------------------------------------------------
 
@@ -378,4 +372,9 @@ class LocalThingsClimate(LocalThingsEntity, ClimateEntity):
         await self._set_mapped('swing', _SWING_TO_DEVICE, swing_mode)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        await self._set_mapped('preset', _PRESET_TO_DEVICE, preset_mode)
+        # Reverse-resolve against the unit's own supportedModes (codes aren't a
+        # fixed transform of the HA value -- e.g. 'NanoSleep' -> 'nanosleep').
+        for code in self._supported(CONVENIENT_HREF):
+            if _preset_to_ha(code) == preset_mode:
+                await self.coordinator.async_send_command(self._bound, ('preset', code))
+                return

--- a/custom_components/localthings/climate.py
+++ b/custom_components/localthings/climate.py
@@ -62,7 +62,12 @@ _SUPPORTED_FIELD = 'x.com.samsung.da.supportedModes'
 _DEVICE_TO_HVAC: dict[str, HVACMode] = {
     'Cool': HVACMode.COOL,
     'Dry': HVACMode.DRY,
+    # Fan-only is spelled 'Wind' on some boards (e.g. TP1X_DA-AC-RAC-01001) and
+    # 'Fan' on others (e.g. TP1X_DA-AC-RAC-01011); both map to FAN_ONLY. The
+    # reverse write can't rely on this map alone (two codes, one HA value) --
+    # _device_code_for_hvac() resolves the code from the unit's supportedModes.
     'Wind': HVACMode.FAN_ONLY,
+    'Fan': HVACMode.FAN_ONLY,
     # The device's 'Auto' is a single-setpoint "device decides" mode -> HA
     # HVACMode.AUTO (renders "Auto"). Not HEAT_COOL: that renders "Heat/cool"
     # and implies a two-setpoint heat+cool range these single-setpoint units
@@ -184,11 +189,15 @@ class LocalThingsClimate(LocalThingsEntity, ClimateEntity):
         return self.coordinator.resource(href) or {}
 
     def _is_on(self) -> bool:
-        rep = self._rep(POWER_HREF)
-        if 'value' in rep:
-            return bool(rep.get('value'))
+        # Prefer the vendor /power/vs/0 (present on every observed board and the
+        # resource writes target -- see airconditioner._climate_write). The
+        # OCF /power/0 is absent on many boards and a stale mirror on some, so
+        # reading it first showed pre-write state after a power toggle.
         vs = self._rep(POWER_VS_HREF)
-        return str(vs.get('x.com.samsung.da.power', '')).lower() == 'on'
+        power = vs.get('x.com.samsung.da.power')
+        if power is not None:
+            return str(power).lower() == 'on'
+        return bool(self._rep(POWER_HREF).get('value'))
 
     def _supported(self, href: str) -> list[str]:
         return list(self._rep(href).get(_SUPPORTED_FIELD) or [])
@@ -202,6 +211,15 @@ class LocalThingsClimate(LocalThingsEntity, ClimateEntity):
         return [mapping[c] for c in self._supported(href) if c in mapping]
 
     # -- temperature --------------------------------------------------------
+
+    def _ocf_temp_authoritative(self) -> bool:
+        """True when the OCF /temperature/{current,desired}/0 pair is the
+        authoritative temperature channel -- signalled by /temperature/current/0
+        being present. Those boards honour reads/writes on /temperature/desired/0
+        and reject the vendor /temperatures/vs/0; boards without the pair (only a
+        desired stub, or nothing) are the reverse. Confirmed on live units of
+        both kinds."""
+        return bool(self._rep(TEMP_CURRENT_HREF))
 
     def _temps_vs(self) -> dict:
         """Vendor `/temperatures/vs/0` items[0] (empty {} when absent)."""
@@ -225,10 +243,14 @@ class LocalThingsClimate(LocalThingsEntity, ClimateEntity):
 
     @property
     def target_temperature(self):
-        v = _num(self._rep(TEMP_DESIRED_HREF).get('temperature'))
-        if v is None:
-            v = _num(self._temps_vs().get('x.com.samsung.da.desired'))
-        return v
+        # Read from the same channel writes go to (see async_set_temperature):
+        # OCF /temperature/desired/0 on boards with the full OCF pair, vendor
+        # /temperatures/vs/0 otherwise -- with the other as fallback.
+        ocf = _num(self._rep(TEMP_DESIRED_HREF).get('temperature'))
+        vs = _num(self._temps_vs().get('x.com.samsung.da.desired'))
+        if self._ocf_temp_authoritative():
+            return ocf if ocf is not None else vs
+        return vs if vs is not None else ocf
 
     def _range(self) -> list | None:
         r = self._rep(TEMP_DESIRED_HREF).get('range')
@@ -302,16 +324,35 @@ class LocalThingsClimate(LocalThingsEntity, ClimateEntity):
 
     # -- writes -------------------------------------------------------------
 
+    def _device_code_for_hvac(self, hvac_mode: HVACMode):
+        """Device mode code for an HA hvac_mode, chosen from this unit's own
+        supportedModes -- fan-only is 'Wind' on some boards and 'Fan' on
+        others, so the reverse map alone can't pick the code this unit accepts.
+        """
+        for code in self._supported(MODE_HREF):
+            if _DEVICE_TO_HVAC.get(code) == hvac_mode:
+                return code
+        return _HVAC_TO_DEVICE.get(hvac_mode)
+
     async def async_set_temperature(self, **kwargs) -> None:
         temp = kwargs.get('temperature')
-        if temp is not None:
-            await self.coordinator.async_send_command(self._bound, ('temperature', temp))
+        if temp is None:
+            return
+        if self._ocf_temp_authoritative():
+            # OCF-pair boards apply the write on /temperature/desired/0.
+            await self.coordinator.async_send_command(
+                self._bound, ('temperature_ocf', temp))
+        else:
+            # Vendor boards apply it on /temperatures/vs/0; pass the current
+            # item so the write RMWs it (preserving current/min/max/unit).
+            await self.coordinator.async_send_command(
+                self._bound, ('temperature', temp, self._temps_vs()))
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         if hvac_mode == HVACMode.OFF:
             await self.coordinator.async_send_command(self._bound, ('power', False))
             return
-        device = _HVAC_TO_DEVICE.get(hvac_mode)
+        device = self._device_code_for_hvac(hvac_mode)
         if device is None:
             return
         if not self._is_on():

--- a/custom_components/localthings/climate.py
+++ b/custom_components/localthings/climate.py
@@ -63,7 +63,11 @@ _DEVICE_TO_HVAC: dict[str, HVACMode] = {
     'Cool': HVACMode.COOL,
     'Dry': HVACMode.DRY,
     'Wind': HVACMode.FAN_ONLY,
-    'Auto': HVACMode.HEAT_COOL,
+    # The device's 'Auto' is a single-setpoint "device decides" mode -> HA
+    # HVACMode.AUTO (renders "Auto"). Not HEAT_COOL: that renders "Heat/cool"
+    # and implies a two-setpoint heat+cool range these single-setpoint units
+    # (including cool-only models) don't have.
+    'Auto': HVACMode.AUTO,
     'Heat': HVACMode.HEAT,
 }
 _HVAC_TO_DEVICE = {v: k for k, v in _DEVICE_TO_HVAC.items()}
@@ -88,13 +92,22 @@ _DEVICE_TO_SWING: dict[str, str] = {
 _SWING_TO_DEVICE = {v: k for k, v in _DEVICE_TO_SWING.items()}
 
 # Preset (convenient mode): Off/Sleep map onto HA standard presets; Quiet/Smart/
-# Speed are custom (translated).
+# Speed and WindFree are custom (translated). On cool-only global RAC variants
+# (e.g. TP1X_DA-AC-RAC-01001) Samsung's WindFree still-air cooling is exposed
+# through this convenient-mode resource under the device code 'Nano' (and
+# 'NanoSleep' for WindFree + sleep) in place of the 'Smart' code seen on other
+# boards -- confirmed empirically by diffing a dump with WindFree off (code
+# 'Off') against one with it on (code 'Nano'). Codes absent from this map are
+# dropped from preset_modes (see _read_modes), so a board that lists neither
+# Smart nor Nano simply won't offer them.
 _DEVICE_TO_PRESET: dict[str, str] = {
     'Off': 'none',
     'Sleep': 'sleep',
     'Quiet': 'quiet',
     'Smart': 'smart',
     'Speed': 'speed',
+    'Nano': 'windfree',
+    'NanoSleep': 'windfree_sleep',
 }
 _PRESET_TO_DEVICE = {v: k for k, v in _DEVICE_TO_PRESET.items()}
 

--- a/custom_components/localthings/registry/by_type/__init__.py
+++ b/custom_components/localthings/registry/by_type/__init__.py
@@ -108,10 +108,17 @@ def for_device_by_model(model_num: str, description: str) -> Optional[DeviceRegi
     # a modelNum carrying the '_PRAC_' (Package Room Air Conditioner) token.
     if key is None and '_PRAC_' in (model_num or ''):
         key = 'airconditioner'
-    # Older/simpler RAC boards (e.g. TP2X_RAC_20K, issue #37) use the plain
-    # '_RAC_' token instead -- distinct from '_PRAC_' above (no overlap: the
-    # 'P' sits between the underscore and 'RAC' in that token).
-    if key is None and '_RAC_' in (model_num or ''):
+    # Other RAC boards carry a bare 'RAC' (Room Air Conditioner) token in the
+    # modelNum, in one of two spellings: the underscore form '_RAC_' (e.g.
+    # TP2X_RAC_20K, issue #37) or the hyphenated form '-RAC-' (e.g.
+    # TP1X_DA-AC-RAC-01001, a cool-only global variant). Both are distinct from
+    # '_PRAC_' above ('P' sits before 'RAC' with no delimiter) and from range
+    # ('-RANGE-') / oven ('-OVEN-') tokens. Most TP1X boards self-report
+    # oneUiVersion and resolve via for_device() upstream of this fallback; the
+    # hyphenated match is what rescues variants whose /otninformation/vs/0 ships
+    # no swVersionInfo block at all, so oneUiVersion is empty.
+    if key is None and ('_RAC_' in (model_num or '')
+                        or '-RAC-' in (model_num or '').upper()):
         key = 'airconditioner'
     # System air conditioners (multi-indoor-unit commercial installs, e.g.
     # A-CAWW-TP2-20-COMMON, issue #52) report no oneUiVersion either and

--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -16,6 +16,7 @@ by_type registry.
 """
 from ..capability import Capability
 from ..entities import BinarySensorDesc, ClimateDesc, SensorDesc, SwitchDesc
+from .laundry import option_write
 
 # ---------------------------------------------------------------------------
 # Canonical AC resource hrefs. The climate entity (climate.py) binds the
@@ -71,6 +72,48 @@ def _first_mode(rep):
     return modes
 
 
+def _mode_options(rep):
+    opts = rep.get('x.com.samsung.da.options')
+    return opts if isinstance(opts, (list, tuple)) else ()
+
+
+def _has_display_light_option(rep, resources):
+    """True when the panel light state is carried inside /mode/vs/0's options
+    blob (a `Light_On`/`Light_Off` token) rather than a dedicated /light/vs/0
+    switch. The two encodings are mutually exclusive across observed boards:
+    models exposing the /light/vs/0 switch (bound by DISPLAY_LIGHT) carry no
+    Light_* option, so this sensor only materialises on the boards that would
+    otherwise have no display-light entity at all."""
+    return any(isinstance(o, str) and o.startswith('Light_')
+               for o in _mode_options(rep))
+
+
+def _display_light_on(rep):
+    """Panel display light state from /mode/vs/0's options blob. The token is
+    INVERTED relative to its name -- confirmed by a live toggle test: with the
+    panel lit the option reads `Light_Off`, and with it dark it reads
+    `Light_On` (the flag really encodes "night/display-off mode active"). So
+    `Light_Off` -> light on, `Light_On` -> light off. Read-only: the light is
+    buried in the opaque options array of the primary climate resource; the
+    write below uses the device's own SingleCommand single-token merge."""
+    for o in _mode_options(rep):
+        if isinstance(o, str) and o.startswith('Light_'):
+            return o == 'Light_Off'
+    return None
+
+
+def _display_light_write(payload, rep, href=None):
+    """Toggle the panel light via a single-token /mode/vs/0 options write
+    (SingleCommand -- 'SingleCommand_1' is advertised in this family's
+    /configuration/vs/0 airconOptionList, and option_write's one-token merge
+    is the same mechanism air_purifier.py uses for its own Light switch).
+    Polarity is inverted (see _display_light_on): switching the lamp ON writes
+    the 'Light_Off' token, OFF writes 'Light_On'."""
+    token = 'Off' if payload == 'On' else 'On'
+    return (['mode', 'vs', '0'],
+            {'x.com.samsung.da.options': option_write('Light', token)})
+
+
 def _climate_write(payload, rep, href=None):
     """Map a (kind, value) command from the climate platform to the
     (path_segs, body) for that one sub-write. `value` is already the raw device
@@ -101,6 +144,18 @@ CLIMATE = Capability(
     entities=(
         ClimateDesc(key='climate', translation_key='airconditioner',
                     rep_fn=_first_mode, write_fn=_climate_write),
+        # Display (panel) light switch, only on boards that encode it in
+        # /mode/vs/0's options instead of a /light/vs/0 switch (see
+        # _has_display_light_option). Shares the /mode/vs/0 href with the
+        # climate entity above -- same Capability, so no multi-cap discriminator
+        # is needed. /mode/vs/0 is OBSERVE-subscribed, so state updates on push;
+        # writes go through the SingleCommand merge in _display_light_write.
+        # Shares the switch.display_light translation with DISPLAY_LIGHT (the
+        # /light/vs/0 switch on other boards) -- mutually exclusive per href.
+        SwitchDesc(key='display_light', rep_fn=_display_light_on,
+                   exists_fn=_has_display_light_option,
+                   write_fn=_display_light_write,
+                   icon='mdi:led-on', entity_category='config'),
     ),
 )
 
@@ -240,7 +295,14 @@ _AC_IGNORED = [
     '/mds/absencemonitoring/vs/0', # motion-detection sensor plumbing (empty here)
     '/mds/absencestate/vs/0',      # motion-detection state (empty here)
     '/remotedatacontrol/vs/0',     # remote data-control session status
+    '/remotedeviceinfo/vs/0',      # remote paired-device id list (empty didList here)
     '/remotetemperature/vs/0',     # external temp-sensor feed (unset on this unit)
+    # Manual airflow-step position (supportedModes Off/80/60/40/Power). Overlaps
+    # the /wind/direction swing control already on the climate card, and the
+    # meaning of the numeric steps vs. 'Power' isn't documented in the dump --
+    # ignored per the 'don't guess' rule rather than modeled as a select whose
+    # write could confuse live HVAC hardware.
+    '/stepcontrol/vs/0',
     '/reserverulesets/vs/0',       # opaque hex-encoded schedule reservation blob
     '/welcome/temperature/vs/0',   # welcome-cooling plumbing
     # System-AC-only (multi-indoor-unit commercial installs, e.g.

--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -115,20 +115,39 @@ def _display_light_write(payload, rep, href=None):
 
 
 def _climate_write(payload, rep, href=None):
-    """Map a (kind, value) command from the climate platform to the
+    """Map a (kind, value[, extra]) command from the climate platform to the
     (path_segs, body) for that one sub-write. `value` is already the raw device
     code (the platform maps HA<->device). async_send_command POSTs to path_segs,
-    so a single desc drives writes across power/mode/temperature/wind resources.
-    Read-modify-write safe: each write sends only its own field, leaving the
-    resource's other fields (e.g. /mode/vs/0's opaque `options` blob) untouched.
+    so a single desc drives writes across the power/mode/temperature/wind
+    resources.
+
+    Power goes to the vendor `/power/vs/0` (the OCF `/power/0` is absent on most
+    models and a non-authoritative mirror where present -- vendor works on every
+    board). Temperature is board-dependent, so the platform picks the channel
+    and sends `temperature_ocf` (-> OCF `/temperature/desired/0`, boards with the
+    full OCF current+desired pair) or `temperature` (-> vendor `/temperatures/vs/0`,
+    boards without it); each honours only its own channel. Mode/fan/swing/preset
+    are always the vendor `/x/vs/0` resources. Each write sends only its own
+    field(s), leaving the resource's other fields (e.g. /mode/vs/0's opaque
+    `options` blob) untouched.
     """
-    kind, value = payload
+    kind = payload[0]
+    value = payload[1] if len(payload) > 1 else None
     if kind == 'power':
-        return (['power', '0'], {'value': bool(value)})
+        return (['power', 'vs', '0'],
+                {'x.com.samsung.da.power': 'On' if value else 'Off'})
     if kind == 'mode':
         return (['mode', 'vs', '0'], {'x.com.samsung.da.modes': [value]})
+    if kind == 'temperature_ocf':
+        return (['temperature', 'desired', '0'],
+                {'temperature': int(round(float(value)))})
     if kind == 'temperature':
-        return (['temperature', 'desired', '0'], {'temperature': int(round(float(value)))})
+        # Read-modify-write the vendor items[]: start from the current item the
+        # platform passes in (preserving current/min/max/unit) and set desired.
+        item = dict(payload[2]) if len(payload) > 2 and isinstance(payload[2], dict) else {}
+        item.setdefault('x.com.samsung.da.id', '0')
+        item['x.com.samsung.da.desired'] = str(int(round(float(value))))
+        return (['temperatures', 'vs', '0'], {'x.com.samsung.da.items': [item]})
     if kind == 'fan':
         return (['wind', 'strength', 'vs', '0'], {'x.com.samsung.da.modes': value})
     if kind == 'swing':

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -97,7 +97,9 @@
             "state": {
               "quiet": "Quiet",
               "smart": "Smart",
-              "speed": "Speed"
+              "speed": "Speed",
+              "windfree": "WindFree",
+              "windfree_sleep": "WindFree sleep"
             }
           }
         }

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -98,8 +98,8 @@
               "quiet": "Quiet",
               "smart": "Smart",
               "speed": "Speed",
-              "windfree": "WindFree",
-              "windfree_sleep": "WindFree sleep"
+              "nano": "WindFree",
+              "nanosleep": "WindFree sleep"
             }
           }
         }

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -98,8 +98,8 @@
               "quiet": "Stil",
               "smart": "Slim",
               "speed": "Snel",
-              "windfree": "WindFree",
-              "windfree_sleep": "WindFree-slaap"
+              "nano": "WindFree",
+              "nanosleep": "WindFree-slaap"
             }
           }
         }

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -97,7 +97,9 @@
             "state": {
               "quiet": "Stil",
               "smart": "Slim",
-              "speed": "Snel"
+              "speed": "Snel",
+              "windfree": "WindFree",
+              "windfree_sleep": "WindFree-slaap"
             }
           }
         }

--- a/tests/fixtures/airconditioner_tp1x_rac_coolonly_device.json
+++ b/tests/fixtures/airconditioner_tp1x_rac_coolonly_device.json
@@ -1,0 +1,515 @@
+{
+  "meta": {
+    "model": "TP1X_DA-AC-RAC-01001_0000",
+    "device_type": "airconditioner",
+    "source": "user diagnostics (scrubbed)",
+    "note": "Cool-only global TP1X RAC variant (airconOptionList AI_RAC_GLOBAL_COOLONLY_3.0). Unlike the other TP1X_DA-AC-RAC dumps, its /otninformation/vs/0 ships no swVersionInfo block, so oneUiVersion is empty and detection must fall back to the hyphenated '-RAC-' modelNum token in for_device_by_model. Adds two hrefs absent from the other AC dumps -- /stepcontrol/vs/0 (manual airflow step) and /remotedeviceinfo/vs/0 (empty paired-device list), both ignored -- and exposes Samsung WindFree via the convenient-mode codes Nano/NanoSleep (in place of the Smart code on other boards; confirmed by an off-vs-on dump diff)."
+  },
+  "device0": [
+    {
+      "rt": [
+        "x.com.samsung.devcol",
+        "oic.wk.col"
+      ],
+      "if": [
+        "oic.if.baseline",
+        "oic.if.ll",
+        "oic.if.b"
+      ]
+    },
+    {
+      "href": "/personality/presence/vs/0",
+      "rep": {
+        "x.com.samsung.da.items": [
+          {
+            "x.com.samsung.da.id": "",
+            "x.com.samsung.da.deviceId": "**REDACTED**",
+            "x.com.samsung.da.value": ""
+          }
+        ]
+      }
+    },
+    {
+      "href": "/realtimenotiforclient/vs/0",
+      "rep": {
+        "x.com.samsung.da.timeforshortnoti": "0",
+        "x.com.samsung.da.longnotisubscription": "false",
+        "x.com.samsung.da.periodicnotisubscription": "true"
+      }
+    },
+    {
+      "href": "/filter/airdustfilter/vs/0",
+      "rep": {
+        "x.com.samsung.da.filterUsage": "100",
+        "x.com.samsung.da.filterUsageResolution": "1",
+        "x.com.samsung.da.filterDesiredUsage": "500",
+        "x.com.samsung.da.filterStatus": "wash",
+        "x.com.samsung.da.filterCapacity": "500",
+        "x.com.samsung.da.filterCapacityUnit": "Hour",
+        "x.com.samsung.da.filterResetType": [
+          "replaceable",
+          "washable"
+        ]
+      }
+    },
+    {
+      "href": "/temperature/control/vs/0",
+      "rep": {
+        "x.com.samsung.da.increment": "1"
+      }
+    },
+    {
+      "href": "/mode/convenient/vs/0",
+      "rep": {
+        "x.com.samsung.da.modes": "Off",
+        "x.com.samsung.da.supportedModes": [
+          "Off",
+          "Sleep",
+          "Quiet",
+          "Speed",
+          "Nano",
+          "NanoSleep"
+        ]
+      }
+    },
+    {
+      "href": "/option/autoclean/vs/0",
+      "rep": {
+        "x.com.samsung.da.status": "Stop",
+        "x.com.samsung.da.settingStatus": "Off",
+        "x.com.samsung.da.progress": "0",
+        "x.com.samsung.da.supportedStatus": [
+          "Start",
+          "Stop"
+        ],
+        "x.com.samsung.da.supportedSettingStatus": [
+          "On",
+          "Off"
+        ]
+      }
+    },
+    {
+      "href": "/wind/strength/vs/0",
+      "rep": {
+        "x.com.samsung.da.modes": "0",
+        "x.com.samsung.da.supportedModes": [
+          "0",
+          "1",
+          "2",
+          "3",
+          "4"
+        ],
+        "x.com.samsung.da.modesName": [
+          "Auto",
+          "Low",
+          "Mid",
+          "High",
+          "Turbo"
+        ]
+      }
+    },
+    {
+      "href": "/wind/direction/vs/0",
+      "rep": {
+        "x.com.samsung.da.modes": "Fix",
+        "x.com.samsung.da.supportedModes": [
+          "Fix",
+          "Up_And_Low",
+          "Left_And_Right",
+          "All"
+        ]
+      }
+    },
+    {
+      "href": "/alarms/vs/0",
+      "rep": {
+        "x.com.samsung.da.items": [
+          {
+            "x.com.samsung.da.id": "0",
+            "x.com.samsung.da.description": "Alarm",
+            "x.com.samsung.da.alarmType": "Device",
+            "x.com.samsung.da.code": "ErrorCode_OFF",
+            "x.com.samsung.da.triggeredTime": "2026-07-26T15:24:44",
+            "x.com.samsung.da.state": "Deleted"
+          },
+          {
+            "x.com.samsung.da.id": "1",
+            "x.com.samsung.da.description": "Alarm",
+            "x.com.samsung.da.alarmType": "Device",
+            "x.com.samsung.da.code": "FilterAlarm",
+            "x.com.samsung.da.triggeredTime": "2026-07-26T15:24:44",
+            "x.com.samsung.da.state": "Created"
+          }
+        ]
+      }
+    },
+    {
+      "href": "/temperatures/vs/0",
+      "rep": {
+        "x.com.samsung.da.items": [
+          {
+            "x.com.samsung.da.id": "0",
+            "x.com.samsung.da.description": "Temperature",
+            "x.com.samsung.da.desired": "25.0",
+            "x.com.samsung.da.current": "20.0",
+            "x.com.samsung.da.maximum": "30",
+            "x.com.samsung.da.minimum": "16",
+            "x.com.samsung.da.increment": "1.0",
+            "x.com.samsung.da.unit": "Celsius"
+          }
+        ]
+      }
+    },
+    {
+      "href": "/temperature/current/0",
+      "rep": {
+        "range": [
+          16,
+          30
+        ],
+        "units": "C",
+        "temperature": 20.0
+      }
+    },
+    {
+      "href": "/temperature/desired/0",
+      "rep": {
+        "range": [
+          16,
+          30
+        ],
+        "units": "C",
+        "temperature": 25.0
+      }
+    },
+    {
+      "href": "/energy/consumption/vs/0",
+      "rep": {
+        "x.com.samsung.da.instantaneousPower": "0.000000",
+        "x.com.samsung.da.cumulativePower": "445938",
+        "x.com.samsung.da.cumulativeSavedPower": "81528",
+        "x.com.samsung.da.cumulativeUnit": "Wh",
+        "x.com.samsung.da.instantaneousPowerUnit": "W"
+      }
+    },
+    {
+      "href": "/energy/consumption/0",
+      "rep": {
+        "power": 0.0
+      }
+    },
+    {
+      "href": "/mode/vs/0",
+      "rep": {
+        "x.com.samsung.da.supportedModes": [
+          "Auto",
+          "Cool",
+          "Dry",
+          "Wind"
+        ],
+        "x.com.samsung.da.modes": [
+          "Auto"
+        ],
+        "x.com.samsung.da.options": [
+          "Sleep_0",
+          "ArtificialWorking_Off",
+          "ComfortAICooling_Off",
+          "AiTempChanged_Off",
+          "AiTemp_240",
+          "OutdoorTemp_84",
+          "CoolCapa_35",
+          "WarmCapa_0",
+          "Light_Off",
+          "Volume_Mute",
+          "StopAutoClean_Idle",
+          "Autoclean_Off",
+          "DiagnosisAI_Off",
+          "ProgressDiagnosisAI_0",
+          "ResultDiagnosisAI_Normal",
+          "OptionCode_52344",
+          "ExtendOptionCode_230029",
+          "RacInfo_None",
+          "UpdateAllow_NotAllowed",
+          "DurationOn_0",
+          "WelcomeCoolingState_Off"
+        ]
+      }
+    },
+    {
+      "href": "/power/vs/0",
+      "rep": {
+        "x.com.samsung.da.power": "Off",
+        "causeSource": "DEFT",
+        "operationNumber": "0"
+      }
+    },
+    {
+      "href": "/power/0",
+      "rep": {
+        "value": false
+      }
+    },
+    {
+      "href": "/sensors/vs/0",
+      "rep": {}
+    },
+    {
+      "href": "/information/vs/0",
+      "rep": {
+        "x.com.samsung.da.modelNum": "TP1X_DA-AC-RAC-01001_0000|10247441|60010523001811014E00002200D00000",
+        "x.com.samsung.da.description": "TP1X_DA-AC-RAC-01001_0000",
+        "x.com.samsung.da.serialNum": "**REDACTED**",
+        "x.com.samsung.da.otnDUID": "**REDACTED**",
+        "x.com.samsung.da.diagProtocolType": "BLE_OCF",
+        "x.com.samsung.da.diagLogType": [
+          "errCode",
+          "dump"
+        ],
+        "x.com.samsung.da.diagDumpType": "file",
+        "x.com.samsung.da.diagEndPoint": "SSM",
+        "x.com.samsung.da.diagMnid": "0AJT",
+        "x.com.samsung.da.diagSetupid": "AR2",
+        "x.com.samsung.da.diagMinVersion": "3.0",
+        "x.com.samsung.da.diagTsId": "DA01",
+        "x.com.samsung.da.items": [
+          {
+            "x.com.samsung.da.id": "0",
+            "x.com.samsung.da.description": "Version",
+            "x.com.samsung.da.type": "Software",
+            "x.com.samsung.da.number": "02646A260327",
+            "x.com.samsung.da.newVersionAvailable": "0"
+          },
+          {
+            "x.com.samsung.da.id": "1",
+            "x.com.samsung.da.description": "Version",
+            "x.com.samsung.da.type": "Firmware",
+            "x.com.samsung.da.number": "102474A23112200",
+            "x.com.samsung.da.newVersionAvailable": "0"
+          },
+          {
+            "x.com.samsung.da.id": "2",
+            "x.com.samsung.da.description": "Version",
+            "x.com.samsung.da.type": "Firmware",
+            "x.com.samsung.da.number": "102702A24041900,102579A10000200",
+            "x.com.samsung.da.newVersionAvailable": "0"
+          }
+        ]
+      }
+    },
+    {
+      "href": "/file/information/vs/0",
+      "rep": {
+        "x.com.samsung.timeoffset": "-03:00",
+        "x.com.samsung.supprtedtype": 1
+      }
+    },
+    {
+      "href": "/configuration/vs/0",
+      "rep": {
+        "x.com.samsung.da.region": "0000000000",
+        "x.com.samsung.da.airconOptionList": [
+          "SingleCommand_1",
+          "DR",
+          "HOMECARE_WIZARD_V2",
+          "PRODUCT_GLOBAL",
+          "AI_RAC_GLOBAL_COOLONLY_3.0",
+          "AI_3.0",
+          "Auto_To_AI"
+        ]
+      }
+    },
+    {
+      "href": "/humidity/0",
+      "rep": {
+        "humidity": 0
+      }
+    },
+    {
+      "href": "/humidity/vs/0",
+      "rep": {
+        "x.com.samsung.da.humidity": "0",
+        "x.com.samsung.da.fivepercentHumidity": "66"
+      }
+    },
+    {
+      "href": "/drlc/0",
+      "rep": {
+        "DRLevel": 1,
+        "start": "2026-07-26T12:01:41Z",
+        "duration": 23,
+        "override": false
+      }
+    },
+    {
+      "href": "/drlc/vs/0",
+      "rep": {
+        "x.com.samsung.da.drlcLevel": "1",
+        "x.com.samsung.da.duration": "23:59:00",
+        "x.com.samsung.da.drlcStartTime": "2026-07-26T12:01:41Z",
+        "x.com.samsung.da.override": "Off",
+        "x.com.samsung.da.realSaving": "Off"
+      }
+    },
+    {
+      "href": "/availablecontrolsets/vs/0",
+      "rep": {
+        "x.com.samsung.da.sets": "000000A0012C0161024904000000",
+        "x.com.samsung.da.id": "RAC",
+        "x.com.samsung.da.version": "1.0"
+      }
+    },
+    {
+      "href": "/stepcontrol/vs/0",
+      "rep": {
+        "x.com.samsung.da.modes": "Off",
+        "x.com.samsung.da.supportedModes": [
+          "Off",
+          "80",
+          "60",
+          "40",
+          "Power"
+        ]
+      }
+    },
+    {
+      "href": "/keepnormalstate/vs/0",
+      "rep": {
+        "x.com.samsung.da.keepnormal": 1
+      }
+    },
+    {
+      "href": "/remotedatacontrol/vs/0",
+      "rep": {
+        "x.com.samsung.da.status": "Off",
+        "x.com.samsung.da.connectionStatus": "Disconnected"
+      }
+    },
+    {
+      "href": "/remotetemperature/vs/0",
+      "rep": {
+        "x.com.samsung.da.temperature": "",
+        "x.com.samsung.da.unit": "",
+        "x.com.samsung.da.error": ""
+      }
+    },
+    {
+      "href": "/remotedeviceinfo/vs/0",
+      "rep": {
+        "x.com.samsung.da.didList": ""
+      }
+    },
+    {
+      "href": "/otninformation/vs/0",
+      "rep": {
+        "x.com.samsung.da.target": "",
+        "x.com.samsung.da.newVersionAvailable": "false",
+        "x.com.samsung.da.newVersionNo": "00000000",
+        "x.com.samsung.da.currentVersionInfo": "00000000",
+        "otnStatus": "None",
+        "flashingProgress": "",
+        "otnTarget": "main",
+        "otnCompleteDate": "noHistory",
+        "otnList": [
+          {
+            "type": "WIFI",
+            "modelId": "ARA-WW-TP1-24-ARXX00",
+            "versions": [
+              "11260327"
+            ],
+            "visVersion": "260327"
+          },
+          {
+            "type": "Micom",
+            "modelId": "045210247441FFFFFFFF",
+            "versions": [
+              "23112200",
+              "FFFFFFFF"
+            ],
+            "visVersion": "231122"
+          },
+          {
+            "type": "Micom",
+            "modelId": "04521027024110257941",
+            "versions": [
+              "24041900",
+              "10000200"
+            ],
+            "visVersion": "240419"
+          }
+        ]
+      }
+    },
+    {
+      "href": "/connectionconfig/vs/0",
+      "rep": {
+        "autoReconnectionMinVersion": "1.0",
+        "autoReconnection": "true",
+        "autoReconnectionProtocolType": [
+          "helper_hotspot",
+          "ble_ocf"
+        ],
+        "supportedWiFiAuthType": [
+          "OPEN",
+          "WEP",
+          "WPA-PSK",
+          "WPA2-PSK",
+          "SAE"
+        ],
+        "supportedWiFiCryptoType": [
+          "TKIP",
+          "AES",
+          "WEP-64",
+          "WEP-128"
+        ],
+        "supportedWiFiFreq": [
+          "2.4G"
+        ],
+        "calmConnectionCare": {
+          "version": "1.0",
+          "role": [
+            "things"
+          ]
+        }
+      }
+    },
+    {
+      "href": "/timezone/vs/0",
+      "rep": {
+        "timezoneid": "America/Sao_Paulo",
+        "offset": "-03:00",
+        "DST": "OFF"
+      }
+    },
+    {
+      "href": "/option/muteonce/vs/0",
+      "rep": {
+        "muteonce": "Off"
+      }
+    },
+    {
+      "href": "/aisleep/vs/0",
+      "rep": {
+        "x.com.samsung.da.displayNightMode": "Off",
+        "x.com.samsung.da.elapsedTime": "0",
+        "x.com.samsung.da.requestFeedback": "Off",
+        "x.com.samsung.da.resultFeedback": "0",
+        "x.com.samsung.da.statusFeedback": "Idle",
+        "x.com.samsung.da.sleepTime": "14002200"
+      }
+    },
+    {
+      "href": "/wirelessinfo/vs/0",
+      "rep": {
+        "macaddressWiFi": "**REDACTED**",
+        "macaddressBLE": "**REDACTED**",
+        "connectedApSsid": "**REDACTED**"
+      }
+    },
+    {
+      "href": "/quickcontrol/info/vs/0",
+      "rep": {
+        "supportedVersion": "1.0"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/golden/airconditioner.json
+++ b/tests/fixtures/golden/airconditioner.json
@@ -7,6 +7,7 @@
     "auto_clean",
     "climate",
     "diagnosis_status",
+    "display_light",
     "energy_kwh",
     "energy_saved_kwh",
     "power_watts"

--- a/tests/fixtures/golden/airconditioner_caww_tp2.json
+++ b/tests/fixtures/golden/airconditioner_caww_tp2.json
@@ -6,6 +6,7 @@
     "auto_clean",
     "climate",
     "diagnosis_status",
+    "display_light",
     "energy_kwh",
     "energy_saved_kwh",
     "firmware_update",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_coolonly.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_coolonly.json
@@ -7,6 +7,7 @@
     "climate",
     "display_light",
     "energy_kwh",
+    "energy_saved_kwh",
     "firmware_update",
     "mute_once",
     "power_watts"

--- a/tests/localthings/test_coordinator.py
+++ b/tests/localthings/test_coordinator.py
@@ -722,10 +722,10 @@ async def test_climate_power_write_applies_to_its_own_href_not_bound_href(
     """Regression for issues #17/#53, using the real AC capability. The
     composite climate entity binds /mode/vs/0 (airconditioner.CLIMATE.href),
     but a power command's write_fn (airconditioner._climate_write) targets
-    the sibling /power/0 -- the href climate.py's `_is_on()` actually reads.
+    the sibling /power/vs/0 -- the href climate.py's `_is_on()` actually reads.
     The optimistic value and settle guard must land there, not on the bound
     /mode/vs/0, or the entity never sees the write and shows stale state
-    until the next unrelated read of /power/0."""
+    until the next unrelated read of /power/vs/0."""
     from custom_components.localthings.registry.capabilities import airconditioner
     from custom_components.localthings.registry.discovery import BoundEntity
 
@@ -744,9 +744,10 @@ async def test_climate_power_write_applies_to_its_own_href_not_bound_href(
         fake.post = lambda *a, **k: (0x44, b'')
         await coordinator.async_send_command(bound, ('power', True))
 
-    assert coordinator._cache.get('/power/0') == {'value': True}
-    assert coordinator._cache.get(airconditioner.CLIMATE.href) != {'value': True}
-    assert coordinator._observe._settle_until.get('/power/0') is not None
+    assert coordinator._cache.get('/power/vs/0', {}).get('x.com.samsung.da.power') == 'On'
+    assert 'x.com.samsung.da.power' not in coordinator._cache.get(
+        airconditioner.CLIMATE.href, {})
+    assert coordinator._observe._settle_until.get('/power/vs/0') is not None
 
 
 async def test_send_command_survives_stale_confirm_poll(

--- a/tests/test_airconditioner_capabilities.py
+++ b/tests/test_airconditioner_capabilities.py
@@ -93,15 +93,34 @@ def test_air_filter_usage_is_percentage_of_capacity():
 
 
 def test_climate_write_targets():
-    """The CLIMATE write_fn maps each (kind, value) command to the right OCF
-    POST target and body. `value` is already the raw device code."""
+    """The CLIMATE write_fn maps each (kind, value) command to the right vendor
+    POST target and body. `value` is already the raw device code. Power and
+    temperature target the vendor /power/vs/0 and /temperatures/vs/0 (the OCF
+    /power/0 + /temperature/desired/0 are absent on most boards and ignore
+    writes where present)."""
     write = airconditioner.CLIMATE.entities[0].write_fn
-    assert write(('power', True), {}) == (['power', '0'], {'value': True})
-    assert write(('power', False), {}) == (['power', '0'], {'value': False})
+    assert write(('power', True), {}) == (
+        ['power', 'vs', '0'], {'x.com.samsung.da.power': 'On'})
+    assert write(('power', False), {}) == (
+        ['power', 'vs', '0'], {'x.com.samsung.da.power': 'Off'})
     assert write(('mode', 'Heat'), {}) == (
         ['mode', 'vs', '0'], {'x.com.samsung.da.modes': ['Heat']})
-    assert write(('temperature', 23.6), {}) == (
+    # OCF-pair boards: temperature_ocf -> /temperature/desired/0.
+    assert write(('temperature_ocf', 23.6), {}) == (
         ['temperature', 'desired', '0'], {'temperature': 24})
+    # Vendor boards: temperature RMWs the vendor items[] -- no item -> minimal.
+    assert write(('temperature', 23.6), {}) == (
+        ['temperatures', 'vs', '0'],
+        {'x.com.samsung.da.items': [
+            {'x.com.samsung.da.id': '0', 'x.com.samsung.da.desired': '24'}]})
+    # With the current item passed, other fields are preserved.
+    assert write(('temperature', 22,
+                  {'x.com.samsung.da.id': '0', 'x.com.samsung.da.current': '20.0',
+                   'x.com.samsung.da.maximum': '30'}), {}) == (
+        ['temperatures', 'vs', '0'],
+        {'x.com.samsung.da.items': [
+            {'x.com.samsung.da.id': '0', 'x.com.samsung.da.current': '20.0',
+             'x.com.samsung.da.maximum': '30', 'x.com.samsung.da.desired': '22'}]})
     assert write(('fan', '2'), {}) == (
         ['wind', 'strength', 'vs', '0'], {'x.com.samsung.da.modes': '2'})
     assert write(('swing', 'All'), {}) == (

--- a/tests/test_airconditioner_capabilities.py
+++ b/tests/test_airconditioner_capabilities.py
@@ -215,6 +215,87 @@ def test_tp1x_rac_expected_state_keys_present():
         assert key in state, key
 
 
+# ---------------------------------------------------------------------------
+# TP1X_DA-AC-RAC-01001 cool-only global variant. Same modelNum as the issue #38
+# board above, but its /otninformation/vs/0 ships no swVersionInfo block, so
+# oneUiVersion is empty and for_device() can't route it. Detection must fall
+# back to the hyphenated '-RAC-' modelNum token (the older '_RAC_' underscore
+# match doesn't fire on this DA-AC-RAC spelling). Adds /stepcontrol/vs/0 and
+# /remotedeviceinfo/vs/0 (both ignored) and the WindFree preset (device code
+# Nano/NanoSleep on this board).
+# ---------------------------------------------------------------------------
+
+def test_tp1x_rac_coolonly_resolves_via_hyphenated_model_fallback():
+    """Empty oneUiVersion -> resolved by the '-RAC-' modelNum token, not
+    for_device(). Guards the regression where this unit loaded as 'unknown'."""
+    resources = _load_device('airconditioner_tp1x_rac_coolonly')
+    otn = resources.get('/otninformation/vs/0', {})
+    assert otn.get('swVersionInfo', {}).get('oneUiVersion', '') == ''
+    reg, _ = _resolve('airconditioner_tp1x_rac_coolonly')
+    assert reg is not None and reg.name == 'airconditioner'
+
+
+def test_tp1x_rac_coolonly_no_unbound_hrefs():
+    """Every resource binds or is ignored -- including the two hrefs unique to
+    this dump (/stepcontrol/vs/0, /remotedeviceinfo/vs/0). Clears the gap repair."""
+    reg, resources = _resolve('airconditioner_tp1x_rac_coolonly')
+    unbound = []
+    discover(resources, reg.capabilities, reg.pattern_capabilities, log=unbound.append)
+    assert unbound == []
+
+
+def test_tp1x_rac_coolonly_stray_hrefs_ignored():
+    ignored_hrefs = {cap.href for cap in airconditioner.COVERAGE}
+    assert '/stepcontrol/vs/0' in ignored_hrefs
+    assert '/remotedeviceinfo/vs/0' in ignored_hrefs
+
+
+def test_tp1x_rac_coolonly_climate_bound():
+    reg, resources = _resolve('airconditioner_tp1x_rac_coolonly')
+    bound = discover(resources, reg.capabilities, reg.pattern_capabilities)
+    climate = [b for b in bound if isinstance(b.desc, ClimateDesc)]
+    assert len(climate) == 1 and climate[0].href == '/mode/vs/0'
+
+
+def test_tp1x_rac_coolonly_display_light_from_mode_options():
+    """This board has no /light/vs/0 switch; the panel light lives in
+    /mode/vs/0's options and surfaces as a display_light switch. The token is
+    inverted vs its name (confirmed by a live toggle): `Light_Off` in this dump
+    means the panel is lit -> on."""
+    reg, resources = _resolve('airconditioner_tp1x_rac_coolonly')
+    state = flatten(discover(resources, reg.capabilities, reg.pattern_capabilities), resources)
+    assert state.get('display_light') is True
+
+
+def test_display_light_option_parsing_and_gating():
+    # Inverted token: Light_Off -> panel lit (on), Light_On -> panel dark (off).
+    lit = {'x.com.samsung.da.options': ['CoolCapa_35', 'Light_Off', 'Volume_Mute']}
+    dark = {'x.com.samsung.da.options': ['Light_On']}
+    absent = {'x.com.samsung.da.options': ['Volume_Mute']}
+    assert airconditioner._display_light_on(lit) is True
+    assert airconditioner._display_light_on(dark) is False
+    assert airconditioner._display_light_on(absent) is None
+    assert airconditioner._has_display_light_option(lit, {}) is True
+    assert airconditioner._has_display_light_option(absent, {}) is False
+
+
+def test_display_light_write_is_inverted_single_token():
+    """Turning the lamp ON writes the inverted 'Light_Off' token as a
+    single-element options list (SingleCommand merge); OFF writes 'Light_On'."""
+    sw = next(e for e in airconditioner.CLIMATE.entities if e.key == 'display_light')
+    assert sw.write_fn('On', {}) == (
+        ['mode', 'vs', '0'], {'x.com.samsung.da.options': ['Light_Off']})
+    assert sw.write_fn('Off', {}) == (
+        ['mode', 'vs', '0'], {'x.com.samsung.da.options': ['Light_On']})
+
+
+def test_switch_board_gates_out_mode_options_light():
+    """Boards with a real /light/vs/0 switch carry no Light_* option, so the
+    binary sensor doesn't double up (mutually exclusive encodings)."""
+    reg, resources = _resolve('airconditioner_tp1x_rac')
+    assert airconditioner._has_display_light_option(resources['/mode/vs/0'], resources) is False
+
+
 def test_caww_tp2_model_resolves_via_model_fallback():
     """A-CAWW-TP2-20-COMMON (issue #52, System AC) reports no oneUiVersion
     and no '_RAC_'/'_PRAC_' token -- resolved via the '-CAWW-' modelNum

--- a/tests/test_golden_regression.py
+++ b/tests/test_golden_regression.py
@@ -245,6 +245,20 @@ def test_registry_reproduces_golden_state_keys_for_tp1x_rac():
     )
 
 
+def test_registry_reproduces_golden_state_keys_for_tp1x_rac_coolonly():
+    """TP1X_DA-AC-RAC-01001 cool-only global variant that reports no
+    oneUiVersion -- resolves via the hyphenated '-RAC-' modelNum fallback."""
+    from tests.conftest import _load_device
+    resources = _load_device('airconditioner_tp1x_rac_coolonly')
+    golden = json.loads((GOLDEN / 'airconditioner_tp1x_rac_coolonly.json').read_text())
+    state_keys = _new_state_keys('airconditioner_tp1x_rac_coolonly', resources)
+    assert set(state_keys) == set(golden['state_keys']), (
+        f"state_keys mismatch:\n"
+        f"  extra:   {sorted(set(state_keys) - set(golden['state_keys']))}\n"
+        f"  missing: {sorted(set(golden['state_keys']) - set(state_keys))}"
+    )
+
+
 def test_registry_reproduces_golden_state_keys_for_range():
     """Range/cooktop-oven combo (model TP1X_DA-KS-RANGE-0102X, issue #44) --
     reports no oneUiVersion; resolved via the '-RANGE-' modelNum token


### PR DESCRIPTION
## Summary
Adds support for Samsung TP1X cool-only global room air conditioners (e.g. `TP1X_DA-AC-RAC-01001`, `airconOptionList` includes `AI_RAC_GLOBAL_COOLONLY_3.0`), which previously loaded as an **unknown** device with only common capabilities. Confirmed against two live units — one cool-only, one heat-capable — plus all existing AC fixtures.

## Changes
**Detection** (`registry/by_type/__init__.py`) — these boards ship no `swVersionInfo` block, so `oneUiVersion` is empty and `for_device()` cannot route them; their `modelNum` spells the RAC token with hyphens (`-AC-RAC-`), which the existing `_RAC_` underscore match missed. Match the hyphenated `-RAC-` token in `for_device_by_model()`.

**Climate** (`climate.py`)
- Map device `Auto` -> `HVACMode.AUTO` (was `HEAT_COOL`, which renders Heat/cool and implies a two-setpoint range these single-setpoint / cool-only units do not have).
- Expose **WindFree** as a preset: on these boards it is the convenient mode `Nano` (`NanoSleep` = WindFree + sleep), in place of `Smart`. Confirmed by diffing a WindFree-off dump (`Off`) vs on (`Nano`).

**Display light** (`registry/capabilities/airconditioner.py`)
- Display-light **switch** for boards that encode the panel light in `/mode/vs/0`''s options blob instead of a `/light/vs/0` switch (mutually exclusive across all observed dumps). Read + single-token `SingleCommand` write, both accounting for the token being **inverted** vs its name (`Light_Off` = panel lit) — confirmed by a live toggle; mirrors `air_purifier.py`''s `Light` switch.
- Ignore `/stepcontrol/vs/0` and `/remotedeviceinfo/vs/0` to clear the coverage-gap repair.

**Tests / fixtures** — new scrubbed fixture + golden for the cool-only unit, detection/coverage/write regression tests, and the three regenerated AC goldens that gain `display_light`.

## Validation
HA-free discovery harness across all six AC fixtures: each resolves to the airconditioner registry, zero unbound hrefs, goldens match; no non-AC fixture misroutes; en/nl translations mirror. All behavior (climate control, WindFree, Auto label, display-light toggle that sticks without disturbing other state) verified live on hardware.

> Note: the full `pytest` suite needs `pytest-homeassistant-custom-component` (Python >= 3.13) and my machine has 3.12, so I validated with the HA-free registry harness. CI should run the full suite.