### PR TITLE
AC: fix options-based display light (truthiness bug + inverted Light token)

### DIFF
--- a/custom_components/localthings/__init__.py
+++ b/custom_components/localthings/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN, PLATFORMS
+from .const import CONF_HOST, DOMAIN, PLATFORMS
 from .coordinator import LocalThingsCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,6 +20,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.async_config_entry_first_refresh()
     except Exception as err:
         raise ConfigEntryNotReady(f"Cannot connect to device: {err}") from err
+    # A refresh can return without the device having identified itself (the
+    # session came up but /device/0 carried no serial yet). coordinator's
+    # device_serial is still the host placeholder at that point, so setting up
+    # platforms now bakes the host into every unique_id and registers a second,
+    # IP-keyed device that outlives the mistake -- its connection_mode sensor
+    # then collides with the real one forever. Retry instead; the placeholder
+    # only exists to bridge the gap before the first successful poll.
+    if not coordinator.discovered:
+        raise ConfigEntryNotReady(
+            f"Device at {entry.data[CONF_HOST]} has not reported its identity yet")
     hass.data[DOMAIN][entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -122,6 +122,15 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # ------------------------------------------------------------------
 
     @property
+    def discovered(self) -> bool:
+        """True once a poll has identified the device and bound its entities.
+
+        Until then device_serial/device_info hold host-derived placeholders, so
+        setup must not register entities against them (see async_setup_entry).
+        """
+        return self._discovered
+
+    @property
     def last_resources(self) -> dict:
         return self._cache.snapshot()
 

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -142,17 +142,40 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         cert_pem = self._entry.data[CONF_LEAF_CERT_PEM]
         key_pem  = self._entry.data[CONF_LEAF_KEY_PEM]
 
-        sess = DtlsCoapSession(host, port, cert_pem=cert_pem, key_pem=key_pem,
-                               on_notification=self._observe.on_notification)
-        sess.connect()
-        sess.start_reader()
-        self._session = sess
-        self._log.debug("DTLS connected to %s:%d", host, port)
-        try:
-            self._identity = read_identity(sess, None)
-        except Exception as e:
-            self._log.debug("read_identity failed: %s", e)
-            self._identity = None
+        # Some Samsung RAC modules expose very few DTLS session slots and WiFi
+        # latency stresses the multi-flight handshake, so a single 12s attempt
+        # frequently times out (especially on reconnect, before the old slot
+        # has aged out). Give the handshake a longer budget and a few
+        # backed-off retries. Runs in an executor thread, so time.sleep is fine.
+        DtlsCoapSession.HANDSHAKE_TIMEOUT_S = 25.0
+        attempts, backoff_s = 3, 8.0
+        last_exc = None
+        for attempt in range(attempts):
+            sess = DtlsCoapSession(host, port, cert_pem=cert_pem, key_pem=key_pem,
+                                   on_notification=self._observe.on_notification)
+            try:
+                sess.connect()
+            except Exception as e:
+                last_exc = e
+                try:
+                    sess.close()
+                except Exception:
+                    pass
+                if attempt < attempts - 1:
+                    self._log.debug("DTLS connect %d/%d to %s:%d failed: %s",
+                                    attempt + 1, attempts, host, port, e)
+                    time.sleep(backoff_s)
+                continue
+            sess.start_reader()
+            self._session = sess
+            self._log.debug("DTLS connected to %s:%d", host, port)
+            try:
+                self._identity = read_identity(sess, None)
+            except Exception as e:
+                self._log.debug("read_identity failed: %s", e)
+                self._identity = None
+            return
+        raise last_exc if last_exc is not None else RuntimeError("DTLS connect failed")
 
     def _close_session(self) -> None:
         sess = self._session

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import threading
 import time
@@ -553,7 +554,14 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     translation_domain=DOMAIN,
                     translation_key=error,
                 )
-        result = write_fn(payload, rep, href)
+        # Pass the full resource snapshot to write_fns that opt in (accept a
+        # `resources` param) so they can pick a model-specific target — e.g.
+        # the AC setpoint, which lives on /temperature/desired/0 on some models
+        # and the vendor /temperatures/vs/0 items array on others.
+        if 'resources' in inspect.signature(write_fn).parameters:
+            result = write_fn(payload, rep, href, resources=resources)
+        else:
+            result = write_fn(payload, rep, href)
         if result is None:
             self._log.warning("write_fn rejected payload %r for %s", payload, href)
             return

