### PR TITLE
feat: Spanish translation (es.json)

### DIFF
--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -1,0 +1,1228 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Añadir electrodoméstico Samsung",
+        "description": "Introduce la dirección IP de tu electrodoméstico Samsung y las credenciales AC14K_M CA usadas para emitir los certificados de dispositivo.",
+        "data": {
+          "host": "Dirección IP",
+          "ca_cert_pem": "Certificado CA (PEM)",
+          "ca_key_pem": "Clave privada CA (PEM)"
+        },
+        "data_description": {
+          "host": "Dirección IP local de tu electrodoméstico Samsung (p. ej. 192.168.1.50).",
+          "ca_cert_pem": "Cadena de certificados CA AC14K_M codificada en PEM. Pega el contenido completo de tu PEM fullchain incluyendo todos los bloques BEGIN/END CERTIFICATE.",
+          "ca_key_pem": "Clave privada AC14K_M codificada en PEM. Pega el contenido completo incluyendo la cabecera y el pie BEGIN/END PRIVATE KEY."
+        }
+      },
+      "user_reuse": {
+        "title": "Añadir electrodoméstico Samsung",
+        "description": "Introduce la dirección IP de tu electrodoméstico Samsung. Se reutilizarán las credenciales CA de un electrodoméstico LocalThings existente.",
+        "data": {
+          "host": "Dirección IP"
+        },
+        "data_description": {
+          "host": "Dirección IP local de tu electrodoméstico Samsung (p. ej. 192.168.1.50)."
+        }
+      },
+      "confirm_unknown_type": {
+        "title": "Tipo de electrodoméstico no reconocido",
+        "description": "No se ha podido reconocer el tipo de este electrodoméstico. Se añadirá igualmente, pero solo con las capacidades comunes (alimentación, alarmas, etc. donde existan) en lugar del conjunto completo de su familia. Puedes ayudar a añadir soporte completo después descargando los diagnósticos de este dispositivo (Ajustes > Dispositivos y servicios > este dispositivo > el menú > Descargar diagnósticos) y reportándolos en una nueva incidencia. Envía para añadirlo de todos modos."
+      }
+    },
+    "error": {
+      "cannot_connect": "No se puede conectar con el dispositivo. Comprueba que la dirección IP sea accesible y que las credenciales CA sean correctas.",
+      "invalid_ca": "No se ha podido cargar el certificado CA o la clave privada. Comprueba que el contenido PEM sea correcto y que la clave coincida con el certificado.",
+      "unknown": "Error inesperado. Consulta los registros de Home Assistant para más detalles."
+    },
+    "abort": {
+      "already_configured": "El dispositivo ya está configurado"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones de LocalThings",
+        "menu_options": {
+          "settings": "Ajustes del dispositivo",
+          "debug_write": "Depuración: escribir en un recurso"
+        }
+      },
+      "settings": {
+        "title": "Ajustes del dispositivo",
+        "description": "Algunos dispositivos aceptan ciertas escrituras (p. ej. la dosificación por defecto de detergente/suavizante en una lavadora) incluso cuando informan de control remoto desactivado. Por defecto, LocalThings bloquea cada escritura con un error claro cuando un dispositivo informa de control remoto desactivado, en lugar de dejar que el dispositivo la rechace en silencio. Solo actívalo si has confirmado que las escrituras funcionan de verdad en este dispositivo con el control remoto desactivado; si no, cambiarás ese error claro por un fallo silencioso.\n\nLa hora estimada de finalización se recalcula a partir de la estimación de tiempo restante del dispositivo en cada sondeo, que puede variar o revisarse uno o dos minutos entre actualizaciones. Sube el valor de cambio mínimo siguiente para mantener el sensor en su último valor notificado hasta que la estimación varíe al menos esa cantidad de minutos, reduciendo el ruido en el historial/registro de actividad. Ponlo a 0 para notificar cada cambio calculado.",
+        "data": {
+          "bypass_remote_control_lock": "Permitir escrituras incluso cuando el control remoto se notifica como desactivado",
+          "finish_time_hysteresis_minutes": "Finalización estimada -- cambio mínimo (minutos)"
+        }
+      },
+      "debug_write": {
+        "title": "Depuración: escribir en un recurso",
+        "description": "Herramienta para usuarios avanzados para precisar el comportamiento de escritura específico del dispositivo. Elige el recurso (href) sobre el que quieres escribir, o escribe uno personalizado que no esté en la lista. Esto omite el bloqueo de control remoto desactivado y envía exactamente los campos que proporciones; puede desconfigurar tu electrodoméstico, así que úsalo deliberadamente.",
+        "data": {
+          "href": "Recurso (href)"
+        }
+      },
+      "debug_edit": {
+        "title": "Escritura de depuración: {href}",
+        "description": "Valor actual de `{href}`:\n```\n{current_value}\n```\nIntroduce SOLO el/los campo(s) que quieras cambiar a continuación. Lo que introduzcas se envía al dispositivo tal cual (una actualización parcial); NO se fusiona con los campos mostrados arriba, así que no pegues el valor completo. Cuida los tipos: una cadena numérica como \"1\" debe seguir entre comillas -- un 1 sin comillas se envía como entero, que algunos dispositivos rechazan.",
+        "data": {
+          "payload": "Contenido a escribir"
+        }
+      },
+      "debug_result": {
+        "title": "Resultado de la escritura de depuración",
+        "description": "El dispositivo devolvió el código CoAP {code}. Una clase 2.xx significa que la escritura fue aceptada; 4.xx/5.xx significa que fue rechazada. El recurso ahora dice:\n```\n{new_value}\n```\nSi el valor no ha cambiado, es probable que el dispositivo haya descartado la escritura. Elige qué hacer a continuación:",
+        "menu_options": {
+          "debug_write": "Escribir otro recurso",
+          "finish": "Finalizar"
+        }
+      }
+    },
+    "error": {
+      "empty_payload": "Introduce al menos un campo para escribir.",
+      "write_failed": "La escritura falló. Consulta los registros de Home Assistant para más detalles."
+    },
+    "abort": {
+      "not_loaded": "Este dispositivo aún no está conectado. Inténtalo de nuevo cuando se haya cargado."
+    }
+  },
+  "issues": {
+    "device_gap": {
+      "title": "Cobertura de capacidades incompleta para {device_name}",
+      "description": "A este dispositivo le falta cobertura completa de capacidades. O su tipo de electrodoméstico no fue reconocido, o algunos de los recursos que expone aún no están modelados. Seguirá funcionando con lo que ya está soportado. Puedes ayudar a ampliar el soporte yendo a Ajustes > Dispositivos y servicios > {device_name} > el menú (arriba a la derecha) > Descargar diagnósticos, y reportándolo con la plantilla de incidencia enlazada."
+    }
+  },
+  "exceptions": {
+    "remote_control_disabled": {
+      "message": "El control remoto está desactivado en este dispositivo. Consulta el manual de tu electrodoméstico para saber cómo activar el control remoto antes de que Home Assistant pueda controlarlo."
+    },
+    "debug_payload_empty": {
+      "message": "El contenido de la escritura de depuración debe ser un objeto no vacío."
+    },
+    "resource_href_required": {
+      "message": "Se requiere un recurso (href)."
+    },
+    "bubble_soak_unavailable_for_cycle": {
+      "message": "El remojo con burbujas no está disponible en el ciclo seleccionado."
+    },
+    "pre_wash_unavailable_for_cycle": {
+      "message": "El prelavado no está disponible en el ciclo seleccionado."
+    },
+    "intensive_unavailable_for_cycle": {
+      "message": "El modo intensivo no está disponible en el ciclo seleccionado."
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "after_run_active": {
+        "name": "Activo tras finalizar"
+      },
+      "any_burner_active": {
+        "name": "Un fuego activo"
+      },
+      "automatic_operation": {
+        "name": "Funcionamiento automático"
+      },
+      "battery_charging": {
+        "name": "Cargando"
+      },
+      "burner_hot_surface": {
+        "name": "Fuego {number} superficie caliente"
+      },
+      "burner_pan_detected": {
+        "name": "Fuego {number} cacerola detectada"
+      },
+      "child_lock": {
+        "name": "Bloqueo infantil"
+      },
+      "cloud_connected": {
+        "name": "Conectado a la nube"
+      },
+      "dustbag_full": {
+        "name": "Bolsa de polvo llena"
+      },
+      "cooktop_power": {
+        "name": "Energía de la placa"
+      },
+      "cooktop_safety_shutoff_enabled": {
+        "name": "Apagado automático por superficie caliente habilitado"
+      },
+      "current_limit_enabled": {
+        "name": "Límite de corriente habilitado"
+      },
+      "overload_protection_active": {
+        "name": "Protección contra sobrecarga activa"
+      },
+      "odor_controller_active": {
+        "name": "Controlador de olores activo"
+      },
+      "cycle_active": {
+        "name": "En funcionamiento"
+      },
+      "defrost_active": {
+        "name": "Descongelación activa"
+      },
+      "detergent_low": {
+        "name": "Poco detergente"
+      },
+      "device_active": {
+        "name": "Dispositivo activo"
+      },
+      "door_open": {
+        "name": "Puerta"
+      },
+      "filter_door_status": {
+        "name": "Puerta del filtro"
+      },
+      "firmware_update": {
+        "name": "Actualización de firmware disponible"
+      },
+      "instance_open": {
+        "name": "{instance_name} abierto"
+      },
+      "paired_hood_connected": {
+        "name": "Campana emparejada conectada"
+      },
+      "paired_hood_light": {
+        "name": "Luz de la campana emparejada"
+      },
+      "paired_hood_power": {
+        "name": "Energía de la campana emparejada"
+      },
+      "periodic_air_sensing": {
+        "name": "Detección de aire periódica"
+      },
+      "pouring": {
+        "name": "Sirviendo"
+      },
+      "alarm_in_mute": {
+        "name": "Alarma en silencio"
+      },
+      "power_state": {
+        "name": "Estado de energía"
+      },
+      "probe_connected": {
+        "name": "Sonda conectada"
+      },
+      "power_switch": {
+        "name": "Energía"
+      },
+      "rapid_freezing": {
+        "name": "Congelación rápida"
+      },
+      "rapid_fridge": {
+        "name": "Frío rápido"
+      },
+      "remote_control": {
+        "name": "Control inteligente"
+      },
+      "softener_low": {
+        "name": "Poco suavizante"
+      }
+    },
+    "button": {
+      "after_run_cancel": {
+        "name": "Cancelar tras finalizar"
+      },
+      "diagnosis_start": {
+        "name": "Iniciar diagnóstico"
+      },
+      "pause": {
+        "name": "Pausar"
+      },
+      "selfcheck_start": {
+        "name": "Iniciar autocomprobación"
+      },
+      "start": {
+        "name": "Iniciar"
+      },
+      "stop": {
+        "name": "Detener"
+      }
+    },
+    "climate": {
+      "airconditioner": {
+        "name": "Aire acondicionado"
+      }
+    },
+    "fan": {
+      "air_purifier_fan": {
+        "name": "Ventilador del purificador de aire"
+      }
+    },
+    "number": {
+      "cook_time": {
+        "name": "Tiempo de cocción"
+      },
+      "delay_start_hours": {
+        "name": "Inicio diferido"
+      },
+      "dispense_capacity": {
+        "name": "Capacidad de dosificación"
+      },
+      "good_sleep": {
+        "name": "Sueño reparador"
+      },
+      "instance_setpoint": {
+        "name": "Punto de ajuste de {instance_name}"
+      },
+      "oven_setpoint": {
+        "name": "Punto de ajuste"
+      },
+      "setpoint": {
+        "name": "Punto de ajuste"
+      },
+      "sound_volume": {
+        "name": "Volumen del sonido"
+      },
+      "target_humidity": {
+        "name": "Humedad objetivo"
+      },
+      "tropical_night_mode": {
+        "name": "Modo noche tropical"
+      }
+    },
+    "select": {
+      "ai_energy_level": {
+        "name": "Nivel del modo de energía IA"
+      },
+      "air_filter_threshold": {
+        "name": "Umbral de alarma del filtro"
+      },
+      "beverage_zone_mode": {
+        "name": "Modo de zona de bebidas",
+        "state": {
+          "sp_ttype_beer_drinks": "Bebidas",
+          "sp_ttype_wine_dessert": "Vino y postres"
+        }
+      },
+      "brightness_level": {
+        "name": "Brillo nocturno",
+        "state": {
+          "33": "Bajo",
+          "66": "Medio",
+          "100": "Alto"
+        }
+      },
+      "cooler_temperature_setpoint": {
+        "name": "Temperatura del enfriador"
+      },
+      "day_brightness": {
+        "name": "Brillo del armario",
+        "state": {
+          "33": "Bajo",
+          "66": "Medio",
+          "100": "Alto"
+        }
+      },
+      "buzzer_sound": {
+        "name": "Volumen",
+        "state": {
+          "Volume_Off": "Apagado",
+          "Volume_Low": "Bajo",
+          "Volume_Med": "Medio",
+          "Volume_High": "Alto"
+        }
+      },
+      "discharging_time": {
+        "name": "Tiempo de descarga",
+        "state": {
+          "1": "1 minuto",
+          "3": "3 minutos"
+        }
+      },
+      "cycle": {
+        "name": "Ciclo"
+      },
+      "detergent_quantity": {
+        "name": "Cantidad de detergente",
+        "state": {
+          "00": "Ninguna",
+          "01": "Baja",
+          "02": "Media",
+          "03": "Alta"
+        }
+      },
+      "detergent_water_hardness": {
+        "name": "Dureza del agua del detergente",
+        "state": {
+          "01": "Blanda",
+          "02": "Media",
+          "03": "Dura"
+        }
+      },
+      "dishwasher_cycle": {
+        "name": "Ciclo",
+        "state": {
+          "80": "Delicado",
+          "83": "Express 60",
+          "84": "Intenso",
+          "86": "Normal",
+          "90": "Autolimpieza",
+          "0e": "Lavado IA",
+          "07": "Prelavado intenso",
+          "8d": "Ollas y sartenes",
+          "8e": "Plástico",
+          "8f": "Cuidado del bebé"
+        }
+      },
+      "dispense_type": {
+        "name": "Tipo de dosificación"
+      },
+      "door_alert": {
+        "name": "Alarma de puerta",
+        "state": {
+          "1": "Alarma 1",
+          "2": "Alarma 2",
+          "3": "Alarma 3",
+          "4": "Alarma 4"
+        }
+      },
+      "dryer_cycle_table_03": {
+        "name": "Ciclo",
+        "state": {
+          "01": "Normal",
+          "06": "Secado por tiempo",
+          "16": "Algodón",
+          "17": "Súper velocidad",
+          "18": "Sintéticos",
+          "19": "Delicados",
+          "20": "Planchado fácil",
+          "21": "Cuidado higiénico",
+          "22": "Secado silencioso",
+          "23": "Secado rápido 35'",
+          "24": "Aire frío",
+          "25": "Aire caliente",
+          "27": "Secado por tiempo",
+          "29": "Secado IA",
+          "1a": "Lana",
+          "1b": "Ropa de cama",
+          "1c": "Toallas",
+          "1d": "Exterior",
+          "1e": "Camisas",
+          "1f": "Carga mixta"
+        }
+      },
+      "favorite_capacity": {
+        "name": "Capacidad favorita"
+      },
+      "favorite_hotwater_temperature": {
+        "name": "Temperatura de agua caliente favorita"
+      },
+      "filter_alarm_time": {
+        "name": "Intervalo de alarma del filtro",
+        "state": {
+          "180": "180 horas",
+          "300": "300 horas",
+          "500": "500 horas",
+          "700": "700 horas"
+        }
+      },
+      "finish_sound": {
+        "name": "Alarma de fin de ciclo",
+        "state": {
+          "Finish Sound_1": "Beyond The Horizon",
+          "Finish Sound_2": "Beyond The Horizon - Corto",
+          "Finish Sound_3": "La Trucha de Schubert"
+        }
+      },
+      "flex_zone_mode": {
+        "name": "Modo de zona flexible",
+        "state": {
+          "cv_ttype_rf9000a_freeze": "Congelar",
+          "cv_ttype_rf9000a_softfreeze": "Congelación suave",
+          "cv_ttype_rf9000a_meat_fish": "Carne/Pescado",
+          "cv_ttype_rf9000a_fruit_veggies": "Fruta y verduras",
+          "cv_ttype_rf9000a_beverage": "Bebidas",
+          "cv_fdr_wine": "Vino",
+          "cv_fdr_deli": "Charcutería",
+          "cv_fdr_beverage": "Bebidas",
+          "cv_fdr_meat": "Carne",
+          "cv_fdr_soft_freezer": "Congelador suave"
+        }
+      },
+      "heated_dry": {
+        "name": "Secado inteligente",
+        "state": {
+          "off": "Desactivado",
+          "low": "Bajo",
+          "high": "Alto",
+          "extra_high": "Extra alto"
+        }
+      },
+      "hot_water_temperature": {
+        "name": "Temperatura del agua caliente"
+      },
+      "ice_type": {
+        "name": "Tipo de hielo de {instance_name}",
+        "state": {
+          "off": "Desactivado",
+          "whiskey_iceball_3": "3 bolas/día",
+          "whiskey_iceball_6": "6 bolas/día",
+          "whiskey_iceball_9": "9 bolas/día"
+        }
+      },
+      "led_brightness": {
+        "name": "Brillo del LED de la puerta",
+        "state": {
+          "low": "Bajo",
+          "high": "Alto"
+        }
+      },
+      "led_night_brightness": {
+        "name": "Brillo nocturno del LED de la puerta",
+        "state": {
+          "low": "Bajo",
+          "high": "Alto"
+        }
+      },
+      "cooking_mode": {
+        "name": "Modo de cocción",
+        "state": {
+          "no_operation": "Sin operación",
+          "micro_wave": "Microondas",
+          "micro_wave_grill": "Microondas + grill",
+          "micro_wave_convection": "Microondas + convección",
+          "convection": "Convección",
+          "air_fryer": "Freidora de aire",
+          "grill": "Grill",
+          "autocook": "Cocción automática",
+          "autocook_custom": "Cocción automática (personalizada)",
+          "deodorization": "Desodorizar",
+          "keep_warm": "Mantener caliente"
+        }
+      },
+      "oven_mode": {
+        "name": "Modo de cocción",
+        "state": {
+          "no_operation": "Sin operación",
+          "bake": "Hornear",
+          "broil": "Gratinar",
+          "convection": "Convección",
+          "convection_bake": "Hornear por convección",
+          "convection_broil": "Gratinar por convección",
+          "frozen_pizza_plus": "Pizza congelada+",
+          "slow_cook": "Cocción lenta",
+          "plate_warm": "Calentar platos",
+          "air_fry": "Freidora de aire"
+        }
+      },
+      "operating_mode": {
+        "name": "Modo de funcionamiento"
+      },
+      "kimchi_zone_mode": {
+        "name": "Modo de almacenamiento de {instance_name}",
+        "state": {
+          "off": "Desactivado",
+          "kimchi_storage_normal": "Kimchi",
+          "kimchi_storage_cold": "Kimchi, fuerte",
+          "kimchi_storage_warm": "Kimchi, suave",
+          "kimchi_storage_low_salt_normal": "Kimchi bajo en sal",
+          "kimchi_storage_low_salt_cold": "Kimchi bajo en sal, fuerte",
+          "kimchi_storage_low_salt_warm": "Kimchi bajo en sal, suave",
+          "kimchi_storage_crunfch": "Kimchi crujiente",
+          "kimchi_storage_buy": "Kimchi comprado",
+          "storage_fridge_normal": "Frigorífico",
+          "storage_fridge_cold": "Frigorífico, fuerte",
+          "storage_fridge_warm": "Frigorífico, suave",
+          "storage_freezer_normal": "Congelador",
+          "storage_freezer_cold": "Congelador, fuerte",
+          "storage_freezer_warm": "Congelador, suave",
+          "kimchi_ripe_low_temp": "Maduración kimchi, baja temperatura",
+          "kimchi_ripe_normal_temp": "Maduración kimchi, temperatura ambiente",
+          "kimchi_ripe_kkakdugi": "Maduración kkakdugi",
+          "kimchi_ripe_dongchimi": "Maduración dongchimi",
+          "meat_ripe_normal": "Maduración de carne",
+          "storage_meat": "Carne y pescado",
+          "storage_fridge_vegetables_fruit": "Fruta y verduras",
+          "storage_fresh_cereal": "Cereales",
+          "storage_fridge_drink": "Bebidas",
+          "storage_fresh_wine": "Vino",
+          "storage_fresh_potato_banana": "Patata y plátano"
+        }
+      },
+      "pantry_zone_mode": {
+        "name": "Modo de zona de despensa",
+        "state": {
+          "fdr_wine": "Vino",
+          "fdr_deli": "Charcutería",
+          "fdr_drinks": "Bebidas"
+        }
+      },
+      "range_burner_power_level": {
+        "name": "Nivel de potencia del fuego {number}",
+        "state": {
+          "0": "Apagado",
+          "boost": "Impulso",
+          "simmer": "Fuego lento"
+        }
+      },
+      "range_hood_lamp_brightness": {
+        "name": "Brillo de la lámpara",
+        "state": {
+          "1": "Nivel 1",
+          "2": "Nivel 2"
+        }
+      },
+      "rinse_cycles": {
+        "name": "Aclarados"
+      },
+      "softener_concentration": {
+        "name": "Concentración del suavizante",
+        "state": {
+          "01": "1x",
+          "02": "2x",
+          "03": "3x"
+        }
+      },
+      "softener_quantity": {
+        "name": "Cantidad de suavizante",
+        "state": {
+          "00": "Ninguna",
+          "01": "Baja",
+          "02": "Media",
+          "03": "Alta"
+        }
+      },
+      "sound_mode": {
+        "name": "Modo de sonido",
+        "state": {
+          "voice": "Voz",
+          "tone": "Tono",
+          "mute": "Silencio"
+        }
+      },
+      "air_purifier_sound_mode": {
+        "name": "Modo de sonido",
+        "state": {
+          "mute": "Silencio",
+          "buzzer": "Zumbador"
+        }
+      },
+      "water_purifier_sound_mode": {
+        "name": "Modo de sonido",
+        "state": {
+          "voice": "Voz",
+          "fixedtone": "Tono fijo",
+          "mute": "Silencio"
+        }
+      },
+      "spin_speed": {
+        "name": "Velocidad de centrifugado",
+        "state": {
+          "rinse_hold": "Solo aclarado",
+          "no_spin": "Sin centrifugado",
+          "low": "Baja",
+          "medium": "Media",
+          "high": "Alta"
+        }
+      },
+      "wash_temperature": {
+        "name": "Temperatura del agua",
+        "state": {
+          "none": "Ninguna",
+          "cold": "Frío",
+          "cool": "Fresca",
+          "warm": "Tibia",
+          "hot": "Caliente",
+          "extra_hot": "Muy caliente"
+        }
+      },
+      "washer_cycle_table_02": {
+        "name": "Ciclo",
+        "state": {
+          "01": "Normal",
+          "04": "Lavado rápido",
+          "17": "Descargado",
+          "1b": "Algodón",
+          "1c": "Eco 40-60",
+          "1d": "Súper velocidad",
+          "1e": "Lavado rápido 15'",
+          "1f": "Frío intenso",
+          "20": "Higiene",
+          "21": "Color",
+          "22": "Lana",
+          "23": "Exterior",
+          "24": "Toallas",
+          "25": "Sintéticos",
+          "26": "Delicados",
+          "27": "Aclarar + Centrifugar",
+          "28": "Solo centrifugar",
+          "29": "Limpieza de Tambor+",
+          "2a": "Vaqueros",
+          "2b": "Lavado IA",
+          "2d": "Lavado silencioso",
+          "2e": "Cuidado del bebé",
+          "2f": "Ropa deportiva",
+          "30": "Día nublado",
+          "32": "Camisas",
+          "33": "Ropa de cama",
+          "34": "Mezcla",
+          "36": "Lavado + Secado",
+          "37": "Lavado con aire",
+          "38": "Secado de algodón",
+          "39": "Secado de sintéticos",
+          "3a": "Limpieza de Tambor",
+          "52": "Eco frío",
+          "53": "Servicio intensivo",
+          "54": "Toallas",
+          "55": "Ropa deportiva",
+          "57": "Delicado",
+          "5e": "Aclarar + Centrifugar",
+          "60": "Autolimpieza+",
+          "65": "Color",
+          "66": "Denim",
+          "7c": "Blancos",
+          "7d": "Ropa de cama / Impermeable",
+          "7e": "Autolimpieza",
+          "7f": "Lana / Delicados",
+          "86": "Lavado profundo",
+          "87": "Descarga de Programas",
+          "8f": "Lavado en frío",
+          "96": "Menos microfibras",
+          "08": "Aclarar + Centrifugar",
+          "74": "Limpieza de Tambor",
+          "06": "Ropa de cama",
+          "A0": "Rápido 15'"
+        }
+      },
+      "washer_dry_level": {
+        "name": "Nivel de secado",
+        "state": {
+          "30": "30 min",
+          "60": "1 hora",
+          "90": "1 h 30",
+          "120": "2 horas",
+          "180": "3 horas",
+          "240": "4 horas",
+          "none": "Desactivado",
+          "cupboard": "Armario"
+        }
+      }
+    },
+    "sensor": {
+      "after_run_progress": {
+        "name": "Progreso tras finalizar"
+      },
+      "air_filter_usage": {
+        "name": "Uso del filtro"
+      },
+      "air_filter_usage_hours": {
+        "name": "Horas de uso del filtro"
+      },
+      "air_quality_standard": {
+        "name": "Estándar de calidad del aire"
+      },
+      "air_sensing_state": {
+        "name": "Estado de detección de aire"
+      },
+      "alarm_code": {
+        "name": "Código de alarma"
+      },
+      "auto_ventilation_action": {
+        "name": "Acción de ventilación automática"
+      },
+      "automatic_ventilation_state": {
+        "name": "Estado de ventilación automática"
+      },
+      "battery": {
+        "name": "Batería"
+      },
+      "burner_state": {
+        "name": "Estado del fuego {number}"
+      },
+      "clean_level": {
+        "name": "Nivel de limpieza"
+      },
+      "co2": {
+        "name": "CO2"
+      },
+      "coffee_brew_status": {
+        "name": "Estado de preparación de café"
+      },
+      "connection_mode": {
+        "name": "Modo de conexión",
+        "state": {
+          "observe": "Push (observación)",
+          "poll": "Sondeo"
+        }
+      },
+      "cooktop_running_state": {
+        "name": "Estado de funcionamiento de la placa"
+      },
+      "cooktop_state": {
+        "name": "Estado de la placa"
+      },
+      "current_limit_level": {
+        "name": "Nivel de límite de corriente"
+      },
+      "filter_time": {
+        "name": "Tiempo de filtro"
+      },
+      "hepa_filter_usage": {
+        "name": "Uso del filtro HEPA"
+      },
+      "outdoor_temperature": {
+        "name": "Temperatura exterior"
+      },
+      "odor_controller_progress": {
+        "name": "Progreso del controlador de olores"
+      },
+      "panel_status": {
+        "name": "Estado del panel"
+      },
+      "sound_output": {
+        "name": "Salida de sonido"
+      },
+      "dustbag_usage": {
+        "name": "Uso de la bolsa de polvo"
+      },
+      "cleanstation_status": {
+        "name": "Estado de la estación de limpieza"
+      },
+      "stick_status": {
+        "name": "Estado de la aspiradora"
+      },
+      "uvc_operation_time": {
+        "name": "Tiempo de funcionamiento UV-C"
+      },
+      "uvc_total_operation_time": {
+        "name": "Tiempo total de funcionamiento UV-C"
+      },
+      "uvc_finished_time": {
+        "name": "Tiempo de finalización UV-C"
+      },
+      "uvc_emitted_time": {
+        "name": "Tiempo emitido UV-C"
+      },
+      "overload_protection_mode": {
+        "name": "Modo de protección contra sobrecarga",
+        "state": {
+          "alarm": "Alarma",
+          "powersaving": "Ahorro de energía"
+        }
+      },
+      "absence_power_saving_mode": {
+        "name": "Modo de ahorro por ausencia",
+        "state": {
+          "eco": "Eco",
+          "normal": "Normal",
+          "comfort": "Confort"
+        }
+      },
+      "motion_detect_wind_mode": {
+        "name": "Modo de viento por detección de movimiento",
+        "state": {
+          "direct": "Directo",
+          "indirect": "Indirecto"
+        }
+      },
+      "current_temp_c": {
+        "name": "Temperatura"
+      },
+      "current_temperature_c": {
+        "name": "Temperatura"
+      },
+      "diagnosis": {
+        "name": "Diagnóstico"
+      },
+      "diagnosis_status": {
+        "name": "Estado del diagnóstico"
+      },
+      "drum_clean_cycles_remaining": {
+        "name": "Limpieza de tambor en"
+      },
+      "drum_clean_last_cleaned": {
+        "name": "Última limpieza del tambor"
+      },
+      "dry_level": {
+        "name": "Nivel de secado"
+      },
+      "dry_time": {
+        "name": "Tiempo de secado"
+      },
+      "dryer_type": {
+        "name": "Tipo de secadora"
+      },
+      "dust": {
+        "name": "Polvo"
+      },
+      "energy_kwh": {
+        "name": "Energía"
+      },
+      "energy_last_month_kwh": {
+        "name": "Energía (último mes)"
+      },
+      "energy_saved_kwh": {
+        "name": "Energía ahorrada"
+      },
+      "energy_this_month_kwh": {
+        "name": "Energía (este mes)"
+      },
+      "fan_direction": {
+        "name": "Dirección del ventilador"
+      },
+      "fan_speed_level": {
+        "name": "Nivel de velocidad del ventilador"
+      },
+      "filter_clean_remain_time": {
+        "name": "Tiempo restante de limpieza del filtro"
+      },
+      "filter_progress": {
+        "name": "Progreso del filtro"
+      },
+      "filter_usage": {
+        "name": "Uso del filtro"
+      },
+      "fine_dust": {
+        "name": "Polvo fino"
+      },
+      "finish_time": {
+        "name": "Finalización estimada"
+      },
+      "completion_minutes": {
+        "name": "Tiempo de finalización"
+      },
+      "freezer_temperature": {
+        "name": "Temperatura del congelador"
+      },
+      "fridge_temperature": {
+        "name": "Temperatura del frigorífico"
+      },
+      "kimchi_ripening_status": {
+        "name": "Estado de fermentación de {instance_name}"
+      },
+      "kimchi_ripening_remaining": {
+        "name": "Tiempo restante de fermentación de {instance_name}"
+      },
+      "kimchi_rack_count": {
+        "name": "Número de bandejas de {instance_name}"
+      },
+      "hood_filter_capacity": {
+        "name": "Capacidad del filtro"
+      },
+      "humidity": {
+        "name": "Humedad"
+      },
+      "hood_filter_usage": {
+        "name": "Uso del filtro"
+      },
+      "instance_temperature": {
+        "name": "Temperatura de {instance_name}"
+      },
+      "job_beginning_status": {
+        "name": "Estado de inicio del ciclo"
+      },
+      "last_air_sensing_level": {
+        "name": "Último nivel de detección de aire"
+      },
+      "last_air_sensing_time": {
+        "name": "Última hora de detección de aire"
+      },
+      "main_timer_current": {
+        "name": "Valor actual del temporizador"
+      },
+      "main_timer_state": {
+        "name": "Estado del temporizador"
+      },
+      "odor": {
+        "name": "Olor"
+      },
+      "operating_mode": {
+        "name": "Modo de funcionamiento"
+      },
+      "operation_origin": {
+        "name": "Última fuente de operación"
+      },
+      "operation_time_minutes": {
+        "name": "Tiempo de funcionamiento"
+      },
+      "oven_state": {
+        "name": "Estado de la cavidad"
+      },
+      "cavity_state": {
+        "name": "Estado de la cavidad"
+      },
+      "power_level": {
+        "name": "Nivel de potencia"
+      },
+      "paired_hood_fan_speed": {
+        "name": "Velocidad del ventilador de la campana emparejada"
+      },
+      "paired_hood_firmware": {
+        "name": "Firmware de la campana emparejada"
+      },
+      "paired_hood_model": {
+        "name": "Modelo de la campana emparejada"
+      },
+      "power_energy_kwh": {
+        "name": "Energía"
+      },
+      "power_watts": {
+        "name": "Potencia"
+      },
+      "probe_battery": {
+        "name": "Batería de la sonda"
+      },
+      "probe_target_temperature": {
+        "name": "Temperatura objetivo de la sonda"
+      },
+      "probe_temperature": {
+        "name": "Temperatura de la sonda"
+      },
+      "progress": {
+        "name": "Progreso"
+      },
+      "progress_percentage": {
+        "name": "Porcentaje de progreso"
+      },
+      "selfcheck_error": {
+        "name": "Error de autocomprobación"
+      },
+      "selfcheck_result": {
+        "name": "Resultado de autocomprobación"
+      },
+      "selfcheck_status": {
+        "name": "Estado de autocomprobación"
+      },
+      "sterilize_last_time": {
+        "name": "Última esterilización"
+      },
+      "sterilize_period": {
+        "name": "Período de esterilización"
+      },
+      "sterilize_plan_time": {
+        "name": "Hora de esterilización planificada"
+      },
+      "sterilize_run_time": {
+        "name": "Tiempo de esterilización"
+      },
+      "super_fine_dust": {
+        "name": "Polvo ultrafino"
+      },
+      "warming_center_state": {
+        "name": "Estado del centro de calentamiento"
+      },
+      "water_liters": {
+        "name": "Consumo de agua"
+      },
+      "waterpurifier_status": {
+        "name": "Estado"
+      },
+      "cup_state": {
+        "name": "Estado de la taza"
+      },
+      "last_pour_type": {
+        "name": "Último tipo de servicio"
+      },
+      "last_pour_capacity": {
+        "name": "Última capacidad servida"
+      },
+      "machine_state": {
+        "name": "Estado de la máquina",
+        "state": {
+          "idle": "Inactiva",
+          "active": "Activa",
+          "pause": "En pausa"
+        }
+      },
+      "filter_status": {
+        "name": "Estado del filtro",
+        "state": {
+          "normal": "Normal",
+          "wash": "Lavar",
+          "replace": "Reemplazar"
+        }
+      },
+      "ice_making_status": {
+        "name": "Estado de fabricación de hielo de {instance_name}",
+        "state": {
+          "icestatus_stop": "Inactiva",
+          "icestatus_run": "Haciendo hielo"
+        }
+      }
+    },
+    "switch": {
+      "ai_energy_level": {
+        "name": "Modo de energía IA"
+      },
+      "air_monitoring": {
+        "name": "Monitorización de aire"
+      },
+      "air_purify": {
+        "name": "Purificación de aire"
+      },
+      "auto_clean": {
+        "name": "Limpieza automática"
+      },
+      "absence_power_saving_active": {
+        "name": "Ahorro por ausencia activo"
+      },
+      "motion_detect_wind_active": {
+        "name": "Evitación de viento por detección de movimiento activa"
+      },
+      "beep": {
+        "name": "Pitido"
+      },
+      "display": {
+        "name": "Pantalla"
+      },
+      "pet_filter_activation": {
+        "name": "Activación de filtro para mascotas"
+      },
+      "auto_empty": {
+        "name": "Autovaciado"
+      },
+      "dustbin_auto_close": {
+        "name": "Cierre automático del depósito"
+      },
+      "spi": {
+        "name": "Ion purificador"
+      },
+      "uvc_intensive_mode": {
+        "name": "Modo intensivo UV-C"
+      },
+      "auto_door_opener": {
+        "name": "Apertura automática de puerta"
+      },
+      "auto_release_dry": {
+        "name": "Liberación automática de secado"
+      },
+      "autofill": {
+        "name": "Jarra de llenado automático"
+      },
+      "bubble_soak": {
+        "name": "Baño de burbujas"
+      },
+      "buzz_lock": {
+        "name": "Bloqueo del zumbador"
+      },
+      "cabinet_light_dim": {
+        "name": "Aumento gradual de brillo"
+      },
+      "cabinet_light_switch": {
+        "name": "Luz del armario"
+      },
+      "child_lock": {
+        "name": "Bloqueo infantil"
+      },
+      "coldwater_lock": {
+        "name": "Bloqueo de agua fría"
+      },
+      "cooktop_child_lock": {
+        "name": "Bloqueo infantil"
+      },
+      "defrost_delay": {
+        "name": "Retardo de descongelación"
+      },
+      "display_light": {
+        "name": "Luz de la pantalla"
+      },
+      "dnd": {
+        "name": "No molestar"
+      },
+      "fast_preheat": {
+        "name": "Precalentamiento rápido"
+      },
+      "favorite_capacity_enabled": {
+        "name": "Capacidad favorita"
+      },
+      "favorite_coffee_enabled": {
+        "name": "Café favorito"
+      },
+      "filter_remind": {
+        "name": "Recordatorio de filtro"
+      },
+      "fridge_sound": {
+        "name": "Sonido"
+      },
+      "hotwater_lock": {
+        "name": "Bloqueo de agua caliente"
+      },
+      "ice_maker_enabled": {
+        "name": "Máquina de hielo"
+      },
+      "ice_night_mode": {
+        "name": "Modo silencioso de hielo nocturno"
+      },
+      "instance_enabled": {
+        "name": "{instance_name} habilitado"
+      },
+      "intensive": {
+        "name": "Intensivo"
+      },
+      "lamp": {
+        "name": "Lámpara"
+      },
+      "led_night_light": {
+        "name": "Luz nocturna del LED de la puerta"
+      },
+      "mute_once": {
+        "name": "Silenciar una vez"
+      },
+      "natural_steam": {
+        "name": "Vapor natural"
+      },
+      "energy_saving": {
+        "name": "Ahorro de energía"
+      },
+      "cooktop_on_alert": {
+        "name": "Alerta de placa encendida"
+      },
+      "power_switch": {
+        "name": "Energía"
+      },
+      "pre_wash": {
+        "name": "Prelavado"
+      },
+      "rapid_freezing": {
+        "name": "Congelación rápida"
+      },
+      "rapid_fridge": {
+        "name": "Frío rápido"
+      },
+      "remind_beep": {
+        "name": "Recordatorio de señal de fin"
+      },
+      "sabbath_mode": {
+        "name": "Modo sábado"
+      },
+      "sanitize": {
+        "name": "Desinfección"
+      },
+      "sound": {
+        "name": "Sonido"
+      },
+      "storm_wash": {
+        "name": "Lavado Tormenta+"
+      },
+      "welcome_lighting": {
+        "name": "Iluminación de bienvenida"
+      },
+      "wrinkle_prevent": {
+        "name": "Anti-arrugas"
+      }
+    },
+    "time": {
+      "dnd_end": {
+        "name": "Fin de no molestar"
+      },
+      "dnd_start": {
+        "name": "Inicio de no molestar"
+      },
+      "led_night_end": {
+        "name": "Fin de la luz nocturna de la puerta"
+      },
+      "led_night_start": {
+        "name": "Inicio de la luz nocturna de la puerta"
+      },
+      "night_end": {
+        "name": "Fin de la luz nocturna"
+      },
+      "night_start": {
+        "name": "Inicio de la luz nocturna"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Adds a complete Spanish translation (`translations/es.json`) for LocalThings: **257 entity names** across all platforms (binary_sensor, button, climate, fan, number, select, sensor, switch, time) plus the full UI strings (config flow, options, issues, exceptions).

### Transparency disclosure
This translation was **AI-assisted (Hermes Agent)** and **reviewed and verified by the repository owner** (Àxel) against the official Samsung SmartThings app on real hardware (washer DA_WM_TP1_21_COMMON). No code was generated — only translation files.

### Washer verification (hardware-tested)
The wash cycle table (`washer_cycle_table_02`) was verified one-by-one against the official app:
- All cycles shown in the catalog match the app names (Cotton, Eco 40-60, Synthetics, Hygiene, etc.)
- **4 cycle codes were missing from the catalog and added** from real hardware: `08` (Rinse+Spin), `74` (Drum Clean+), `06` (Bedding), `A0` (15' Quick Wash)
- Washer options verified: Volume (Apagado/Bajo/Medio/Alto), Finish alarm (Beyond The Horizon, Beyond The Horizon - Corto, La Trucha de Schubert), Bubble soak (Baño de burbujas)

### Other appliances
Fridges, dishwashers, ovens, dryers, etc. are translated from the existing English catalog but **not hardware-tested**. Please review those if you have the hardware.

### Notes
- Spanish language code: `es`
- Follows the same structure as `en.json` / `nl.json` / `cs.json`
- Happy to adjust any wording to match Samsung's official Spanish terminology
