### PR TITLE
Honour hvac_mode in the AC climate set_temperature

### DIFF
--- a/custom_components/localthings/climate.py
+++ b/custom_components/localthings/climate.py
@@ -393,6 +393,16 @@ class LocalThingsClimate(LocalThingsEntity, ClimateEntity):
         return _HVAC_TO_DEVICE.get(hvac_mode)
 
     async def async_set_temperature(self, **kwargs) -> None:
+        # HA's set_temperature service forwards an optional hvac_mode here; honour
+        # it (set the mode first -- that also powers the unit on when it was off),
+        # matching the climate contract other integrations follow. Without this a
+        # set_temperature call carrying hvac_mode (e.g. a dashboard "turn on to
+        # Auto 24" button) set the setpoint but never changed mode or powered on.
+        hvac_mode = kwargs.get('hvac_mode')
+        if hvac_mode is not None:
+            await self.async_set_hvac_mode(hvac_mode)
+            if hvac_mode == HVACMode.OFF:
+                return
         temp = kwargs.get('temperature')
         if temp is None:
             return


### PR DESCRIPTION
## What

The AC `climate` entity's `async_set_temperature` ignored an `hvac_mode` passed alongside the setpoint — it only wrote the target temperature. Home Assistant's `climate.set_temperature` service forwards an optional `hvac_mode` into `async_set_temperature(**kwargs)` and expects the entity to apply it (it does **not** call `async_set_hvac_mode` separately). So a `set_temperature` call carrying `hvac_mode` set the setpoint but never changed the mode or powered the unit on.

Concretely: a dashboard button (or automation) that turns the unit on by calling `set_temperature` with `hvac_mode: auto` + `temperature: 24` set the temperature but left the AC off. This only became reachable after the `Auto -> HVACMode.AUTO` mapping (#114) — before that `auto` wasn't a valid mode at all, so the whole call was rejected.

## Change

When `hvac_mode` is present, apply it first — which powers the unit on if it was off, via the existing `async_set_hvac_mode` — then write the setpoint. The plain `set_temperature` path (no `hvac_mode`) is unchanged.

## Notes

- **Deliberately unconditional** — no `hvac_mode != self.hvac_mode` short-circuit. These boards have observable state lag, so a stale cached `hvac_mode` could skip a mode write the caller actually asked for; always applying the requested mode is the safe choice.
- **AIComfort:** a caller that explicitly sends `hvac_mode: auto` while the unit is in the `ai_comfort` preset will switch it to plain Auto — that's honouring an explicit request. A normal setpoint change (no `hvac_mode`) leaves the preset untouched.
- **Tests:** consistent with the existing climate tests, which cover the pure module-level maps/helpers and leave the entity's async methods (this one, `async_set_hvac_mode`, ...) to the HA fixture layer they deliberately don't exercise — there's no pure logic to extract here. Verified on live hardware (cool-only and heat-capable RAC units): with the AC off, `set_temperature` + `hvac_mode: auto` now powers on to Auto and applies the setpoint.