### PR TITLE
Add x.com.st.d.hood to _OIC_TYPE_TO_KEY; document why oic.d.cooktop is not mapped

### DIFF
--- a/custom_components/localthings/registry/by_type/__init__.py
+++ b/custom_components/localthings/registry/by_type/__init__.py
@@ -214,6 +214,16 @@ def _consumer_model_key(description: str) -> Optional[str]:
 # device-type vocabulary (used for categories with no `oic.d.*` equivalent),
 # same prefix convention as the `x.com.samsung.da.*` resource fields
 # elsewhere in this codebase.
+#
+# `oic.d.cooktop` is deliberately absent, and is the one measured type left out.
+# A TP1X_DA-KS-COOKTOP induction reports it, but `cooktop` and
+# `induction_cooktop` are two unrelated registries that happen to share the
+# English word (see by_type/cooktop.py's docstring: the NA9300K gas family keeps
+# burner state in /mode/vs/0's options array, a completely different OCF
+# surface). The OCF type does not distinguish them, so mapping it to either key
+# would silently misroute the other -- and as the *primary* signal it would
+# override a `COOKTOP`/`CT` board token that had it right. Same reasoning as
+# `oic.d.robotcleaner` above: no unambiguous key to point at, so no row.
 _OIC_TYPE_TO_KEY: dict[str, str] = {
     'oic.d.airconditioner': 'airconditioner',
     'oic.d.airpurifier': 'air_purifier',
@@ -223,6 +233,7 @@ _OIC_TYPE_TO_KEY: dict[str, str] = {
     'oic.d.refrigerator': 'refrigerator',
     'oic.d.washer': 'washer',
     'x.com.st.d.airqualitysensor': 'air_monitor',
+    'x.com.st.d.hood': 'range_hood',              # AHD-WW-TP1-22-COMMON
     'x.com.st.d.stickcleaner': 'vacuum_station',
     'x.com.st.d.steamcloset': 'air_dresser',
 }

--- a/tests/test_by_type.py
+++ b/tests/test_by_type.py
@@ -149,6 +149,7 @@ class TestForDeviceByOicType:
         ('oic.d.oven', 'oven'),
         ('oic.d.refrigerator', 'refrigerator'),
         ('oic.d.washer', 'washer'),
+        ('x.com.st.d.hood', 'range_hood'),
         ('x.com.st.d.stickcleaner', 'vacuum_station'),
         ('x.com.st.d.steamcloset', 'air_dresser'),
         ('x.com.st.d.airqualitysensor', 'air_monitor'),
@@ -176,6 +177,18 @@ class TestForDeviceByOicType:
         a genuine robot-vacuum dump."""
         from custom_components.localthings.registry.by_type import for_device_by_oic_type
         assert for_device_by_oic_type(('oic.d.robotcleaner',)) is None
+
+    def test_cooktop_is_not_mapped_to_either_cooktop_registry(self):
+        """'oic.d.cooktop' cannot tell the two cooktop families apart.
+
+        A TP1X_DA-KS-COOKTOP induction reports it, but `cooktop` is the
+        unrelated NA9300K gas family (burner state in /mode/vs/0's options
+        array, a different OCF surface -- see by_type/cooktop.py). Mapping the
+        type to either key would misroute the other, and as the primary signal
+        it would override a board token that had it right.
+        """
+        from custom_components.localthings.registry.by_type import for_device_by_oic_type
+        assert for_device_by_oic_type(('oic.d.cooktop',)) is None
 
     def test_empty_returns_none(self):
         from custom_components.localthings.registry.by_type import for_device_by_oic_type


### PR DESCRIPTION
Measured `/oic/d` on nine Samsung appliances on Korean-market firmware. All nine populate it with a concrete type:

| count | `rt` (concrete type) | board / `n` |
|---|---|---|
| 4 | `oic.d.airconditioner` | `AJ023CN1UBC1`, "Samsung System A/C" |
| 3 | `oic.d.refrigerator` | "[refrigerator] Samsung" |
| 1 | `oic.d.cooktop` | `TP1X_DA-KS-COOKTOP`, "Samsung Cooktop" |
| 1 | `x.com.st.d.hood` | `AHD-WW-TP1-22-COMMON`, "Samsung Hood" |

Every one agreed with what `for_device_by_model` already concluded from the board token, so this is corroboration of the existing rows rather than a correction to any of them.

### What this changes

**Adds `x.com.st.d.hood` → `range_hood`.** It was the one measured type with a registry to point at and no row.

**Leaves `oic.d.cooktop` out, with a comment saying why.** The induction above reports it, but `cooktop` and `induction_cooktop` are unrelated registries that happen to share the English word — `by_type/cooktop.py`'s own docstring makes that point, and the NA9300K gas family keeps burner state in `/mode/vs/0`'s options array, a different OCF surface entirely. Nothing in the OCF type distinguishes them, so mapping it to either key silently misroutes the other. Because `resolve()` consults this table *first*, it would also override a `COOKTOP`/`CT` board token that had it right. Same shape of argument as the existing `oic.d.robotcleaner` note, so I wrote it as a sibling of that one rather than inventing a new convention.

A test pins each: `x.com.st.d.hood` resolves, `oic.d.cooktop` resolves to `None`.

### One incidental data point

`for_device_by_oic_type`'s docstring says this "only ever helps a minority of dumps", and `_device_types` says "only a minority of dumps populate it". That may understate it — nine out of nine here answer with a usable type, across four families. Four appliance types on one market's firmware is not enough to generalise from, so I have not touched that wording; passing it along in case other reports point the same way.

### Verification

Full suite, Python 3.13 via `requirements-dev.txt`: **1024 passed**.

Context: I maintain a Homey port of this integration ([moKorean/com.lomohome.localthings](https://github.com/moKorean/com.lomohome.localthings)), which is where the nine appliances are paired. Earlier contribution from the same hardware was #194 (`CAC`).