### PR TITLE
Parallel DTLS probe + cached leaf (config-flow add ~14s -> ~1.4s)

### DIFF
--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Local Things integration."""
 from __future__ import annotations
 
+import asyncio
 import datetime
 import json
 import logging
@@ -9,12 +10,17 @@ import selectors
 import socket
 import ssl
 import time
-from typing import Any
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import TYPE_CHECKING, Any, Callable
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import (
     ObjectSelector,
     SelectSelector,
@@ -33,6 +39,7 @@ from .const import (
     CONF_BYPASS_REMOTE_CONTROL,
     PROBE_PORT_RANGE, PREFERRED_PROBE_PORTS, LIVENESS_PROBE_TIMEOUT_S,
     PROBE_GET_TIMEOUT_S,
+    RACE_OVERALL_S,
 )
 
 _TEXT = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT))
@@ -49,6 +56,36 @@ class CannotConnect(Exception):
 
 class InvalidCA(Exception):
     pass
+
+
+class _CertRejected(Exception):
+    """Raised by a probe worker when the device rejects the client cert
+    (DTLS alert: handshake_failure / bad_certificate / unknown_ca / ...).
+    Distinguished from a port TimeoutError so the probe can decide whether a
+    full-cert-rejection warrants a UUID-rotation re-mint fallback."""
+
+
+# DTLS alert phrases that signal the device rejected the client cert. The
+# first four are the spec/design's cert-reject alerts. The extra two widen
+# the net: `access denied` (alert 49) is the device's ACL rejecting the peer
+# UUID — a genuine cert-rejection signal in OCF; `decrypt error` (alert 51)
+# is broader but included so an all-ports crypto failure still triggers the
+# re-mint attempt. The fallback is bounded: it only fires when ALL
+# candidates match, so a spurious match on one port is harmless.
+_CERT_ALERT_MARKERS = (
+    'handshake failure', 'bad certificate', 'unknown ca',
+    'certificate unknown', 'access denied', 'decrypt error',
+)
+
+
+def _is_cert_alert(exc: Exception) -> bool:
+    """True iff a DtlsCoapSession.connect() failure looks like a DTLS cert-reject
+    alert. DtlsCoapSession wraps SSL.Error as ConnectionError("DTLS handshake
+    error: <SSL.Error str>"); we match on the alert phrase in that string.
+    Conservative: anything unrecognized is treated as a generic handshake error
+    (NOT a cert reject), so the UUID-rotation fallback never fires on a guess."""
+    msg = str(exc).lower()
+    return any(m in msg for m in _CERT_ALERT_MARKERS)
 
 
 def _fetch_samsung_uuid() -> str:
@@ -219,31 +256,127 @@ def _is_placeholder_serial(serial: str) -> bool:
     return serial.strip().lower().startswith('nothing')
 
 
-def _probe_and_validate(host: str, ca_cert_pem: str, ca_key_pem: str) -> dict:
-    """Fetch UUID, mint leaf cert, probe each port. Returns config entry data dict."""
+def _race_handshake(
+    host: str, candidates: list[int], worker: Callable[[int], dict],
+) -> tuple[dict | None, bool, Exception | None]:
+    """Race `worker(port)` across `candidates` in parallel threads.
+
+    `worker(port)` must return an info dict on success or raise:
+      * _CertRejected  — device rejected the client cert
+      * TimeoutError    — port didn't answer the DTLS handshake
+      * Exception       — any other failure (SSL error, GET code != 2.05, ...)
+
+    Returns (info, False, None) as soon as the first worker returns a valid
+    info dict. Losing workers are NOT waited for: shutdown(wait=False) leaves
+    them running as daemon threads (ThreadPoolExecutor workers are daemons
+    on Python 3.9+), and each worker's `finally: sess.close()` cleans its
+    socket when it eventually times out / errors.
+    Returns (None, cert_rejected, last_exc) if no worker succeeds, where
+    cert_rejected is True iff every candidate raised _CertRejected — the
+    signal the caller uses to decide whether to re-mint the leaf cert once —
+    and last_exc is the most recent exception seen (timeout, cert-reject, or
+    generic) so the caller's CannotConnect message can carry a per-port hint
+    about why the race failed (e.g. the DTLS timeout when all ports went
+    silent).
+    """
+    cert_error_count = 0
+    last_exc: Exception | None = None
+    ex = ThreadPoolExecutor(max_workers=max(1, len(candidates)))
+    try:
+        futs = [ex.submit(worker, p) for p in candidates]
+        try:
+            for fut in as_completed(futs, timeout=RACE_OVERALL_S):
+                try:
+                    info = fut.result()
+                except _CertRejected as e:
+                    cert_error_count += 1
+                    last_exc = e
+                    _LOGGER.debug("race: port rejected cert: %s", e)
+                except Exception as e:  # noqa: BLE001 — classify by type below
+                    last_exc = e
+                    _LOGGER.debug("race: port failed: %s", e)
+                else:
+                    return info, False, None
+        except FuturesTimeoutError as e:
+            last_exc = e
+            _LOGGER.debug("race: no winner within %.1fs", RACE_OVERALL_S)
+    finally:
+        ex.shutdown(wait=False)
+    cert_rejected = cert_error_count == len(candidates) and cert_error_count > 0
+    return None, cert_rejected, last_exc
+
+
+def _persist_refreshed_leaf(
+    hass: HomeAssistant, entry: config_entries.ConfigEntry, fullchain_pem: str, key_pem: str,
+) -> None:
+    """Update an existing config entry's leaf cert/key after a UUID-rotation
+    re-mint, so subsequent device adds reuse the fresh leaf.
+
+    Called from the executor thread (_probe_and_validate runs there), so we
+    schedule the async update on the HA loop and block briefly for it to
+    complete. Best-effort: a failure to persist must not abort the in-progress
+    add (the info dict already carries the fresh leaf for THIS entry).
+    """
+    async def _update():
+        await hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data,
+                  CONF_LEAF_CERT_PEM: fullchain_pem,
+                  CONF_LEAF_KEY_PEM: key_pem},
+        )
+    try:
+        fut = asyncio.run_coroutine_threadsafe(_update(), hass.loop)
+        fut.result(timeout=5.0)
+    except Exception as e:  # noqa: BLE001 — best-effort
+        _LOGGER.warning("Failed to persist refreshed leaf cert: %s", e)
+
+
+def _probe_and_validate(
+    host: str,
+    ca_cert_pem: str,
+    ca_key_pem: str,
+    cached_leaf: tuple[str, str] | None = None,
+    hass: Any = None,
+    entry: Any = None,
+) -> dict:
+    """Fetch UUID (or reuse cached_leaf), mint leaf cert if needed, race ports.
+
+    Returns config entry data dict. ``cached_leaf`` is an optional
+    ``(fullchain_pem, key_pem)`` tuple reused from a prior config entry — when
+    provided, the Samsung-cloud UUID fetch and leaf mint are skipped and the
+    cached leaf is raced directly. On all-cert-rejected with a cached leaf
+    present, a one-shot fresh-mint fallback fires: re-fetch UUID, re-mint,
+    race again. When that fallback succeeds and ``hass``+``entry`` are
+    provided, the refreshed leaf is persisted to the existing entry via
+    ``_persist_refreshed_leaf`` so subsequent device adds reuse it.
+    """
     import cbor2
     from smartthings_local.protocol.dtls_session import DtlsCoapSession
     from .registry.batch import parse_device0_batch
     from .registry.by_type import resolve as resolve_registry
 
-    _LOGGER.debug("Fetching Samsung cloud UUID from %s", _SAMSUNG_CLOUD_HOST)
-    try:
-        uuid = _fetch_samsung_uuid()
-    except Exception as exc:
-        _LOGGER.debug("UUID fetch failed: %s", exc, exc_info=True)
-        raise CannotConnect(f"Failed to fetch Samsung UUID: {exc}") from exc
-    _LOGGER.debug("Got UUID: %s", uuid)
+    if cached_leaf is not None:
+        fullchain_pem, leaf_key_pem = cached_leaf
+        _LOGGER.debug("Reusing cached leaf cert (UUID fetch + mint skipped)")
+    else:
+        _LOGGER.debug("Fetching Samsung cloud UUID from %s", _SAMSUNG_CLOUD_HOST)
+        try:
+            uuid = _fetch_samsung_uuid()
+        except Exception as exc:
+            _LOGGER.debug("UUID fetch failed: %s", exc, exc_info=True)
+            raise CannotConnect(f"Failed to fetch Samsung UUID: {exc}") from exc
+        _LOGGER.debug("Got UUID: %s", uuid)
 
-    _LOGGER.debug("Minting leaf cert for UUID %s", uuid)
-    try:
-        fullchain_pem, leaf_key_pem = _mint_leaf_cert(ca_cert_pem, ca_key_pem, uuid)
-    except InvalidCA:
-        _LOGGER.debug("CA credentials invalid", exc_info=True)
-        raise
-    except Exception as exc:
-        _LOGGER.debug("Leaf cert minting failed: %s", exc, exc_info=True)
-        raise CannotConnect(f"Failed to mint leaf cert: {exc}") from exc
-    _LOGGER.debug("Leaf cert minted successfully")
+        _LOGGER.debug("Minting leaf cert for UUID %s", uuid)
+        try:
+            fullchain_pem, leaf_key_pem = _mint_leaf_cert(ca_cert_pem, ca_key_pem, uuid)
+        except InvalidCA:
+            _LOGGER.debug("CA credentials invalid", exc_info=True)
+            raise
+        except Exception as exc:
+            _LOGGER.debug("Leaf cert minting failed: %s", exc, exc_info=True)
+            raise CannotConnect(f"Failed to mint leaf cert: {exc}") from exc
+        _LOGGER.debug("Leaf cert minted successfully")
 
     candidates = _find_live_ports(
         host, PROBE_PORT_RANGE, LIVENESS_PROBE_TIMEOUT_S
@@ -257,51 +390,81 @@ def _probe_and_validate(host: str, ca_cert_pem: str, ca_key_pem: str) -> dict:
     # generic "no live port found" message.
     _LOGGER.debug("Live DTLS port candidates on %s: %s", host, candidates)
 
-    last_exc = None
-    for port in candidates:
-        sess = None
-        try:
-            sess = DtlsCoapSession(
-                host, port,
-                cert_pem=fullchain_pem,
-                key_pem=leaf_key_pem,
-            )
-            sess.connect()
-            sess.start_reader()
-            code, payload = sess.get(['device', '0'], timeout=PROBE_GET_TIMEOUT_S)
-            if code != 0x45 or not payload:
-                raise CannotConnect(f"port {port}: unexpected code {code:#04x}")
-            body = cbor2.loads(payload)
-            resources = (
-                parse_device0_batch(body) if isinstance(body, list) else {}
-            )
-            serial = (
-                resources
-                .get('/information/vs/0', {})
-                .get('x.com.samsung.da.serialNum', '')
-            )
-            if not serial or _is_placeholder_serial(serial):
-                serial = f"{host}:{port}"
-            recognized_registry = resolve_registry(resources)
-            return {
-                "port": port,
-                "serial": serial,
-                "leaf_cert_pem": fullchain_pem,
-                "leaf_key_pem": leaf_key_pem,
-                "device_type_recognized": recognized_registry is not None,
-            }
-        except CannotConnect:
-            raise
-        except Exception as exc:
-            last_exc = exc
-            _LOGGER.debug("port %d failed: %s", port, exc)
-        finally:
-            if sess is not None:
+    def _make_worker(
+        cert_pem: str, key_pem: str, session_factory: Callable[..., Any] = DtlsCoapSession,
+    ) -> Callable[[int], dict]:
+        """Nested per-port worker closure. Captures `host` and the
+        function-level imports (cbor2, parse_device0_batch, resolve_registry).
+        session_factory defaults to DtlsCoapSession (function-level import,
+        re-resolved each _probe_and_validate call so monkeypatches take)."""
+        def worker(port):
+            sess = session_factory(host, port, cert_pem=cert_pem, key_pem=key_pem)
+            try:
+                try:
+                    sess.connect()
+                except TimeoutError:
+                    raise
+                except Exception as e:
+                    if _is_cert_alert(e):
+                        raise _CertRejected(str(e)) from e
+                    raise
+                sess.start_reader()
+                code, payload = sess.get(['device', '0'], timeout=PROBE_GET_TIMEOUT_S)
+                if code != 0x45 or not payload:
+                    raise CannotConnect(f"port {port}: unexpected code {code:#04x}")
+                body = cbor2.loads(payload)
+                resources = (
+                    parse_device0_batch(body) if isinstance(body, list) else {}
+                )
+                serial = (
+                    resources.get('/information/vs/0', {})
+                    .get('x.com.samsung.da.serialNum', '')
+                )
+                if not serial or _is_placeholder_serial(serial):
+                    serial = f"{host}:{port}"
+                recognized_registry = resolve_registry(resources)
+                return {
+                    "port": port,
+                    "serial": serial,
+                    "leaf_cert_pem": cert_pem,
+                    "leaf_key_pem": key_pem,
+                    "device_type_recognized": recognized_registry is not None,
+                }
+            finally:
                 try:
                     sess.close()
                 except Exception:
                     pass
-    raise CannotConnect(f"no port responded on {host}: {last_exc}")
+        return worker
+
+    worker = _make_worker(fullchain_pem, leaf_key_pem)
+    info, cert_rejected, last_exc = _race_handshake(host, candidates, worker)
+
+    if info is None and cert_rejected and cached_leaf is not None:
+        # All candidates rejected the cached leaf cert → UUID likely rotated.
+        # Re-fetch UUID + re-mint once, then race again with the fresh leaf.
+        _LOGGER.info("Cached leaf rejected by all ports; re-minting (UUID rotation?)")
+        try:
+            uuid = _fetch_samsung_uuid()
+            fullchain_pem, leaf_key_pem = _mint_leaf_cert(ca_cert_pem, ca_key_pem, uuid)
+        except InvalidCA:
+            raise
+        except Exception as exc:
+            raise CannotConnect(f"re-mint after cert rejection failed: {exc}") from exc
+        info, _, last_exc = _race_handshake(
+            host, candidates, _make_worker(fullchain_pem, leaf_key_pem),
+        )
+        if info is not None and hass is not None and entry is not None:
+            _persist_refreshed_leaf(hass, entry, fullchain_pem, leaf_key_pem)
+
+    if info is None:
+        base = f"no port responded on {host}"
+        if last_exc is not None:
+            base = f"{base}: {last_exc}"
+        raise CannotConnect(
+            base + (" (cert rejected)" if cert_rejected else "")
+        )
+    return info
 
 
 class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -350,12 +513,24 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._ca_cert_pem = user_input[CONF_CA_CERT_PEM].strip()
                 self._ca_key_pem  = user_input[CONF_CA_KEY_PEM].strip()
 
+            cached_leaf = None
+            entry_ref = None
+            if has_creds:
+                cached_leaf = (
+                    existing[0].data[CONF_LEAF_CERT_PEM],
+                    existing[0].data[CONF_LEAF_KEY_PEM],
+                )
+                entry_ref = existing[0]
+
             try:
                 info = await self.hass.async_add_executor_job(
                     _probe_and_validate,
                     self._host,
                     self._ca_cert_pem,
                     self._ca_key_pem,
+                    cached_leaf,
+                    self.hass,
+                    entry_ref,
                 )
             except InvalidCA:
                 errors["base"] = "invalid_ca"

--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -349,6 +349,19 @@ def _probe_and_validate(
     race again. When that fallback succeeds and ``hass``+``entry`` are
     provided, the refreshed leaf is persisted to the existing entry via
     ``_persist_refreshed_leaf`` so subsequent device adds reuse it.
+
+    Note: the winning worker's DTLS session is closed here on an ephemeral
+    source port. The coordinator's first connect (coordinator._connect_session)
+    binds a fixed local port — a different 5-tuple — so it cannot evict this
+    probe's just-closed session at handshake time per RFC 6347 §4.2.8, and the
+    appliance rejects the coordinator's first handshake until the orphan ages
+    out (~8s observed on ARTIK051/TP2X). One-time per device add, auto-recovers
+    on the coordinator's retry; not a bug, just the last visible latency chunk
+    now that the probe itself races instead of sequencing through false-positive
+    timeouts. Fixing it would mean handing the probe's session to the
+    coordinator, but that session is on an ephemeral port and the coordinator's
+    fixed-port eviction relies on a stable 5-tuple across reconnects — so the
+    hand-off defers the same ~8s to the first reconnect rather than removing it.
     """
     import cbor2
     from smartthings_local.protocol.dtls_session import DtlsCoapSession

--- a/custom_components/localthings/const.py
+++ b/custom_components/localthings/const.py
@@ -42,6 +42,14 @@ LIVENESS_PROBE_TIMEOUT_S = 1.5
 # without stalling setup; it matches the per-resource read timeout elsewhere.
 PROBE_GET_TIMEOUT_S = 10.0
 
+# Ceiling for the whole parallel DTLS handshake race in the config-flow probe.
+# A winning worker must complete connect() + GET /device/0 within this window;
+# the real port typically finishes in ~1.4 s (handshake) + GET. Set to
+# HANDSHAKE_TIMEOUT_S (12 s, library default) + PROBE_GET_TIMEOUT_S (10 s) +
+# slack so a slow-but-real device can still win, while a fully dead host
+# fails fast relative to the old N x 12 s sequential loop.
+RACE_OVERALL_S = 25.0
+
 # Base for the local (client-side) DTLS source port, distinct from the
 # destination probe ports above. See coordinator._local_source_port for why a
 # fixed per-device source port matters and how the per-device offset is

--- a/tests/localthings/test_config_flow.py
+++ b/tests/localthings/test_config_flow.py
@@ -10,7 +10,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.localthings.const import (
     CONF_BYPASS_REMOTE_CONTROL, CONF_CA_CERT_PEM, CONF_CA_KEY_PEM,
-    CONF_HOST, CONF_PORT, DOMAIN,
+    CONF_HOST, CONF_LEAF_CERT_PEM, CONF_LEAF_KEY_PEM, CONF_PORT, DOMAIN,
 )
 
 from .conftest import (
@@ -539,3 +539,355 @@ def test_is_placeholder_serial_accepts_real_serials():
     from custom_components.localthings.config_flow import _is_placeholder_serial
     assert _is_placeholder_serial('0A1B2C3D4E5F') is False
     assert _is_placeholder_serial('') is False
+
+
+import time
+
+
+def test_race_returns_first_winner():
+    """First worker to return a valid info dict wins; wall-clock << sequential."""
+    from custom_components.localthings.config_flow import _race_handshake, _CertRejected
+
+    def worker(port):
+        if port == 49155:
+            return {"port": port, "serial": "WINNER", "ok": True}
+        # False-positive port: simulate the library's connect() TimeoutError.
+        raise TimeoutError(f"DTLS handshake timeout to 10.0.0.1:{port}")
+
+    t0 = time.monotonic()
+    info, cert_rejected, _ = _race_handshake("10.0.0.1", [49154, 49155, 49153], worker)
+    elapsed = time.monotonic() - t0
+    assert info == {"port": 49155, "serial": "WINNER", "ok": True}
+    assert cert_rejected is False
+    assert elapsed < 1.0   # winner is instant; no 12 s false-positive penalty
+
+
+def test_race_all_timeout_no_cert_rejected():
+    """All workers timeout → (None, False); not a cert problem, so no fallback."""
+    from custom_components.localthings.config_flow import _race_handshake
+
+    def worker(port):
+        raise TimeoutError(f"DTLS handshake timeout to 10.0.0.1:{port}")
+
+    info, cert_rejected, _ = _race_handshake("10.0.0.1", [49154, 49155], worker)
+    assert info is None
+    assert cert_rejected is False
+
+
+def test_race_all_cert_rejected_classified():
+    """All workers raise _CertRejected → cert_rejected=True (triggers fallback upstream)."""
+    from custom_components.localthings.config_flow import _race_handshake, _CertRejected
+
+    def worker(port):
+        raise _CertRejected(f"alert handshake failure from 10.0.0.1:{port}")
+
+    info, cert_rejected, _ = _race_handshake("10.0.0.1", [49154, 49155], worker)
+    assert info is None
+    assert cert_rejected is True
+
+
+def test_race_mixed_cert_and_timeout_not_all_cert():
+    """Mix of cert-reject and timeout → cert_rejected=False (ambiguous, no fallback)."""
+    from custom_components.localthings.config_flow import _race_handshake, _CertRejected
+
+    def worker(port):
+        if port == 49154:
+            raise _CertRejected("alert handshake failure")
+        raise TimeoutError("DTLS handshake timeout")
+
+    info, cert_rejected, _ = _race_handshake("10.0.0.1", [49154, 49155], worker)
+    assert info is None
+    assert cert_rejected is False
+
+
+async def test_probe_race_winner_with_fake_session(hass: HomeAssistant, monkeypatch) -> None:
+    """_probe_and_validate races candidates and returns the winner's port/info."""
+    import cbor2
+    from custom_components.localthings import config_flow
+
+    device0 = [
+        {'rt': ['x.com.samsung.devcol']},
+        {'href': '/information/vs/0', 'rep': {
+            'x.com.samsung.da.modelNum': 'TP2X_REF_20K|00136643|...',
+            'x.com.samsung.da.description': 'TP2X_REF_20K',
+            'x.com.samsung.da.serialNum': 'FRIDGE-RACE-001',
+        }},
+        {'href': '/otninformation/vs/0', 'rep': {}},
+    ]
+
+    class _FakeSession:
+        def __init__(self, host, port, cert_pem=None, key_pem=None):
+            self.host, self.port = host, port
+        def connect(self):
+            if self.port != 49155:
+                raise TimeoutError(f"DTLS handshake timeout to {self.host}:{self.port}")
+        def start_reader(self):
+            pass
+        def get(self, path, timeout=15.0):
+            return 0x45, cbor2.dumps(device0)
+        def close(self):
+            pass
+
+    monkeypatch.setattr(config_flow, '_fetch_samsung_uuid', lambda: 'test-uuid')
+    monkeypatch.setattr(
+        config_flow, '_mint_leaf_cert',
+        lambda ca_cert, ca_key, uuid: ('FULLCHAIN', 'LEAFKEY'),
+    )
+    monkeypatch.setattr(
+        config_flow, '_find_live_ports',
+        lambda host, ports, timeout: [49154, 49155, 49153],
+    )
+    monkeypatch.setattr(
+        'smartthings_local.protocol.dtls_session.DtlsCoapSession', _FakeSession,
+    )
+
+    info = await hass.async_add_executor_job(
+        config_flow._probe_and_validate, '10.0.0.254', 'CA', 'CAKEY',
+    )
+    assert info['port'] == 49155
+    assert info['serial'] == 'FRIDGE-RACE-001'
+    assert info['leaf_cert_pem'] == 'FULLCHAIN'
+    assert info['device_type_recognized'] is True
+
+
+async def test_cached_leaf_skips_fetch_and_mint(hass: HomeAssistant, monkeypatch) -> None:
+    """When cached_leaf is provided, UUID fetch + leaf mint are not called."""
+    import cbor2
+    from custom_components.localthings import config_flow
+
+    device0 = [
+        {'href': '/information/vs/0', 'rep': {
+            'x.com.samsung.da.modelNum': 'TP2X_REF_20K|x', 'x.com.samsung.da.description': 'TP2X_REF_20K',
+            'x.com.samsung.da.serialNum': 'CACHED-001'}},
+        {'href': '/otninformation/vs/0', 'rep': {}},
+    ]
+
+    class _FakeSession:
+        def __init__(self, host, port, cert_pem=None, key_pem=None): self.port = port
+        def connect(self): pass
+        def start_reader(self): pass
+        def get(self, path, timeout=15.0): return 0x45, cbor2.dumps(device0)
+        def close(self): pass
+
+    fetch_calls = []
+    mint_calls = []
+    monkeypatch.setattr(config_flow, '_fetch_samsung_uuid', lambda: fetch_calls.append(1) or 'UUID')
+    monkeypatch.setattr(config_flow, '_mint_leaf_cert', lambda *a, **k: mint_calls.append(1) or ('X', 'Y'))
+    monkeypatch.setattr(config_flow, '_find_live_ports', lambda host, ports, t: [49155])
+    monkeypatch.setattr('smartthings_local.protocol.dtls_session.DtlsCoapSession', _FakeSession)
+
+    info = await hass.async_add_executor_job(
+        config_flow._probe_and_validate,
+        '10.0.0.254', 'CA', 'CAKEY', ('CACHEDFULLCHAIN', 'CACHEDLEAFKEY'),
+    )
+    assert info['leaf_cert_pem'] == 'CACHEDFULLCHAIN'
+    assert info['leaf_key_pem'] == 'CACHEDLEAFKEY'
+    assert info['port'] == 49155
+    assert fetch_calls == []   # UUID fetch skipped
+    assert mint_calls == []    # mint skipped
+
+
+async def test_second_device_passes_cached_leaf(hass: HomeAssistant, monkeypatch) -> None:
+    """The has_creds branch passes the existing entry's leaf as cached_leaf."""
+    from custom_components.localthings import config_flow
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from .conftest import ENTRY_DATA, MOCK_HOST
+
+    existing = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA)
+    existing.add_to_hass(hass)
+
+    captured = {}
+
+    def fake_probe(host, ca_cert, ca_key, cached_leaf=None, hass=None, entry=None):
+        captured['cached_leaf'] = cached_leaf
+        captured['hass'] = hass
+        captured['entry'] = entry
+        return {'port': 49155, 'serial': 'SECOND-DEV', 'leaf_cert_pem': 'L', 'leaf_key_pem': 'K',
+                'one_ui_version': '', 'device_type_recognized': True}
+
+    monkeypatch.setattr(config_flow, '_probe_and_validate', fake_probe)
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={'source': 'user'})
+    assert result['step_id'] == 'user_reuse'
+    result = await hass.config_entries.flow.async_configure(
+        result['flow_id'], {CONF_HOST: MOCK_HOST},
+    )
+    assert result['type'] == FlowResultType.CREATE_ENTRY
+    assert captured['cached_leaf'] == (
+        ENTRY_DATA[CONF_LEAF_CERT_PEM], ENTRY_DATA[CONF_LEAF_KEY_PEM],
+    )
+    assert captured['hass'] is hass
+    assert captured['entry'] is existing
+
+
+async def test_fallback_re_mint_on_all_cert_rejected(hass: HomeAssistant, monkeypatch) -> None:
+    """Cached leaf, all workers cert-reject → fetch+mint once, second race succeeds."""
+    import cbor2
+    from custom_components.localthings import config_flow
+
+    device0 = [
+        {'rt': ['x.com.samsung.devcol']},
+        {'href': '/information/vs/0', 'rep': {
+            'x.com.samsung.da.modelNum': 'TP2X_REF_20K|x', 'x.com.samsung.da.description': 'TP2X_REF_20K',
+            'x.com.samsung.da.serialNum': 'ROT-001'}},
+        {'href': '/otninformation/vs/0', 'rep': {}},
+    ]
+
+    class _RejectSession:
+        def __init__(self, host, port, cert_pem=None, key_pem=None):
+            self.cert_pem = cert_pem
+        def connect(self):
+            raise ConnectionError("DTLS handshake error: alert handshake failure")
+        def start_reader(self): pass
+        def get(self, path, timeout=15.0): return 0x45, cbor2.dumps(device0)
+        def close(self): pass
+
+    class _OkSession:
+        def __init__(self, host, port, cert_pem=None, key_pem=None):
+            self.cert_pem = cert_pem
+        def connect(self): pass
+        def start_reader(self): pass
+        def get(self, path, timeout=15.0): return 0x45, cbor2.dumps(device0)
+        def close(self): pass
+
+    # First race (cached leaf 'OLDFULLCHAIN'): every candidate cert-rejects.
+    # Second race (re-minted leaf 'NEWCHAIN'): ok. Decision keyed on cert_pem
+    # so it's deterministic under parallel worker construction (no shared counter).
+    def factory(host, port, cert_pem=None, key_pem=None):
+        if cert_pem == 'OLDFULLCHAIN':
+            return _RejectSession(host, port, cert_pem, key_pem)
+        return _OkSession(host, port, cert_pem, key_pem)
+    monkeypatch.setattr('smartthings_local.protocol.dtls_session.DtlsCoapSession', factory)
+
+    fetch_calls = []
+    monkeypatch.setattr(config_flow, '_fetch_samsung_uuid', lambda: fetch_calls.append(1) or 'NEW-UUID')
+    monkeypatch.setattr(config_flow, '_mint_leaf_cert', lambda *a, **k: ('NEWCHAIN', 'NEWKEY'))
+    monkeypatch.setattr(config_flow, '_find_live_ports', lambda host, ports, t: [49154, 49155, 49153])
+    # _persist_refreshed_leaf needs an entry; pass a MockConfigEntry.
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    entry = MockConfigEntry(domain=DOMAIN, data={**ENTRY_DATA, CONF_HOST: '10.0.0.254'})
+    entry.add_to_hass(hass)
+    monkeypatch.setattr(config_flow, '_persist_refreshed_leaf', lambda *a, **k: None)
+
+    info = await hass.async_add_executor_job(
+        config_flow._probe_and_validate,
+        '10.0.0.254', 'CA', 'CAKEY', ('OLDFULLCHAIN', 'OLDLEAFKEY'), hass, entry,
+    )
+    assert info['serial'] == 'ROT-001'
+    assert info['leaf_cert_pem'] == 'NEWCHAIN'   # re-minted leaf used
+    assert fetch_calls == [1]                     # UUID fetched exactly once (fallback)
+
+
+async def test_persist_refreshed_leaf_updates_entry(hass: HomeAssistant, monkeypatch) -> None:
+    """E2E: the fresh-mint fallback persists the refreshed leaf to the
+    existing entry. Does NOT monkeypatch _persist_refreshed_leaf, so the
+    real `asyncio.run_coroutine_threadsafe(...).result()` path runs."""
+    import cbor2
+    from custom_components.localthings import config_flow
+    from custom_components.localthings.const import (
+        CONF_LEAF_CERT_PEM, CONF_LEAF_KEY_PEM,
+    )
+
+    device0 = [
+        {'rt': ['x.com.samsung.devcol']},
+        {'href': '/information/vs/0', 'rep': {
+            'x.com.samsung.da.modelNum': 'TP2X_REF_20K|x',
+            'x.com.samsung.da.description': 'TP2X_REF_20K',
+            'x.com.samsung.da.serialNum': 'PERSIST-001'}},
+        {'href': '/otninformation/vs/0', 'rep': {}},
+    ]
+
+    class _RejectSession:
+        def __init__(self, host, port, cert_pem=None, key_pem=None):
+            self.cert_pem = cert_pem
+        def connect(self):
+            raise ConnectionError("DTLS handshake error: alert handshake failure")
+        def start_reader(self): pass
+        def get(self, path, timeout=15.0): return 0x45, cbor2.dumps(device0)
+        def close(self): pass
+
+    class _OkSession:
+        def __init__(self, host, port, cert_pem=None, key_pem=None):
+            self.cert_pem = cert_pem
+        def connect(self): pass
+        def start_reader(self): pass
+        def get(self, path, timeout=15.0): return 0x45, cbor2.dumps(device0)
+        def close(self): pass
+
+    def factory(host, port, cert_pem=None, key_pem=None):
+        if cert_pem == 'OLDFULLCHAIN':
+            return _RejectSession(host, port, cert_pem, key_pem)
+        return _OkSession(host, port, cert_pem, key_pem)
+    monkeypatch.setattr('smartthings_local.protocol.dtls_session.DtlsCoapSession', factory)
+
+    monkeypatch.setattr(config_flow, '_fetch_samsung_uuid', lambda: 'NEW-UUID')
+    monkeypatch.setattr(config_flow, '_mint_leaf_cert', lambda *a, **k: ('NEWCHAIN', 'NEWKEY'))
+    monkeypatch.setattr(config_flow, '_find_live_ports', lambda host, ports, t: [49154, 49155, 49153])
+
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    entry = MockConfigEntry(domain=DOMAIN, data={**ENTRY_DATA, CONF_HOST: '10.0.0.254'})
+    entry.add_to_hass(hass)
+
+    info = await hass.async_add_executor_job(
+        config_flow._probe_and_validate,
+        '10.0.0.254', 'CA', 'CAKEY', ('OLDFULLCHAIN', 'OLDLEAFKEY'), hass, entry,
+    )
+    await hass.async_block_till_done()
+
+    assert info['leaf_cert_pem'] == 'NEWCHAIN'
+    assert entry.data[CONF_LEAF_CERT_PEM] == 'NEWCHAIN'
+    assert entry.data[CONF_LEAF_KEY_PEM] == 'NEWKEY'
+
+
+async def test_no_fallback_on_timeout(hass: HomeAssistant, monkeypatch) -> None:
+    """Cached leaf, all workers timeout → no re-mint, CannotConnect."""
+    from custom_components.localthings import config_flow
+    from custom_components.localthings.config_flow import CannotConnect
+
+    class _TimeoutSession:
+        def __init__(self, host, port, cert_pem=None, key_pem=None): pass
+        def connect(self): raise TimeoutError("DTLS handshake timeout")
+        def start_reader(self): pass
+        def get(self, path, timeout=15.0): raise AssertionError("should not reach GET")
+        def close(self): pass
+    monkeypatch.setattr('smartthings_local.protocol.dtls_session.DtlsCoapSession', _TimeoutSession)
+    fetch_calls = []
+    monkeypatch.setattr(config_flow, '_fetch_samsung_uuid', lambda: fetch_calls.append(1) or 'UUID')
+    monkeypatch.setattr(config_flow, '_mint_leaf_cert', lambda *a, **k: ('X', 'Y'))
+    monkeypatch.setattr(config_flow, '_find_live_ports', lambda host, ports, t: [49154, 49155])
+
+    with pytest.raises(CannotConnect):
+        await hass.async_add_executor_job(
+            config_flow._probe_and_validate,
+            '10.0.0.254', 'CA', 'CAKEY', ('OLDCHAIN', 'OLDKEY'), hass, None,
+        )
+    assert fetch_calls == []   # no UUID fetch (timeout is not a cert problem)
+
+
+async def test_no_fallback_on_mixed_errors(hass: HomeAssistant, monkeypatch) -> None:
+    """Cached leaf, mix of cert-reject + timeout → no re-mint, CannotConnect."""
+    import cbor2
+    from custom_components.localthings import config_flow
+    from custom_components.localthings.config_flow import CannotConnect
+
+    class _MixSession:
+        def __init__(self, host, port, cert_pem=None, key_pem=None): self.port = port
+        def connect(self):
+            if self.port == 49154:
+                raise ConnectionError("DTLS handshake error: alert handshake failure")
+            raise TimeoutError("DTLS handshake timeout")
+        def start_reader(self): pass
+        def get(self, path, timeout=15.0): return 0x45, cbor2.dumps([])
+        def close(self): pass
+    monkeypatch.setattr('smartthings_local.protocol.dtls_session.DtlsCoapSession', _MixSession)
+    fetch_calls = []
+    monkeypatch.setattr(config_flow, '_fetch_samsung_uuid', lambda: fetch_calls.append(1) or 'UUID')
+    monkeypatch.setattr(config_flow, '_mint_leaf_cert', lambda *a, **k: ('X', 'Y'))
+    monkeypatch.setattr(config_flow, '_find_live_ports', lambda host, ports, t: [49154, 49155])
+
+    with pytest.raises(CannotConnect):
+        await hass.async_add_executor_job(
+            config_flow._probe_and_validate,
+            '10.0.0.254', 'CA', 'CAKEY', ('OLDCHAIN', 'OLDKEY'), hass, None,
+        )
+    assert fetch_calls == []   # mix → no fallback