--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -12,5 +12,5 @@
     "pyOpenSSL>=23.0",
     "smartthings-local>=0.1.0"
   ],
-  "version": "0.11.3"
+  "version": "0.11.4"
 }

--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -12,5 +12,5 @@
     "pyOpenSSL>=23.0",
     "smartthings-local>=0.1.0"
   ],
-  "version": "0.11.2"
+  "version": "0.11.3"
 }

--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -12,5 +12,5 @@
     "pyOpenSSL>=23.0",
     "smartthings-local>=0.1.0"
   ],
-  "version": "0.11.4"
+  "version": "0.11.6"
 }

--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -12,5 +12,5 @@
     "pyOpenSSL>=23.0",
     "smartthings-local>=0.1.0"
   ],
-  "version": "0.11.1"
+  "version": "0.11.2"
 }

--- a/custom_components/localthings/registry/by_type/airconditioner.py
+++ b/custom_components/localthings/registry/by_type/airconditioner.py
@@ -19,6 +19,7 @@ REGISTRY = DeviceRegistry(
         *common.UNIVERSAL,
         dishwasher.DIAGNOSIS,
         airconditioner.CLIMATE,
+        airconditioner.HUMIDITY,
         airconditioner.AIR_PURIFY,
         airconditioner.AUTO_CLEAN,
         airconditioner.AIR_FILTER,

--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -71,7 +71,7 @@ def _first_mode(rep):
     return modes
 
 
-def _climate_write(payload, rep, href=None):
+def _climate_write(payload, rep, href=None, resources=None):
     """Map a (kind, value) command from the climate platform to the
     (path_segs, body) for that one sub-write. `value` is already the raw device
     code (the platform maps HA<->device). async_send_command POSTs to path_segs,
@@ -85,6 +85,18 @@ def _climate_write(payload, rep, href=None):
     if kind == 'mode':
         return (['mode', 'vs', '0'], {'x.com.samsung.da.modes': [value]})
     if kind == 'temperature':
+        # Two setpoint layouts exist across models: the scalar
+        # /temperature/desired/0, and the vendor /temperatures/vs/0 items
+        # array (e.g. TP2X_RAC_20K, which returns 4.04 Not Found on
+        # /temperature/desired/0 — see current_/target_temperature's read
+        # fallback above). Prefer the scalar when the device exposes it; else
+        # write the vendor items array. `resources` is the device snapshot
+        # (keyed by href); when absent (legacy caller) keep the scalar path.
+        if resources is not None and '/temperature/desired/0' not in resources:
+            return (['temperatures', 'vs', '0'],
+                    {'x.com.samsung.da.items': [
+                        {'x.com.samsung.da.id': '0',
+                         'x.com.samsung.da.desired': f"{float(value):.1f}"}]})
         return (['temperature', 'desired', '0'], {'temperature': int(round(float(value)))})
     if kind == 'fan':
         return (['wind', 'strength', 'vs', '0'], {'x.com.samsung.da.modes': value})

--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -75,9 +75,12 @@ def _volume_write(payload, rep, href=None):
 
 
 def _light_write(payload, rep, href=None):
+    # payload is the switch platform's 'On'/'Off' string -- pass it through
+    # like air_purifier.MODE does. Truthiness is wrong here: 'Off' is a
+    # non-empty string, so `'On' if payload else 'Off'` sent Light_On for
+    # both toggle directions.
     return ['mode', 'vs', '0'], {
-        'x.com.samsung.da.options': option_write(
-            'Light', 'On' if payload else 'Off'),
+        'x.com.samsung.da.options': option_write('Light', payload),
     }
 
 

--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -15,7 +15,7 @@ different schema (see capabilities/__init__.py). They live only in the AC
 by_type registry.
 """
 from ..capability import Capability
-from ..entities import BinarySensorDesc, ClimateDesc, SensorDesc, SwitchDesc
+from ..entities import BinarySensorDesc, ClimateDesc, NumberDesc, SensorDesc, SwitchDesc
 
 # ---------------------------------------------------------------------------
 # Canonical AC resource hrefs. The climate entity (climate.py) binds the
@@ -48,6 +48,34 @@ def _num(v):
         return float(v)
     except (TypeError, ValueError):
         return None
+
+
+# --- /mode/vs/0 options blob ('Light_On', 'Volume_100'/'Volume_Mute', ...) ---
+# Some settings (display light, beep volume) have no dedicated resource on
+# models like TP2X_RAC_20K; they live only in /mode/vs/0's `options` array and
+# are written back one token at a time (the device merges by prefix — see
+# common.merge_options_field). These read/write that array.
+def _opt(rep, key):
+    for o in (rep.get('x.com.samsung.da.options') or ()):
+        if isinstance(o, str) and o.startswith(key + '_'):
+            return o[len(key) + 1:]
+    return None
+
+
+def _has_opt(rep, key):
+    return _opt(rep, key) is not None
+
+
+def _vol_read(rep):
+    v = _opt(rep, 'Volume')
+    if v is None:
+        return None
+    return 0 if v == 'Mute' else _num(v)
+
+
+def _vol_token(p):
+    p = int(round(float(p)))
+    return 'Volume_Mute' if p <= 0 else f'Volume_{p}'
 
 
 def _filter_usage_percent(rep):
@@ -113,6 +141,35 @@ CLIMATE = Capability(
     entities=(
         ClimateDesc(key='climate', translation_key='airconditioner',
                     rep_fn=_first_mode, write_fn=_climate_write),
+        # Display light + beep volume: on models like TP2X_RAC_20K these are
+        # options on /mode/vs/0 (no /light/vs/0 or /audioVolume/vs/0 resource),
+        # so bind them here and gate on the option being present.
+        SwitchDesc(key='display_light', icon='mdi:led-on',
+                   entity_category='config',
+                   rep_fn=lambda rep: _opt(rep, 'Light') == 'On',
+                   exists_fn=lambda rep, res: _has_opt(rep, 'Light'),
+                   write_fn=lambda p, rep, href=None: (
+                       ['mode', 'vs', '0'],
+                       {'x.com.samsung.da.options': [
+                           'Light_On' if p else 'Light_Off']})),
+        NumberDesc(key='sound_volume', icon='mdi:volume-high',
+                   entity_category='config',
+                   native_min=0, native_max=100, step=1,
+                   rep_fn=_vol_read,
+                   exists_fn=lambda rep, res: _has_opt(rep, 'Volume'),
+                   write_fn=lambda p, rep, href=None: (
+                       ['mode', 'vs', '0'],
+                       {'x.com.samsung.da.options': [_vol_token(p)]})),
+    ),
+)
+
+HUMIDITY = Capability(
+    href='/humidity/vs/0',
+    poll_tier='warm',
+    entities=(
+        SensorDesc(key='humidity', field='x.com.samsung.da.humidity',
+                   device_class='humidity', unit='%', state_class='measurement',
+                   value_fn=_num),
     ),
 )
 

--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -16,7 +16,7 @@ by_type registry.
 """
 from ..capability import Capability
 from ..entities import BinarySensorDesc, ClimateDesc, NumberDesc, SensorDesc, SwitchDesc
-from .laundry import bool_option_exists, bool_option_value, option_value, option_write
+from .laundry import bool_option_exists, option_value, option_write
 
 # ---------------------------------------------------------------------------
 # Canonical AC resource hrefs. The climate entity (climate.py) binds the
@@ -74,13 +74,25 @@ def _volume_write(payload, rep, href=None):
     }
 
 
+# The RAC Light token is INVERTED: Light_Off = display lit, Light_On =
+# display dark (verified on three live RAC units, 2026-07-29; matches the
+# long-standing SmartThings quirk where you send "Light_Off" to turn the
+# panel on). Both the read and the write below flip the token so the HA
+# switch tracks the physical display, not the wire token. Two historical
+# bugs lived here: the write used `'On' if payload else 'Off'` -- but the
+# switch platform passes the *string* 'Off', which is truthy, so both
+# toggle directions sent Light_On -- and neither direction accounted for
+# the inversion. air_purifier's Light token is NOT inverted; its mapping
+# is deliberately different.
+def _light_value(rep):
+    v = option_value(rep.get('x.com.samsung.da.options'), 'Light')
+    return None if v is None else v == 'Off'
+
+
 def _light_write(payload, rep, href=None):
-    # payload is the switch platform's 'On'/'Off' string -- pass it through
-    # like air_purifier.MODE does. Truthiness is wrong here: 'Off' is a
-    # non-empty string, so `'On' if payload else 'Off'` sent Light_On for
-    # both toggle directions.
     return ['mode', 'vs', '0'], {
-        'x.com.samsung.da.options': option_write('Light', payload),
+        'x.com.samsung.da.options': option_write(
+            'Light', 'Off' if payload == 'On' else 'On'),
     }
 
 
@@ -180,7 +192,7 @@ CLIMATE = Capability(
         # same key.
         SwitchDesc(key='display_light', icon='mdi:led-on',
                    entity_category='config',
-                   rep_fn=bool_option_value('Light'),
+                   rep_fn=_light_value,
                    exists_fn=lambda rep, resources: (
                        HREF_LIGHT not in resources
                        and bool_option_exists('Light')(rep, resources)),

--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -16,6 +16,7 @@ by_type registry.
 """
 from ..capability import Capability
 from ..entities import BinarySensorDesc, ClimateDesc, NumberDesc, SensorDesc, SwitchDesc
+from .laundry import bool_option_exists, bool_option_value, option_value, option_write
 
 # ---------------------------------------------------------------------------
 # Canonical AC resource hrefs. The climate entity (climate.py) binds the
@@ -35,6 +36,7 @@ HREF_WIND_STRENGTH = '/wind/strength/vs/0'        # fan_mode
 HREF_WIND_DIRECTION = '/wind/direction/vs/0'      # swing_mode
 HREF_CONVENIENT = '/mode/convenient/vs/0'         # preset_mode
 HREF_TEMPS_VS = '/temperatures/vs/0'              # vendor temp fallback (items[] array)
+HREF_LIGHT = '/light/vs/0'                        # display light (absent on TP2X)
 
 CLIMATE_CONSUMED_HREFS = [
     HREF_POWER, HREF_POWER_VS, HREF_TEMP_CURRENT, HREF_TEMP_DESIRED,
@@ -53,29 +55,54 @@ def _num(v):
 # --- /mode/vs/0 options blob ('Light_On', 'Volume_100'/'Volume_Mute', ...) ---
 # Some settings (display light, beep volume) have no dedicated resource on
 # models like TP2X_RAC_20K; they live only in /mode/vs/0's `options` array and
-# are written back one token at a time (the device merges by prefix — see
-# common.merge_options_field). These read/write that array.
-def _opt(rep, key):
-    for o in (rep.get('x.com.samsung.da.options') or ()):
-        if isinstance(o, str) and o.startswith(key + '_'):
-            return o[len(key) + 1:]
-    return None
-
-
-def _has_opt(rep, key):
-    return _opt(rep, key) is not None
-
-
-def _vol_read(rep):
-    v = _opt(rep, 'Volume')
+# are written back one token at a time (the device merges by prefix -- see
+# common.merge_options_field), exactly as air_purifier.MODE does for its own
+# Light token. Reuses laundry's option helpers rather than re-deriving them.
+def _volume_percent(rep):
+    """Beep volume as 0-100, with the 'Mute' token folded in as 0."""
+    v = option_value(rep.get('x.com.samsung.da.options'), 'Volume')
     if v is None:
         return None
     return 0 if v == 'Mute' else _num(v)
 
 
-def _vol_token(p):
-    p = int(round(float(p)))
-    return 'Volume_Mute' if p <= 0 else f'Volume_{p}'
+def _volume_write(payload, rep, href=None):
+    pct = int(round(float(payload)))
+    return ['mode', 'vs', '0'], {
+        'x.com.samsung.da.options': option_write(
+            'Volume', 'Mute' if pct <= 0 else pct),
+    }
+
+
+def _light_write(payload, rep, href=None):
+    return ['mode', 'vs', '0'], {
+        'x.com.samsung.da.options': option_write(
+            'Light', 'On' if payload else 'Off'),
+    }
+
+
+def _humidity_percent(rep):
+    """Relative humidity, or None where neither field carries a real reading.
+
+    /humidity/vs/0 exposes two fields and which one is live varies by board.
+    A TP2X_RAC_20K measured in the field reports both x.com.samsung.da.humidity
+    and .fivepercentHumidity as the same percentage ('51'), which is what
+    establishes they are one quantity; every dump this family has been
+    verified against instead pins .humidity to a dead '0'/'0.000000' sentinel
+    and carries the reading only in .fivepercentHumidity (43, 83, 53). So:
+    prefer the primary field, fall back to the five-percent one, and gate the
+    sensor off when neither is plausible -- 0 % RH is the sentinel, never a
+    real room. That last part is why this href had sat in _AC_IGNORED.
+    """
+    for field in ('x.com.samsung.da.humidity',
+                  'x.com.samsung.da.fivepercentHumidity'):
+        v = rep.get(field)
+        if isinstance(v, (list, tuple)):
+            continue
+        n = _num(v)
+        if n is not None and 0 < n <= 100:
+            return n
+    return None
 
 
 def _filter_usage_percent(rep):
@@ -142,34 +169,41 @@ CLIMATE = Capability(
         ClimateDesc(key='climate', translation_key='airconditioner',
                     rep_fn=_first_mode, write_fn=_climate_write),
         # Display light + beep volume: on models like TP2X_RAC_20K these are
-        # options on /mode/vs/0 (no /light/vs/0 or /audioVolume/vs/0 resource),
-        # so bind them here and gate on the option being present.
+        # options on /mode/vs/0 -- there is no /light/vs/0 (4.04 there) and no
+        # dedicated volume resource at all -- so bind them here and gate on the
+        # token actually being reported. display_light additionally stands down
+        # where DISPLAY_LIGHT's own /light/vs/0 exists, so a model carrying both
+        # gets one switch from the dedicated resource rather than two under the
+        # same key.
         SwitchDesc(key='display_light', icon='mdi:led-on',
                    entity_category='config',
-                   rep_fn=lambda rep: _opt(rep, 'Light') == 'On',
-                   exists_fn=lambda rep, res: _has_opt(rep, 'Light'),
-                   write_fn=lambda p, rep, href=None: (
-                       ['mode', 'vs', '0'],
-                       {'x.com.samsung.da.options': [
-                           'Light_On' if p else 'Light_Off']})),
+                   rep_fn=bool_option_value('Light'),
+                   exists_fn=lambda rep, resources: (
+                       HREF_LIGHT not in resources
+                       and bool_option_exists('Light')(rep, resources)),
+                   write_fn=_light_write),
         NumberDesc(key='sound_volume', icon='mdi:volume-high',
                    entity_category='config',
                    native_min=0, native_max=100, step=1,
-                   rep_fn=_vol_read,
-                   exists_fn=lambda rep, res: _has_opt(rep, 'Volume'),
-                   write_fn=lambda p, rep, href=None: (
-                       ['mode', 'vs', '0'],
-                       {'x.com.samsung.da.options': [_vol_token(p)]})),
+                   rep_fn=_volume_percent,
+                   exists_fn=lambda rep, resources: (
+                       option_value(rep.get('x.com.samsung.da.options'),
+                                    'Volume') is not None),
+                   write_fn=_volume_write),
     ),
 )
 
