### PR TITLE
feat(by_type): route the CAC board family to the air-conditioner registry

### DIFF
--- a/custom_components/localthings/registry/by_type/__init__.py
+++ b/custom_components/localthings/registry/by_type/__init__.py
@@ -75,10 +75,12 @@ _BOARD_TOKEN_TO_KEY: dict[str, str] = {
     # Air conditioners. Every one of these is a distinct board family with
     # the same resource surface: room (issues #37, #91), package, Korean
     # (#136), window (#87), 2-in-1 floor+wall (#150, #153), system/commercial
-    # (#52), and ARA-WW wall-mount (#115, #116, #117, #120).
+    # (#52), ARA-WW wall-mount (#115, #116, #117, #120), and CAC
+    # (TP1X_DA-AC-CAC-01001, a Korean-market unit).
     'RAC': 'airconditioner',
     'PRAC': 'airconditioner',
     'KRAC': 'airconditioner',
+    'CAC': 'airconditioner',
     'WAC': 'airconditioner',
     'FAC': 'airconditioner',
     'CAWW': 'airconditioner',

--- a/tests/test_by_type.py
+++ b/tests/test_by_type.py
@@ -102,6 +102,19 @@ class TestBoardTokenTable:
         for prefix, key in _CONSUMER_PREFIX_TO_KEY.items():
             assert key in _REGISTRY_BY_KEY, f"{prefix!r} -> unknown registry {key!r}"
 
+    def test_cac_board_family_types_as_air_conditioner(self):
+        """TP1X_DA-AC-CAC-01001 is a Korean-market air conditioner whose token
+        matched nothing: 'CAC' was absent, and the bare 'AC' that the rest of the
+        modelNum offers is deliberately not in the table. It resolved to None and
+        raised the unrecognised-device repair despite reporting the same resource
+        surface the airconditioner registry already covers."""
+        from custom_components.localthings.registry.by_type import for_device_by_model
+        registry = for_device_by_model(
+            'TP1X_DA-AC-CAC-01001_0000|10255541|60030717171811DF42005F2A00F2ED00',
+            'TP1X_DA-AC-CAC-01001_0000')
+        assert registry is not None
+        assert registry.name == 'airconditioner'
+
     def test_tokens_are_upper_case(self):
         """`_board_tokens` upper-cases before lookup, so a lower-case entry
         would be dead."""


### PR DESCRIPTION
## Problem

A Korean-market air conditioner reporting `TP1X_DA-AC-CAC-01001` resolves to `None`
and raises the "incomplete capability coverage" repair, even though it reports the
same resource surface the `airconditioner` registry already covers.

`_board_tokens` reduces its `modelNum` to `[TP1X, DA, AC, CAC, 01001, 0000]`. None of
those is in `_BOARD_TOKEN_TO_KEY`: `CAC` is missing, and the bare `AC` it also offers
is deliberately excluded — correctly so, since it would swallow `DHM` and `AIR`.
`for_device_by_resources` doesn't catch it either, as the unit has no `/oven/vs/0`,
no hood resources, and no `DeviceType_` option on `/mode/vs/0`.

So the fallback that exists for boards with a scrubbed `modelNum` can't help here:
the `modelNum` is perfectly good, it just names a family the table doesn't list.

## Change

One token, placed with the other air-conditioner families, plus a test alongside the
existing routing cases.

## Evidence

Against a live `/device/0` dump from the unit (51 resources):

| | before | after |
|---|---|---|
| `resolve()` | `None` | `airconditioner` |
| entities bound | — | 41 |
| unbound hrefs | — | 10 |

The 10 remaining gaps, in case they're useful for issue triage — this board carries
several features the registry doesn't cover yet:

```
/edgelighting/vs/0
/filter/airdustPM1filter/vs/0
/light/stateful/vs/0
/mds/absenceclean/vs/0
/settings/sound/mode/vs/0
/settings/sound/optimization/vs/0
/settings/sound/output/vs/0
/settings/sound/volume/vs/0
/smartsensingcooling/vs/0
/uvled/vs/0
```

Note `/light/stateful/vs/0` rather than the `/light/vs/0` that `DISPLAY_LIGHT` binds,
and a second `PM1` filter alongside `/filter/airdustfilter/vs/0`. I'm happy to open a
separate issue with the dump if you'd like coverage for those.

## What I verified

The registry package is HA-free, so I drove it directly rather than standing up the
full test environment:

- `CAC` now types as `airconditioner`
- The token-table invariants your tests assert still hold: no bare family token
  (`AC`, `DA`, `KS`, `WM`, `TP1X`, `TP2X`, `ARTIK051`) is present, every token and
  consumer prefix resolves to a real registry, and every token is upper-case
- No routing regressions across nine existing families: `RAC`, `KRAC`, `DHM`, `AIR`,
  `WAC`, `ARTIK051_DONGLE_REF`, the legacy gas cooktop (`ARTIK051_GB_CT_001` +
  `ARTIK051_GLOBAL_COOKTOP`, which must stay `gas_cooktop` and not the induction
  registry), `TP1X_DA-KS-COOKTOP`, and a `WW` consumer prefix
- `discover()` against the live dump binds 41 entities

I have not run the full pytest suite; the checks above were run directly against the
`registry` package on Python 3.14.

## Context

Found while porting this integration to Homey
([moKorean/com.lomohome.localthings](https://github.com/moKorean/com.lomohome.localthings)).
Your protocol analysis and registry design are what made that feasible at all —
thank you for documenting the reasoning as thoroughly as you did, particularly the
wire-level constants in `dtls_session.py` and the read/write judgments in
`capabilities/`. Both saved a great deal of guessing.
