### PR TITLE
Fix/dryer cycle mappings

### DIFF
--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -292,19 +292,25 @@
           "01": "Normal",
           "06": "Time dry",
           "16": "Cotton",
+          "17": "Super Speed",
           "18": "Synthetics",
           "19": "Delicates",
           "20": "Iron dry",
+          "21": "Hygiene Care",
+          "22": "Silent Dry",
           "23": "Quick Dry 35",
           "24": "Cool air",
           "25": "Warm air",
           "27": "Time dry",
+          "29": "AI Dry",
           "1a": "Wool",
           "1b": "Bedding",
           "1c": "Shirts",
           "1d": "Towels",
           "1e": "Outdoor",
-          "1f": "Mixed load"
+          "1f": "Mixed load",
+          "2b": "Self Tub Dry",
+          "4c": "Air Refresh"
         }
       },
       "favorite_capacity": {

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -298,7 +298,7 @@
           "20": "Iron dry",
           "21": "Hygiene Care",
           "22": "Silent Dry",
-          "23": "Quick Dry 35",
+          "23": "Quick Dry 35'",
           "24": "Cool air",
           "25": "Warm air",
           "27": "Time dry",

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -292,19 +292,25 @@
           "01": "Normaal",
           "06": "Tijdprogramma",
           "16": "Katoen",
+          "17": "Super Speed",
           "18": "Synthetisch",
           "19": "Fijne was",
           "20": "Strijkdroog",
+          "21": "Hygiënisch drogen",
+          "22": "Stil drogen",
           "23": "Snel drogen 35'",
           "24": "Koude lucht",
           "25": "Warme lucht",
           "27": "Tijdprogramma",
+          "29": "AI drogen",
           "1a": "Wol",
           "1b": "Beddengoed",
           "1c": "Overhemden",
           "1d": "Handdoeken",
           "1e": "Outdoor",
-          "1f": "Gemengde was"
+          "1f": "Gemengde was",
+          "2b": "Zelf trommel drogen",
+          "4c": "Opfrissen"
         }
       },
       "favorite_capacity": {


### PR DESCRIPTION
This pull request updates the dryer program translations in both the English (`en.json`) and Dutch (`nl.json`) language files to add several new program names and improve consistency. The most important changes are grouped below:

**New dryer program translations added:**

* Added translations for new dryer programs such as "Super Speed", "Hygiene Care", "Silent Dry", "AI Dry", "Self Tub Dry", and "Air Refresh" in both `en.json` and `nl.json`. [[1]](diffhunk://#diff-01d14ff3566a04cf5c5b749e3bbd72dac785644579abb23e17eba9bf2d607af7R295-R313) [[2]](diffhunk://#diff-b4e77cf45b11e7d3c3f645609af05024bdd6f747fd9fea1261a61c48d12db00cR295-R313)

`**The dutch translations should be double checked.**`

I have verified the new mappings against my DV90BB9445GBS2 heat-pump dryer.

**Translation improvements and consistency:**

* Updated "Quick Dry 35" --> "Quick Dry 35'" for consistency between the English and Dutch translations. [[1]](diffhunk://#diff-01d14ff3566a04cf5c5b749e3bbd72dac785644579abb23e17eba9bf2d607af7R295-R313) [[2]](diffhunk://#diff-b4e77cf45b11e7d3c3f645609af05024bdd6f747fd9fea1261a61c48d12db00cR295-R313)

