### PR TITLE
Preserve AC target temperature across OFF-to-mode transitions

### DIFF
--- a/custom_components/localthings/climate.py
+++ b/custom_components/localthings/climate.py
@@ -431,29 +431,63 @@ class LocalThingsClimate(LocalThingsEntity, ClimateEntity):
         # matching the climate contract other integrations follow. Without this a
         # set_temperature call carrying hvac_mode (e.g. a dashboard "turn on to
         # Auto 24" button) set the setpoint but never changed mode or powered on.
+        temp = kwargs.get('temperature')
+        temperature_command = None
+        if temp is not None:
+            kind = (
+                'temperature_ocf'
+                if self._ocf_temp_authoritative()
+                else 'temperature'
+            )
+            temperature_command = (kind, temp)
         hvac_mode = kwargs.get('hvac_mode')
         if hvac_mode is not None:
-            await self.async_set_hvac_mode(hvac_mode)
+            await self._async_set_hvac_mode(
+                hvac_mode, preserve_target=temp is None)
             if hvac_mode == HVACMode.OFF:
                 return
-        temp = kwargs.get('temperature')
-        if temp is None:
+        if temperature_command is None:
             return
         # OCF-pair boards write /temperature/desired/0; vendor boards write
-        # /temperatures/vs/0 (see airconditioner._climate_write).
-        kind = 'temperature_ocf' if self._ocf_temp_authoritative() else 'temperature'
-        await self.coordinator.async_send_command(self._bound, (kind, temp))
+        # /temperatures/vs/0 (see airconditioner._climate_write). The channel
+        # is captured before a requested mode transition because its refresh
+        # may temporarily expose an incomplete resource snapshot.
+        await self.coordinator.async_send_command(
+            self._bound, temperature_command)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        await self._async_set_hvac_mode(hvac_mode, preserve_target=True)
+
+    async def _async_set_hvac_mode(
+        self, hvac_mode: HVACMode, *, preserve_target: bool,
+    ) -> None:
         if hvac_mode == HVACMode.OFF:
             await self.coordinator.async_send_command(self._bound, ('power', False))
             return
         device = self._device_code_for_hvac(hvac_mode)
         if device is None:
             return
-        if not self._is_on():
+        was_off = not self._is_on()
+        preserved_command = None
+        if was_off and preserve_target:
+            target = self.target_temperature
+            if target is not None:
+                kind = (
+                    'temperature_ocf'
+                    if self._ocf_temp_authoritative()
+                    else 'temperature'
+                )
+                preserved_command = (kind, target)
+        if was_off:
             await self.coordinator.async_send_command(self._bound, ('power', True))
         await self.coordinator.async_send_command(self._bound, ('mode', device))
+        # Some boards restore a stale secondary temperature channel while
+        # powering up. Reassert the pre-transition setpoint after issuing the
+        # power and mode writes so that OFF -> ON keeps the user's existing
+        # target (including a valid minimum such as 16 °C).
+        if preserved_command is not None:
+            await self.coordinator.async_send_command(
+                self._bound, preserved_command)
 
     async def async_turn_on(self) -> None:
         await self.coordinator.async_send_command(self._bound, ('power', True))