+# 'warm' rather than the default 'cold': a cold href is only refreshed by the
+# ~30s /device/0 summary sweep, and this resource comes back as a stub there on
+# TP2X -- so a cold humidity sensor would sit at unknown indefinitely.
 HUMIDITY = Capability(
     href='/humidity/vs/0',
     poll_tier='warm',
     entities=(
-        SensorDesc(key='humidity', field='x.com.samsung.da.humidity',
-                   device_class='humidity', unit='%', state_class='measurement',
-                   value_fn=_num),
+        SensorDesc(key='humidity', device_class='humidity', unit='%',
+                   state_class='measurement', rep_fn=_humidity_percent,
+                   exists_fn=lambda rep, resources: (
+                       not rep or _humidity_percent(rep) is not None)),
     ),
 )
 
@@ -218,7 +252,7 @@ AIR_FILTER = Capability(
 )
 
 DISPLAY_LIGHT = Capability(
-    href='/light/vs/0',
+    href=HREF_LIGHT,
     poll_tier='cold',
     entities=(
         SwitchDesc(key='display_light', field='mode',
@@ -289,9 +323,12 @@ CURRENT_LIMIT = Capability(
 _AC_IGNORED = [
     # All-zero and ambiguously encoded on this model (2-value arrays); the
     # 'don't guess' rule -- leave unmodeled rather than invent entities.
+    # /humidity/vs/0 used to sit here for the same reason; it is now modeled by
+    # HUMIDITY above, which self-gates back off on exactly that encoding, so it
+    # must NOT be listed here as well (two undiscriminated caps on one href is
+    # a _build error). /humidity/0 stays -- 4.04 on TP2X, empty elsewhere.
     '/sensors/vs/0',
     '/humidity/0',
-    '/humidity/vs/0',
     # Presence-personalization plumbing (empty item list here).
     '/personality/presence/vs/0',
     # --- TP1X/TP2X-class housekeeping / opaque blobs. These carry no

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -523,6 +523,9 @@
       "hood_filter_capacity": {
         "name": "Filter capacity"
       },
+      "humidity": {
+        "name": "Humidity"
+      },
       "hood_filter_usage": {
         "name": "Filter usage"
       },

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -523,6 +523,9 @@
       "hood_filter_capacity": {
         "name": "Filtercapaciteit"
       },
+      "humidity": {
+        "name": "Luchtvochtigheid"
+      },
       "hood_filter_usage": {
         "name": "Filterverbruik"
       },

--- a/tests/fixtures/golden/airconditioner.json
+++ b/tests/fixtures/golden/airconditioner.json
@@ -7,8 +7,10 @@
     "auto_clean",
     "climate",
     "diagnosis_status",
+    "display_light",
     "energy_kwh",
     "energy_saved_kwh",
-    "power_watts"
+    "power_watts",
+    "sound_volume"
   ]
 }

--- a/tests/fixtures/golden/airconditioner_caww_tp2.json
+++ b/tests/fixtures/golden/airconditioner_caww_tp2.json
@@ -6,10 +6,13 @@
     "auto_clean",
     "climate",
     "diagnosis_status",
+    "display_light",
     "energy_kwh",
     "energy_saved_kwh",
     "firmware_update",
+    "humidity",
     "mute_once",
-    "power_watts"
+    "power_watts",
+    "sound_volume"
   ]
 }

--- a/tests/fixtures/golden/airconditioner_tp1x_da_ac_rac_01011.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_da_ac_rac_01011.json
@@ -10,6 +10,7 @@
     "energy_kwh",
     "energy_saved_kwh",
     "firmware_update",
+    "humidity",
     "mute_once",
     "selfcheck_error",
     "selfcheck_result",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac.json
@@ -15,6 +15,7 @@
     "mute_once",
     "selfcheck_error",
     "selfcheck_result",
-    "selfcheck_status"
+    "selfcheck_status",
+    "sound_volume"
   ]
 }

