### PR TITLE
Route VS9700 stick vacuum (VSWW) to vacuum_station registry

### DIFF
--- a/custom_components/localthings/registry/by_type/__init__.py
+++ b/custom_components/localthings/registry/by_type/__init__.py
@@ -111,6 +111,7 @@ _BOARD_TOKEN_TO_KEY: dict[str, str] = {
     'CT': 'cooktop',
     'VSKR': 'vacuum_station',       # issue #131 -- stick-vacuum clean station
     'DF': 'air_dresser',            # issue #162
+    'VSWW': 'vacuum_station',       # issue #219   
 }
 
 _TOKEN_SPLIT_RE = re.compile(r'[^A-Z0-9]+')


### PR DESCRIPTION
Routes the Samsung Bespoke Jet stick vacuum (A-VSWW-TP1-23-VS9700, OCF type x.com.st.d.stickcleaner) to the existing vacuum_station registry via its board token VSWW (region sibling of VSKR). All resources bind cleanly, no new registry needed. Confirmed working in HA. Closes #219 .