--- a/tests/test_climate_temperature_transition.py
+++ b/tests/test_climate_temperature_transition.py
@@ -1,0 +1,156 @@
+"""Regression tests for AC target-temperature preservation on power-up."""
+
+import pytest
+from homeassistant.components.climate import HVACMode
+
+from custom_components.localthings.climate import LocalThingsClimate
+from custom_components.localthings.registry.by_type.airconditioner import REGISTRY
+from custom_components.localthings.registry.discovery import discover
+from custom_components.localthings.registry.entities import ClimateDesc
+from tests.conftest import _load_device
+
+
+class _FakeCoordinator:
+    device_serial = 'TEST-AC-SERIAL'
+    device_info = {}
+    data = {}
+
+    def __init__(self, resources):
+        self.last_resources = resources
+        self.commands = []
+        self.command_hook = None
+
+    def resource(self, href):
+        return self.last_resources.get(href, {})
+
+    async def async_send_command(self, bound, payload):
+        self.commands.append((bound, payload))
+        if self.command_hook is not None:
+            self.command_hook(payload)
+
+
+def _entity(resources):
+    bound = discover(
+        resources,
+        REGISTRY.capabilities,
+        REGISTRY.pattern_capabilities,
+    )
+    climate_bound = next(
+        item for item in bound if isinstance(item.desc, ClimateDesc)
+    )
+    coordinator = _FakeCoordinator(resources)
+    return LocalThingsClimate(coordinator, climate_bound), coordinator
+
+
+def _payloads(coordinator):
+    return [payload for _, payload in coordinator.commands]
+
+
+@pytest.mark.parametrize('target', [16.0, 26.0])
+async def test_off_to_cool_reasserts_ocf_target_after_power_and_mode(target):
+    resources = _load_device('airconditioner')
+    resources['/temperature/desired/0']['temperature'] = target
+    entity, coordinator = _entity(resources)
+
+    await entity.async_set_hvac_mode(HVACMode.COOL)
+
+    assert _payloads(coordinator) == [
+        ('power', True),
+        ('mode', 'Cool'),
+        ('temperature_ocf', target),
+    ]
+
+
+async def test_power_up_captures_target_and_write_channel_before_first_await():
+    resources = _load_device('airconditioner')
+    resources['/temperature/desired/0']['temperature'] = 26.0
+    entity, coordinator = _entity(resources)
+
+    def simulate_transition_readback(payload):
+        if payload == ('power', True):
+            resources['/temperature/desired/0']['temperature'] = 16.0
+            resources['/temperature/current/0'] = {}
+
+    coordinator.command_hook = simulate_transition_readback
+
+    await entity.async_set_hvac_mode(HVACMode.COOL)
+
+    assert _payloads(coordinator) == [
+        ('power', True),
+        ('mode', 'Cool'),
+        ('temperature_ocf', 26.0),
+    ]
+
+
+async def test_off_to_cool_reasserts_vendor_target_on_vendor_only_board():
+    resources = _load_device('airconditioner_tp1x_da_ac_rac_01011')
+    entity, coordinator = _entity(resources)
+
+    await entity.async_set_hvac_mode(HVACMode.COOL)
+
+    assert _payloads(coordinator) == [
+        ('power', True),
+        ('mode', 'Cool'),
+        ('temperature', 25.0),
+    ]
+
+
+async def test_mode_change_while_on_does_not_write_temperature():
+    resources = _load_device('airconditioner')
+    resources['/power/vs/0']['x.com.samsung.da.power'] = 'On'
+    entity, coordinator = _entity(resources)
+
+    await entity.async_set_hvac_mode(HVACMode.DRY)
+
+    assert _payloads(coordinator) == [('mode', 'Dry')]
+
+
+async def test_power_up_without_known_target_skips_temperature_write():
+    resources = _load_device('airconditioner')
+    resources['/temperature/desired/0'].pop('temperature')
+    resources['/temperatures/vs/0']['x.com.samsung.da.items'][0].pop(
+        'x.com.samsung.da.desired'
+    )
+    entity, coordinator = _entity(resources)
+
+    await entity.async_set_hvac_mode(HVACMode.COOL)
+
+    assert _payloads(coordinator) == [
+        ('power', True),
+        ('mode', 'Cool'),
+    ]
+
+
+async def test_explicit_temperature_with_mode_writes_only_the_new_target():
+    resources = _load_device('airconditioner')
+    resources['/temperature/desired/0']['temperature'] = 26.0
+    entity, coordinator = _entity(resources)
+
+    def simulate_transition_readback(payload):
+        if payload == ('power', True):
+            resources['/temperature/current/0'] = {}
+
+    coordinator.command_hook = simulate_transition_readback
+
+    await entity.async_set_temperature(
+        hvac_mode=HVACMode.COOL,
+        temperature=24.0,
+    )
+
+    assert _payloads(coordinator) == [
+        ('power', True),
+        ('mode', 'Cool'),
+        ('temperature_ocf', 24.0),
+    ]
+
+
+async def test_explicit_temperature_with_off_only_turns_power_off():
+    resources = _load_device('airconditioner')
+    entity, coordinator = _entity(resources)
+
+    await entity.async_set_temperature(
+        hvac_mode=HVACMode.OFF,
+        temperature=24.0,
+    )
+
+    assert _payloads(coordinator) == [('power', False)]


### PR DESCRIPTION
## What changed

- Preserve the current AC target temperature before an OFF -> non-OFF HVAC
  mode transition.
- Issue the power and mode commands first, then reassert the preserved target
  on the same OCF or vendor temperature channel that was authoritative before
  the transition.
- Keep `set_temperature(hvac_mode=..., temperature=...)` to one target write:
  the explicitly requested value replaces, rather than follows, the old
  preserved value.
- Capture both explicit and preserved temperature commands before the first
  awaited transition write, so a transiently incomplete refresh cannot switch
  an OCF board onto the vendor write path.

## Root cause

On a live Samsung AC, an Apple Home OFF -> Cool action reached Home Assistant
only as `climate.set_hvac_mode(cool)`; there was no temperature command.
During the device transition and reconnect window, its OCF desired-temperature
resource and secondary vendor temperature resource could diverge. The stale
secondary value could later become the reported target.

LocalThings currently writes power and mode for this path but assumes the
setpoint survives the transition. Reasserting the pre-transition setpoint after
those writes closes that gap without filtering any temperature value. In
particular, 16 C remains valid and is explicitly covered by a regression test.

## Tests

- `pytest tests/ -q` — 695 passed
- `git diff --check`
- Python bytecode compilation for the integration and new test module

The regression tests cover:

- OCF and vendor-only temperature channels
- command order: power -> mode -> preserved target
- a transition refresh changing 26 C to 16 C before the final write
- a legitimate 16 C target
- already-on mode changes and missing targets
- explicit `hvac_mode` + temperature calls without duplicate target writes
- OFF + explicit temperature retaining the existing power-off behavior

## Live validation

I ported the same sequencing to an installed LocalThings integration and ran a
Fan-only -> OFF -> Cool transition on an ARTIK051-class AC. The verified device
command order was power, mode, then desired temperature. More than three
minutes later, Home Assistant and both raw temperature resources still agreed
on 26 C, and the coordinator was back in observe mode.

Related context: #91, #92, #128.