--- a/tests/fixtures/golden/airconditioner_tp2x_rac_20k.json
+++ b/tests/fixtures/golden/airconditioner_tp2x_rac_20k.json
@@ -5,9 +5,12 @@
     "alarm_code",
     "auto_clean",
     "climate",
+    "display_light",
     "energy_kwh",
     "firmware_update",
+    "humidity",
     "mute_once",
-    "power_watts"
+    "power_watts",
+    "sound_volume"
   ]
 }

--- a/tests/test_airconditioner_capabilities.py
+++ b/tests/test_airconditioner_capabilities.py
@@ -251,6 +251,18 @@ def test_display_light_write_target():
     assert write('Off', {}) == (['light', 'vs', '0'], {'mode': 'Off'})
 
 
+def test_options_display_light_write_target():
+    """Regression: the options-based display light (TP2X-class, no
+    /light/vs/0) must map the 'On'/'Off' payload by value. 'Off' is a
+    truthy non-empty string, so the old truthiness check sent Light_On
+    for both toggle directions -- displays lit back up on every
+    night-time turn_off."""
+    assert airconditioner._light_write('On', {}) == (
+        ['mode', 'vs', '0'], {'x.com.samsung.da.options': ['Light_On']})
+    assert airconditioner._light_write('Off', {}) == (
+        ['mode', 'vs', '0'], {'x.com.samsung.da.options': ['Light_Off']})
+
+
 def test_current_limit_is_read_only():
     """Meaning/write contract for the current-limit levels isn't confirmed
     from the dump alone -- exposed as read-only diagnostic sensors rather

--- a/tests/test_airconditioner_capabilities.py
+++ b/tests/test_airconditioner_capabilities.py
@@ -251,16 +251,27 @@ def test_display_light_write_target():
     assert write('Off', {}) == (['light', 'vs', '0'], {'mode': 'Off'})
 
 
-def test_options_display_light_write_target():
-    """Regression: the options-based display light (TP2X-class, no
-    /light/vs/0) must map the 'On'/'Off' payload by value. 'Off' is a
-    truthy non-empty string, so the old truthiness check sent Light_On
-    for both toggle directions -- displays lit back up on every
-    night-time turn_off."""
+def test_options_display_light_write_is_inverted():
+    """Regression: the RAC Light token is inverted (Light_Off = display
+    lit), and the payload arrives as the *string* 'On'/'Off' -- the old
+    truthiness check (`'On' if payload else 'Off'`) sent Light_On for
+    both toggle directions, so displays lit back up on every night-time
+    turn_off. Turning the switch on must send Light_Off and vice versa."""
     assert airconditioner._light_write('On', {}) == (
-        ['mode', 'vs', '0'], {'x.com.samsung.da.options': ['Light_On']})
-    assert airconditioner._light_write('Off', {}) == (
         ['mode', 'vs', '0'], {'x.com.samsung.da.options': ['Light_Off']})
+    assert airconditioner._light_write('Off', {}) == (
+        ['mode', 'vs', '0'], {'x.com.samsung.da.options': ['Light_On']})
+
+
+def test_options_display_light_state_is_inverted():
+    """Same inversion on the read side: Light_Off in options[] means the
+    display is physically lit, so the switch reports on; absent token
+    reports unknown, not off."""
+    assert airconditioner._light_value(
+        {'x.com.samsung.da.options': ['Light_Off', 'Volume_100']}) is True
+    assert airconditioner._light_value(
+        {'x.com.samsung.da.options': ['Light_On', 'Volume_100']}) is False
+    assert airconditioner._light_value({'x.com.samsung.da.options': []}) is None
 
 
 def test_current_limit_is_read_only():


### PR DESCRIPTION
## Bug

On models whose display light lives in `/mode/vs/0`'s options array (no `/light/vs/0`), the display-light switch was doubly wrong:

1. **Truthiness bug**: `switch.py` passes the payload as the string `'On'`/`'Off'`, and `'Off'` is truthy — so `_light_write`'s `'On' if payload else 'Off'` sent `Light_On` for both toggle directions. Introduced in c7e9aec.
2. **Inverted token**: on RAC units the Light token is inverted — `Light_Off` = display lit, `Light_On` = dark (the long-standing SmartThings quirk). Neither the read nor the write accounted for it.

Net effect: every `switch.turn_off` lit the display, and the confirming poll snapped the HA toggle back to on, so the switch looked stuck-on.

## Fix

- `_light_write` maps the payload by value **and** flips the token (`'On'` → `Light_Off`, `'Off'` → `Light_On`).
- New `_light_value` rep_fn flips the read side and reports unknown (not off) when the token is absent.
- `air_purifier`'s Light token is not inverted and is deliberately left alone (comment added).

## Tests

- `test_options_display_light_write_is_inverted` pins both write directions.
- `test_options_display_light_state_is_inverted` pins the read side incl. absent-token → `None`.

Verified live on three Samsung RAC units: both toggle directions now stick and track the physical panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)