### PR TITLE
Report whether the auto-clean cycle is running, and how far through

### DIFF
--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -742,6 +742,25 @@ AUTO_CLEAN = Capability(
                    write_fn=lambda p, rep, href=None: (
                        ['option', 'autoclean', 'vs', '0'],
                        {'x.com.samsung.da.settingStatus': 'On' if p == 'On' else 'Off'})),
+        # The cycle, as opposed to the switch above -- `settingStatus` says the
+        # feature is enabled, which it is whether or not the unit is drying right
+        # now. `status` is the run state, and the resource advertises exactly
+        # Start/Stop in `supportedStatus`. Observed on a TP1X_DA-AC-CAC-01001:
+        # 'Start' with progress 98 while a cycle ran, then 'Stop' with progress 0
+        # the moment it finished.
+        BinarySensorDesc(key='auto_clean_running',
+                         field='x.com.samsung.da.status',
+                         icon='mdi:spray-bottle',
+                         entity_category='diagnostic',
+                         value_fn=lambda v: v == 'Start'),
+        # Percent through that cycle, matching the figure the appliance shows on
+        # its own display (checked against 55% mid-run).
+        SensorDesc(key='auto_clean_progress',
+                   field='x.com.samsung.da.progress',
+                   icon='mdi:progress-clock',
+                   unit='%', state_class='measurement',
+                   entity_category='diagnostic',
+                   value_fn=common.int_or_none),
     ),
 )
 

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -1,6 +1,9 @@
 {
   "entity": {
     "binary_sensor": {
+      "auto_clean_running": {
+        "name": "Automatické čištění probíhá"
+      },
       "after_run_active": {
         "name": "Dosoušení aktivní"
       },
@@ -615,6 +618,9 @@
       }
     },
     "sensor": {
+      "auto_clean_progress": {
+        "name": "Průběh automatického čištění"
+      },
       "after_run_progress": {
         "name": "Průběh dosoušení"
       },

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -1,6 +1,9 @@
 {
   "entity": {
     "binary_sensor": {
+      "auto_clean_running": {
+        "name": "Auto clean running"
+      },
       "after_run_active": {
         "name": "After run active"
       },
@@ -615,6 +618,9 @@
       }
     },
     "sensor": {
+      "auto_clean_progress": {
+        "name": "Auto clean progress"
+      },
       "after_run_progress": {
         "name": "After run progress"
       },

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -1,6 +1,9 @@
 {
   "entity": {
     "binary_sensor": {
+      "auto_clean_running": {
+        "name": "Auto clean actief"
+      },
       "after_run_active": {
         "name": "Nadraaien actief"
       },
@@ -615,6 +618,9 @@
       }
     },
     "sensor": {
+      "auto_clean_progress": {
+        "name": "Auto clean voortgang"
+      },
       "after_run_progress": {
         "name": "Voortgang nadraaien"
       },

--- a/tests/fixtures/golden/airconditioner.json
+++ b/tests/fixtures/golden/airconditioner.json
@@ -6,6 +6,8 @@
     "air_purify",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "clean_level",
     "climate",

--- a/tests/fixtures/golden/airconditioner_ara_ww_tp1_22.json
+++ b/tests/fixtures/golden/airconditioner_ara_ww_tp1_22.json
@@ -5,6 +5,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_cac.json
+++ b/tests/fixtures/golden/airconditioner_cac.json
@@ -8,6 +8,8 @@
     "air_purify",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "clean_level",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_caww_tp2.json
+++ b/tests/fixtures/golden/airconditioner_caww_tp2.json
@@ -5,6 +5,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_fac_bora.json
+++ b/tests/fixtures/golden/airconditioner_fac_bora.json
@@ -6,6 +6,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_fac_bora_205_flat.json
+++ b/tests/fixtures/golden/airconditioner_fac_bora_205_flat.json
@@ -6,6 +6,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_fac_bora_2in1.json
+++ b/tests/fixtures/golden/airconditioner_fac_bora_2in1.json
@@ -6,6 +6,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_lnx_rac_heatpump.json
+++ b/tests/fixtures/golden/airconditioner_lnx_rac_heatpump.json
@@ -7,6 +7,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_tp1x_da_ac_rac_01011.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_da_ac_rac_01011.json
@@ -7,6 +7,8 @@
     "air_purify",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "clean_level",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac.json
@@ -7,6 +7,8 @@
     "air_purify",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_limit_enabled",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_01001.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_01001.json
@@ -5,6 +5,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_coolonly.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_coolonly.json
@@ -5,6 +5,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_odor_controller.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_odor_controller.json
@@ -7,6 +7,8 @@
     "air_purify",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_limit_enabled",

--- a/tests/fixtures/golden/airconditioner_tp2x_rac_20k.json
+++ b/tests/fixtures/golden/airconditioner_tp2x_rac_20k.json
@@ -5,6 +5,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_windfree.json
+++ b/tests/fixtures/golden/airconditioner_windfree.json
@@ -6,6 +6,8 @@
     "air_purify",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "clean_level",
     "climate",

--- a/tests/fixtures/golden/airconditioner_windfree_oscillation.json
+++ b/tests/fixtures/golden/airconditioner_windfree_oscillation.json
@@ -6,6 +6,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_window_ac.json
+++ b/tests/fixtures/golden/airconditioner_window_ac.json
@@ -5,6 +5,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/dehumidifier.json
+++ b/tests/fixtures/golden/dehumidifier.json
@@ -6,6 +6,8 @@
     "air_filter_usage_hours",
     "alarm_code",
     "auto_clean",
+    "auto_clean_progress",
+    "auto_clean_running",
     "energy_kwh",
     "energy_saved_kwh",
     "firmware_update",


### PR DESCRIPTION
`/option/autoclean/vs/0` carries three fields and only `settingStatus` is read today. That one says the feature is *enabled* — which it is whether or not the unit is drying right now — so nothing reports an actual cycle.

```
settingStatus: On      <- the existing auto_clean switch
status:        Stop    supportedStatus: [Start, Stop]
progress:      0
```

This adds a binary sensor for `status` and a percentage sensor for `progress`.

### Measured

On a `TP1X_DA-AC-CAC-01001`, sampling the resource every eight seconds across a cycle:

| | `status` | `progress` |
|---|---|---|
| mid-cycle | `Start` | `98` |
| the moment it finished | `Stop` | `0` |

The percentage matches the figure the appliance shows on its own display — checked against 55% part-way through, reported by the owner watching both at once.

### Notes

- Golden state keys updated for the 18 fixtures that bind `AUTO_CLEAN`. Additive only; no key was removed from any of them.
- Translations added for `en`, `nl` and `cs`. `cs.json` is CRLF in this repo, and the patch preserves that — worth knowing, since a JSON round-trip silently rewrites the whole file.
- **Not** included: `/selfcheck/vs/0` has the same `status`/`progress` shape and `SELF_CHECK` already maps `status`, `result` and `error` but not `progress`. I have only ever seen that field at `0` on this hardware — no self-check has run — so I have not mapped it here. Happy to add it if you have a dump with one in progress.

Full suite passes: **1070 tests**, Python 3.13 via `requirements-dev.txt`.

Context: same hardware as #230. I maintain a Homey port of this integration ([moKorean/com.lomohome.localthings](https://github.com/moKorean/com.lomohome.localthings)).