### PR TITLE
fix(hood_fan): fall back to settable min/max when supportedFanSpeed is missing

### DIFF
--- a/custom_components/localthings/registry/capabilities/range_hood.py
+++ b/custom_components/localthings/registry/capabilities/range_hood.py
@@ -79,6 +79,15 @@ def _hood_fan_write(payload, rep, href=None):
             str(code)
             for code in rep.get('x.com.samsung.da.hood.supportedFanSpeed', ())
         ]
+        if not supported:
+            min_s = rep.get('x.com.samsung.da.hood.settableMinFanSpeed')
+            max_s = rep.get('x.com.samsung.da.hood.settableMaxFanSpeed')
+            if min_s is not None and max_s is not None:
+                try:
+                    mn, mx = int(min_s), int(max_s)
+                    supported = [str(i) for i in range(mn, mx + 1)]
+                except (ValueError, TypeError):
+                    pass
         if value not in supported:
             return None
         return ['hood', 'fanspeed', 'vs', '0'], {

--- a/tests/test_range_hood_capabilities.py
+++ b/tests/test_range_hood_capabilities.py
@@ -99,6 +99,16 @@ def test_fan_write_contract():
     )
     assert desc.write_fn(('speed', '99'), rep) is None
 
+    rep_fallback = {
+        'x.com.samsung.da.hood.settableMinFanSpeed': '0',
+        'x.com.samsung.da.hood.settableMaxFanSpeed': '3',
+    }
+    assert desc.write_fn(('speed', '2'), rep_fallback) == (
+        ['hood', 'fanspeed', 'vs', '0'],
+        {'x.com.samsung.da.hood.fanSpeed': '2'},
+    )
+    assert desc.write_fn(('speed', '4'), rep_fallback) is None
+
 
 def test_lamp_write_contract():
     lamp, brightness = range_hood.HOOD_LAMP.entities


### PR DESCRIPTION
Fixes #217

### Summary

Fixes an issue where speed write requests (`write_fn rejected payload ('speed', '...') for /hood/fanspeed/vs/0`) were rejected for devices (such as certain over-the-range microwave vent fans) that omit `x.com.samsung.da.hood.supportedFanSpeed` from their state representation.

### Changes

- Updated `_hood_fan_write` in [`range_hood.py`](file:///home/firstof9/github/localthings/custom_components/localthings/registry/capabilities/range_hood.py) to fall back to constructing valid speed bounds from `x.com.samsung.da.hood.settableMinFanSpeed` and `x.com.samsung.da.hood.settableMaxFanSpeed` when `supportedFanSpeed` is absent.
- Added unit test in [`test_range_hood_capabilities.py`](file:///home/firstof9/github/localthings/tests/test_range_hood_capabilities.py) to verify write validation succeeds with min/max fields when `supportedFanSpeed` is missing.