### PR TITLE
fix(fan): fall back to settableMin/MaxFanSpeed when supportedFanSpeed is omitted (#201)

### DIFF
--- a/custom_components/localthings/fan.py
+++ b/custom_components/localthings/fan.py
@@ -42,6 +42,7 @@ POWER_VS_HREF = '/power/vs/0'
 _FAN_SPEED_FIELD = 'x.com.samsung.da.hood.fanSpeed'
 _SUPPORTED_FAN_SPEED_FIELD = 'x.com.samsung.da.hood.supportedFanSpeed'
 _MIN_FAN_SPEED_FIELD = 'x.com.samsung.da.hood.settableMinFanSpeed'
+_MAX_FAN_SPEED_FIELD = 'x.com.samsung.da.hood.settableMaxFanSpeed'
 _OFF_SPEED_CODE = '0'
 
 _MODES_FIELD = 'x.com.samsung.da.modes'
@@ -125,7 +126,7 @@ class LocalThingsRangeHoodFan(LocalThingsEntity, FanEntity):
         if supported:
             return [str(value) for value in supported]
         min_s = rep.get(_MIN_FAN_SPEED_FIELD)
-        max_s = rep.get('x.com.samsung.da.hood.settableMaxFanSpeed')
+        max_s = rep.get(_MAX_FAN_SPEED_FIELD)
         if min_s is not None and max_s is not None:
             try:
                 mn, mx = int(min_s), int(max_s)

--- a/custom_components/localthings/fan.py
+++ b/custom_components/localthings/fan.py
@@ -89,11 +89,13 @@ class LocalThingsRangeHoodFan(LocalThingsEntity, FanEntity):
     """
 
     _enable_turn_on_off_backwards_compatibility = False
-    _attr_supported_features = (
-        FanEntityFeature.SET_SPEED
-        | FanEntityFeature.TURN_ON
-        | FanEntityFeature.TURN_OFF
-    )
+
+    @property
+    def supported_features(self) -> FanEntityFeature:
+        features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        if self.speed_count > 0:
+            features |= FanEntityFeature.SET_SPEED
+        return features
 
     def __init__(self, coordinator: LocalThingsCoordinator, bound) -> None:
         super().__init__(coordinator, bound)
@@ -119,7 +121,18 @@ class LocalThingsRangeHoodFan(LocalThingsEntity, FanEntity):
 
     def _all_speed_codes(self) -> list[str]:
         rep = self._rep(self._bound.href)
-        return [str(value) for value in rep.get(_SUPPORTED_FAN_SPEED_FIELD, ())]
+        supported = rep.get(_SUPPORTED_FAN_SPEED_FIELD)
+        if supported:
+            return [str(value) for value in supported]
+        min_s = rep.get(_MIN_FAN_SPEED_FIELD)
+        max_s = rep.get('x.com.samsung.da.hood.settableMaxFanSpeed')
+        if min_s is not None and max_s is not None:
+            try:
+                mn, mx = int(min_s), int(max_s)
+                return [str(i) for i in range(mn, mx + 1)]
+            except (ValueError, TypeError):
+                pass
+        return []
 
     def _active_speed_codes(self) -> list[str]:
         codes = self._all_speed_codes()

--- a/tests/test_range_hood_fan.py
+++ b/tests/test_range_hood_fan.py
@@ -224,3 +224,19 @@ async def test_microwave_vent_fan_set_percentage_zero_turns_off():
     await entity.async_set_percentage(0)
 
     assert coordinator.commands[-1][1] == ('speed', '0')
+
+
+def test_microwave_vent_fan_missing_supported_fan_speed_falls_back_to_settable_min_max():
+    """Hardware omitting supportedFanSpeed (e.g. ME8000T / issue #172) falls back
+    to building speed codes from settableMinFanSpeed ('0') and settableMaxFanSpeed ('3')."""
+    resources = _load_device('microwave_me7500d')
+    resources['/hood/fanspeed/vs/0'].pop('x.com.samsung.da.hood.supportedFanSpeed', None)
+    resources['/hood/fanspeed/vs/0']['x.com.samsung.da.hood.settableMinFanSpeed'] = '0'
+    resources['/hood/fanspeed/vs/0']['x.com.samsung.da.hood.settableMaxFanSpeed'] = '3'
+
+    entity = _microwave_entity(resources)
+    assert entity._all_speed_codes() == ['0', '1', '2', '3']
+    assert entity._active_speed_codes() == ['1', '2', '3']
+    assert entity.speed_count == 3
+    assert entity.supported_features & 1  # FanEntityFeature.SET_SPEED is present
+


### PR DESCRIPTION
Fixes https://github.com/mbillow/localthings/issues/201

## Summary
Fixes a `ZeroDivisionError: division by zero` in Home Assistant when initializing fan entities for Samsung Microwave and range hood units (such as `ME8000T-/AA0` / `TP2X_DA-KS-MICROWAVE-0101X`):

```text
2026-07-29 15:37:30.747 ERROR (MainThread) [homeassistant.components.fan] Error adding entity fan.kitchen_samsung_microwave_... for domain fan with platform localthings
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/fan/__init__.py", line 408, in state_attributes
    data[FanEntityStateAttribute.PERCENTAGE_STEP] = self.percentage_step
  File "/usr/src/homeassistant/homeassistant/components/fan/__init__.py", line 363, in percentage_step
    return 100 / self.speed_count
ZeroDivisionError: division by zero
```

**Changes:**
- Updated `LocalThingsRangeHoodFan._all_speed_codes()` to fall back to generating speed codes from `settableMinFanSpeed` (e.g. `'0'`) and `settableMaxFanSpeed` (e.g. `'3'`) when `supportedFanSpeed` is absent from `/hood/fanspeed/vs/0`.
- Made `supported_features` on `LocalThingsRangeHoodFan` a dynamic property that includes `FanEntityFeature.SET_SPEED` only when `speed_count > 0`, protecting against division by zero in Home Assistant if `speed_count` ever equals 0.
- Added unit test `test_microwave_vent_fan_missing_supported_fan_speed_falls_back_to_settable_min_max` in `tests/test_range_hood_fan.py`.

## Test plan
- [x] `PYTHONPATH=. ./.venv/bin/pytest --cov=custom_components/localthings tests/` — 968 passed (100% pass rate, 87% overall coverage).
- [x] Added unit test `test_microwave_vent_fan_missing_supported_fan_speed_falls_back_to_settable_min_max` verifying `speed_count` equals 3 (speeds 1, 2, 3) and `SET_SPEED` is enabled when `supportedFanSpeed` is absent.