### PR DESCRIPTION
Resolves #211

The observe grace-period early-exit (the other first-refresh latency win from this work) was split to #227 — it touches `observe.py`, not the config-flow probe path, so it's independent of the race and can land regardless of how the probe latency is approached (see the discussion on #211 around a library-level DTLS ClientHello liveness probe).

## What

Cuts localthings device-add latency on the happy path: races DTLS handshakes across the liveness candidates in parallel instead of sequencing through false-positive ports, and reuses the cached leaf cert for 2nd+ devices. Two commits here (the orphan-cooldown doc rides along — it edits a docstring the race adds, so it can't travel separately).

## Why / measured

Production trace adding a fridge (`TP2X_REF_20K`), config-flow probe (the part #211 is about):

| phase | before | after |
|---|---|---|
| config-flow probe (sequential false-positive DTLS timeouts) | ~14s | ~1.4s |
| coordinator first-connect orphan cooldown | ~8.4s | ~8.4s (documented — see §2) |

The probe went from ~14s to ~1.4s. (The ~15s observe grace wait and the ~1.8s discovery that made up the rest of the first refresh are separate; the grace wait is in #227.)

## Changes

### 1. Parallel DTLS probe + cached leaf  (`feat(config-flow)`)
`_probe_and_validate` races DTLS handshakes across the liveness candidates in parallel (`ThreadPoolExecutor`; first valid `/device/0` wins; losers time out in the background via `shutdown(wait=False)` — the `with`-form's `shutdown(wait=True)` would block on losers and re-introduce the sequential wall-clock). 2nd+ device adds reuse the cached leaf cert from an existing entry (skip the Samsung-cloud UUID fetch + mint); on all-cert-rejected, a one-shot UUID-rotation re-mint fallback fires and the refreshed leaf is persisted to the existing entry. Race layer races callables with an injectable `session_factory`, so it's transport-agnostic for future TCP/8888 families. No `smartthings_local` library change.

### 2. Document post-probe DTLS orphan-cooldown gotcha  (`docs`)
After the race, the coordinator's first connect can be rejected for ~8s then succeed on retry. Root cause: the race's winning session closes on an **ephemeral** source port; the coordinator binds a **fixed** local port (`_local_source_port`), a different 5-tuple, so per RFC 6347 §4.2.8 it cannot evict the probe's just-closed session at handshake time and waits for age-out. One-time per device add, auto-recovers on retry. Documented rather than fixed: a session hand-off would defer the same ~8s to the first reconnect (the handed-off session is on an ephemeral port, which breaks the fixed-port eviction the coordinator relies on across reconnects), and racing on the fixed port breaks the parallel race (workers can't share a local UDP port — `recvfrom` mis-demux). This is the last visible latency chunk now that the probe races.

## Tests
Full suite: 1005 passed (with the grace-sleep commit; this branch's subset passes too — the race's tests are in `tests/localthings/test_config_flow.py`). No `smartthings_local` library change; no `manifest.json` change; no UI/error-mapping change.

## Note on overlap with library-level work
A DTLS ClientHello-based liveness gate is being prototyped in `smartthings-local` (see @QuiteYellow's comment on #211): it would identify the real DTLS port in ~1 RTT via the HelloVerifyRequest and pre-filter dead ports before any full handshake. If that lands in the library, it supersedes the integration-level race here (false-positives eliminated at the liveness stage → one candidate → no parallel race needed). The orphan doc (§2) is orthogonal to the liveness approach and stands either way; the race (§1) is the integration-level stopgap until/unless the library probe ships.