### PR TITLE
fix(registry): route microwaves without /information/vs/0 to microwave registry

### DIFF
--- a/custom_components/localthings/registry/by_type/__init__.py
+++ b/custom_components/localthings/registry/by_type/__init__.py
@@ -327,18 +327,20 @@ def for_device_by_resources(resources: dict[str, dict]) -> Optional[DeviceRegist
         and '/hood/lamp/vs/0' in resources
     ):
         return _REGISTRY_BY_KEY['range_hood']
-    # Oven/range-combo boards that report no /information/vs/0 at all
-    # (issue #74's NE63B8411SS -- the resource is simply absent from the
-    # dump, not just empty) can't be matched via for_device_by_model's
-    # modelNum tokens either. 'Bake' is oven/range cook-mode vocabulary that
-    # no other family's /mode/vs/0 uses (confirmed against the microwave,
-    # cooktop, and every laundry fixture), so its presence alongside the
-    # oven cavity resource is a safe signature. Distinguish range (has a
-    # cooktop half) from a plain wall oven by which cooktop-status resource,
-    # if any, is also present.
+    # Oven/range/microwave boards that report no /information/vs/0 at all
+    # (issue #74's NE63B8411SS, issue #172's ME8000T -- the resource is simply
+    # absent from the dump, not just empty) can't be matched via
+    # for_device_by_model's modelNum tokens either. Mode vocabulary alongside
+    # the oven cavity resource (/oven/vs/0) is a safe signature.
     supported_modes = mode.get('x.com.samsung.da.supportedModes') or ()
-    if '/oven/vs/0' in resources and 'Bake' in supported_modes:
-        if '/cooktopmonitoring/vs/0' in resources or '/cooktop/status/vs/0' in resources:
-            return _REGISTRY_BY_KEY['range']
-        return _REGISTRY_BY_KEY['oven']
+    if '/oven/vs/0' in resources:
+        if any(
+            m in supported_modes
+            for m in ('MicroWave', 'MicroWaveGrill', 'MicroWaveConvection')
+        ):
+            return _REGISTRY_BY_KEY['microwave']
+        if 'Bake' in supported_modes:
+            if '/cooktopmonitoring/vs/0' in resources or '/cooktop/status/vs/0' in resources:
+                return _REGISTRY_BY_KEY['range']
+            return _REGISTRY_BY_KEY['oven']
     return None

--- a/tests/test_by_type.py
+++ b/tests/test_by_type.py
@@ -529,3 +529,21 @@ class TestForDeviceByResources:
             },
         }
         assert for_device_by_resources(resources) is None
+
+    def test_microwave_without_information_is_microwave(self):
+        """Issue #172: Samsung Microwave (ME8000T-/AA0) has no /information/vs/0
+        resource and empty oneUiVersion; 'MicroWave' in supportedModes alongside
+        /oven/vs/0 must route to the microwave registry."""
+        from custom_components.localthings.registry.by_type import for_device_by_resources
+        resources = {
+            '/mode/vs/0': {
+                'x.com.samsung.da.supportedModes': ['MicroWave', 'Autocook', 'Convection'],
+                'x.com.samsung.da.options': ['DeviceType_ME8000T-/AA0', 'Lamp_Off'],
+            },
+            '/oven/vs/0': {'x.com.samsung.da.state': 'Ready'},
+            '/hood/fanspeed/vs/0': {'x.com.samsung.da.hood.fanSpeed': '0'},
+        }
+        reg = for_device_by_resources(resources)
+        assert reg is not None
+        assert reg.name == 'microwave'
+


### PR DESCRIPTION
## Summary

Fixes https://github.com/mbillow/localthings/issues/172

Samsung Microwave units such as `ME8000T-/AA0` (`TP2X_DA-KS-MICROWAVE`) omit the `/information/vs/0` resource entirely and report no `swVersionInfo` in `/otninformation/vs/0`. As a result, model-based detection (`for_device_by_model`) cannot execute, and device detection fell back to `unknown`, missing all 24 microwave entities (including vent fan speed `/hood/fanspeed/vs/0` and lamp switch `/mode/vs/0`).

**Changes:**
- Updated `for_device_by_resources()` in `by_type/__init__.py` to check for microwave resource signatures: when `/oven/vs/0` is present and `/mode/vs/0`'s `supportedModes` contains microwave cooking modes (`MicroWave`, `MicroWaveGrill`, or `MicroWaveConvection`), route to `_REGISTRY_BY_KEY['microwave']`.
- Routing to `microwave` binds all 24 device entities (vent fan, lamp switch, cavity state, microwave setpoint, cooking mode select, doors, power).
- Added `test_microwave_without_information_is_microwave` in `tests/test_by_type.py`.

## Test plan
- [x] `PYTHONPATH=. ./.venv/bin/pytest --cov=custom_components/localthings tests/` — 778 passed (100% pass rate, 86% overall coverage, 100% coverage on `by_type/__init__.py`).
- [x] Added unit test `test_microwave_without_information_is_microwave` verifying resource-based device resolution for microwave hardware omitting `/information/vs/0`.
