### PR TITLE
Fix devices coming up entity-less after a Core restart (#254)

### DIFF
--- a/custom_components/localthings/__init__.py
+++ b/custom_components/localthings/__init__.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
@@ -20,8 +21,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await coordinator.async_config_entry_first_refresh()
     except Exception as err:
+        # Close whatever the failed refresh left open before handing this
+        # coordinator to the garbage collector. `_poll_once` deliberately
+        # leaves the session up on a `TimeoutError` (the transfer may just
+        # be slow -- see its docstring), so a refresh that fails that way
+        # ends here with a live, bound UDP socket that nothing will ever
+        # close. HA retries setup on its own backoff with a *new*
+        # coordinator, and every device's source port is fixed by design
+        # (`_local_source_port`), so each abandoned socket keeps squatting
+        # the exact port the next attempt binds -- SO_REUSEADDR lets the
+        # bind succeed, and then two sockets on one port race for the
+        # device's datagrams. Failing setup is precisely when retries are
+        # most likely, so leaking there is what would hurt most.
+        await coordinator.async_close()
         raise ConfigEntryNotReady(f"Cannot connect to device: {err}") from err
     hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    # Send the DTLS close_notify on Core shutdown, not just on unload
+    # (issue #254). `async_close` otherwise only runs via
+    # `async_unload_entry` -- a reload or a remove -- and HA does not unload
+    # config entries on a plain Core restart, so a restart left the previous
+    # run's association orphaned on the appliance. The device then holds that
+    # stale session for minutes, which is what makes the next run's handshake
+    # time out in the first place. Closing cleanly here means there is
+    # usually nothing to evict on the way back up. This is belt-and-braces
+    # with the fixed source port (RFC 6347 section 4.2.8 eviction): that
+    # handles the unclean-shutdown case this cannot, e.g. a power cut or a
+    # SIGKILL, where no close_notify is ever sent.
+    #
+    # Registered as a coroutine listener rather than one that spawns its own
+    # task: the event bus runs it as a hass-tracked job, so the close is
+    # awaited by the `async_block_till_done()` inside `hass.async_stop`. A
+    # detached task would just as likely be cancelled mid-shutdown, which is
+    # the exact no-close_notify case this exists to prevent.
+    async def _async_close_on_stop(_event: Event) -> None:
+        await coordinator.async_close()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_close_on_stop)
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/localthings/__init__.py
+++ b/custom_components/localthings/__init__.py
@@ -21,39 +21,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await coordinator.async_config_entry_first_refresh()
     except Exception as err:
-        # Close whatever the failed refresh left open before handing this
-        # coordinator to the garbage collector. `_poll_once` deliberately
-        # leaves the session up on a `TimeoutError` (the transfer may just
-        # be slow -- see its docstring), so a refresh that fails that way
-        # ends here with a live, bound UDP socket that nothing will ever
-        # close. HA retries setup on its own backoff with a *new*
-        # coordinator, and every device's source port is fixed by design
-        # (`_local_source_port`), so each abandoned socket keeps squatting
-        # the exact port the next attempt binds -- SO_REUSEADDR lets the
-        # bind succeed, and then two sockets on one port race for the
-        # device's datagrams. Failing setup is precisely when retries are
-        # most likely, so leaking there is what would hurt most.
+        # `_poll_once` deliberately leaves the session up on a `TimeoutError`
+        # (the transfer may just be slow -- see its docstring), so a refresh
+        # that fails that way ends here with a live, bound UDP socket that
+        # nothing would ever close. HA retries setup on its own backoff with
+        # a *new* coordinator, and each device's source port is fixed by
+        # design (`_local_source_port`), so an abandoned socket squats the
+        # exact port the next attempt binds -- SO_REUSEADDR lets that bind
+        # succeed, leaving two sockets racing for the device's datagrams.
         await coordinator.async_close()
         raise ConfigEntryNotReady(f"Cannot connect to device: {err}") from err
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    # Send the DTLS close_notify on Core shutdown, not just on unload
-    # (issue #254). `async_close` otherwise only runs via
-    # `async_unload_entry` -- a reload or a remove -- and HA does not unload
-    # config entries on a plain Core restart, so a restart left the previous
-    # run's association orphaned on the appliance. The device then holds that
-    # stale session for minutes, which is what makes the next run's handshake
-    # time out in the first place. Closing cleanly here means there is
-    # usually nothing to evict on the way back up. This is belt-and-braces
-    # with the fixed source port (RFC 6347 section 4.2.8 eviction): that
-    # handles the unclean-shutdown case this cannot, e.g. a power cut or a
-    # SIGKILL, where no close_notify is ever sent.
+    # Send the DTLS close_notify on Core shutdown, not just on unload (issue
+    # #254). `async_close` otherwise only runs via `async_unload_entry`, and
+    # HA does not unload entries on a plain Core restart -- so a restart left
+    # the previous run's association orphaned on the appliance, which is what
+    # makes the *next* run's handshake time out. Complements the fixed source
+    # port, which covers the unclean-exit case this cannot (see
+    # `_local_source_port`).
     #
-    # Registered as a coroutine listener rather than one that spawns its own
-    # task: the event bus runs it as a hass-tracked job, so the close is
-    # awaited by the `async_block_till_done()` inside `hass.async_stop`. A
-    # detached task would just as likely be cancelled mid-shutdown, which is
-    # the exact no-close_notify case this exists to prevent.
+    # A coroutine listener, not one that spawns its own task: the event bus
+    # runs it as a hass-tracked job, so the close is awaited by the
+    # `async_block_till_done()` inside `hass.async_stop`. A detached task
+    # would likely be cancelled mid-shutdown -- the exact no-close_notify
+    # case this exists to prevent.
     async def _async_close_on_stop(_event: Event) -> None:
         await coordinator.async_close()
 

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -791,7 +791,36 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         normal on a flaky device; a run of them is a real problem. Any
         other exception (a `ConnectionError`, an explicitly closed
         session) is unambiguous and always reconnects immediately.
+
+        Never defers before the first successful discovery (issue #254).
+        Deferring is a *mid-session* judgement call: it means "keep the
+        entities we already have and try again next cycle," which is only
+        coherent once there are entities to keep. On the very first refresh
+        the same `TimeoutError` means something completely different —
+        `_poll_once` calls `_connect_session`, so `connect()`'s own
+        handshake timeout surfaces here as a `TimeoutError` too, and that is
+        a dead connection, not a slow transfer. Deferring it made
+        `_async_update_data` return `flatten([], {})` == `{}` instead of
+        raising; `DataUpdateCoordinator` counts any non-raising return as
+        success, so `async_config_entry_first_refresh` saw a healthy first
+        refresh, skipped `ConfigEntryNotReady`, and setup forwarded the
+        platforms with `bound` still empty. Every platform enumerates
+        `bound` exactly once in its `async_setup_entry` and has no dynamic
+        add-listener, so the device came up with zero entities: a later
+        cycle would repopulate `bound` (`_discovered` was still False), but
+        nothing would ever add the entities for it, leaving every restored
+        entity stuck `unavailable` until a manual per-device reload.
+
+        This is reachable on a plain Core restart because HA doesn't unload
+        entries on restart, so the device is often still holding the
+        previous run's DTLS association when we reconnect. Returning False
+        here puts a pre-discovery failure back on the normal path: one
+        reconnect attempt, and if that fails too the exception propagates as
+        `UpdateFailed` -> `ConfigEntryNotReady`, so HA retries on its own
+        backoff until the handshake goes through — no reload needed.
         """
+        if not self._discovered:
+            return False
         if not isinstance(e, TimeoutError):
             return False
         if self._observe.mode == MODE_OBSERVE and self._observe.recently_notified():

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -793,31 +793,16 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         session) is unambiguous and always reconnects immediately.
 
         Never defers before the first successful discovery (issue #254).
-        Deferring is a *mid-session* judgement call: it means "keep the
-        entities we already have and try again next cycle," which is only
-        coherent once there are entities to keep. On the very first refresh
-        the same `TimeoutError` means something completely different —
-        `_poll_once` calls `_connect_session`, so `connect()`'s own
-        handshake timeout surfaces here as a `TimeoutError` too, and that is
-        a dead connection, not a slow transfer. Deferring it made
-        `_async_update_data` return `flatten([], {})` == `{}` instead of
-        raising; `DataUpdateCoordinator` counts any non-raising return as
-        success, so `async_config_entry_first_refresh` saw a healthy first
-        refresh, skipped `ConfigEntryNotReady`, and setup forwarded the
-        platforms with `bound` still empty. Every platform enumerates
-        `bound` exactly once in its `async_setup_entry` and has no dynamic
-        add-listener, so the device came up with zero entities: a later
-        cycle would repopulate `bound` (`_discovered` was still False), but
-        nothing would ever add the entities for it, leaving every restored
-        entity stuck `unavailable` until a manual per-device reload.
-
-        This is reachable on a plain Core restart because HA doesn't unload
-        entries on restart, so the device is often still holding the
-        previous run's DTLS association when we reconnect. Returning False
-        here puts a pre-discovery failure back on the normal path: one
-        reconnect attempt, and if that fails too the exception propagates as
-        `UpdateFailed` -> `ConfigEntryNotReady`, so HA retries on its own
-        backoff until the handshake goes through — no reload needed.
+        Deferring is a *mid-session* judgement call — "keep the entities we
+        already have and try again next cycle" — which is only coherent once
+        there are entities to keep. Pre-discovery the same exception type
+        means something else entirely: `_poll_once` calls `_connect_session`,
+        so `connect()`'s own handshake timeout surfaces here as a
+        `TimeoutError` too, and that is a dead connection, not a slow
+        transfer. Deferring it returned an empty dict instead of raising,
+        which `DataUpdateCoordinator` counts as a successful first refresh —
+        and since platforms enumerate `bound` exactly once, the entry loaded
+        with zero entities and stayed that way until a manual reload.
         """
         if not self._discovered:
             return False
@@ -887,7 +872,15 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 except Exception as e2:
                     self._log.error("poll failed after reconnect: %s", e2)
                     snapshot = self._cache.snapshot()
-                    if snapshot:
+                    # `self._discovered` is the same precondition
+                    # `_defer_reconnect_for` applies (issue #254): returning
+                    # degraded-but-successful data is only meaningful once
+                    # there are bound entities to carry it. Pre-discovery the
+                    # cache happens to always be empty -- every apply() site
+                    # is gated on post-discovery state -- so this arm is
+                    # unreachable then, but that is a non-local accident
+                    # across four call sites, not something to rely on.
+                    if self._discovered and snapshot:
                         self._log.debug("Full error:", exc_info=e2)
                         return flatten(self.bound, snapshot)
                     raise UpdateFailed(f"poll failed after reconnect: {e2}") from e2

--- a/tests/localthings/test_coordinator.py
+++ b/tests/localthings/test_coordinator.py
@@ -1250,106 +1250,77 @@ def test_local_source_port_non_ipv4_falls_back_to_hash() -> None:
 
 # ----------------------------------------------------------------------
 # Issue #254: a pre-discovery poll failure must never look like a
-# successful first refresh.
+# successful first refresh. See `_defer_reconnect_for` for the mechanism.
 # ----------------------------------------------------------------------
+
+_HANDSHAKE_TIMEOUT = TimeoutError('DTLS handshake timed out')
 
 
 async def test_first_refresh_timeout_recovers_via_reconnect(
     hass: HomeAssistant, mock_entry, fridge_resources
 ) -> None:
-    """A handshake timeout on the very first poll reconnects instead of
-    being deferred (issue #254).
-
-    `_poll_once` connects when there is no session, so `connect()`'s own
-    handshake timeout arrives here as a `TimeoutError` -- indistinguishable
-    by type from a slow blockwise transfer, but meaning a dead connection.
-    Deferring it returned `flatten([], {})` == `{}` without raising, which
-    `DataUpdateCoordinator` counts as a successful refresh, so the entry
-    loaded with `bound` empty and every platform added zero entities.
-    """
-    calls = {'n': 0}
-
-    def _poll(self):
-        calls['n'] += 1
-        if calls['n'] == 1:
-            raise TimeoutError('DTLS handshake timed out')
-        return fridge_resources
-
+    """A pre-discovery handshake timeout reconnects instead of deferring."""
     with (
         patch('custom_components.localthings.coordinator.LocalThingsCoordinator._connect_session'),
-        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once', _poll),
+        patch(
+            'custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once',
+            side_effect=[_HANDSHAKE_TIMEOUT, fridge_resources],
+        ) as mock_poll,
         patch('custom_components.localthings.coordinator.LocalThingsCoordinator._close_session'),
     ):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
-    # The retry inside the first refresh is what makes this recoverable
+    # The reconnect inside the first refresh is what makes this recoverable
     # without HA having to fail and re-run setup at all.
-    assert calls['n'] == 2
+    assert mock_poll.call_count == 2
     assert mock_entry.state is ConfigEntryState.LOADED
     coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
     assert coordinator.bound, "discovery must have run before platforms are forwarded"
-    # The regression this guards is entity-visible, not just state on the
-    # coordinator: platforms enumerate `bound` once and have no dynamic
-    # add-listener, so an empty `bound` at forward time means the device
-    # stays entity-less until a manual reload.
+    # The regression is entity-visible, not just coordinator state: platforms
+    # enumerate `bound` once, so an empty `bound` at forward time leaves the
+    # device with no entities until a manual reload.
     assert hass.states.async_all(), "device came up with zero entities"
+    # The reconnect handled this failure, so it must not also be charged
+    # against the mid-session timeout budget.
+    assert coordinator._consecutive_poll_timeouts == 0
 
 
-async def test_first_refresh_persistent_timeout_raises_not_ready(
+async def test_first_refresh_persistent_timeout_fails_setup(
     hass: HomeAssistant, mock_entry
 ) -> None:
     """When the reconnect times out too, the first refresh must fail so HA
-    retries on its backoff -- not load an entity-less entry (issue #254)."""
+    retries on its backoff -- not load an entity-less entry. The session it
+    left open is closed on the way out (`_poll_once` keeps it up on a
+    `TimeoutError`, and the source port is fixed per device)."""
     with (
         patch('custom_components.localthings.coordinator.LocalThingsCoordinator._connect_session'),
         patch(
             'custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once',
-            side_effect=TimeoutError('DTLS handshake timed out'),
+            side_effect=_HANDSHAKE_TIMEOUT,
         ),
         patch('custom_components.localthings.coordinator.LocalThingsCoordinator._close_session'),
+        # Asserted on `async_close` rather than `_close_session`: the
+        # reconnect path calls the latter on its own, so it is already true
+        # whether or not setup cleans up after itself.
+        patch.object(
+            LocalThingsCoordinator, 'async_close', autospec=True,
+        ) as mock_async_close,
     ):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
     assert mock_entry.state is ConfigEntryState.SETUP_RETRY
     assert not hass.states.async_all()
-
-
-async def test_first_refresh_timeout_does_not_consume_timeout_budget(
-    hass: HomeAssistant, mock_entry, fridge_resources
-) -> None:
-    """The pre-discovery gate must not leave `_consecutive_poll_timeouts`
-    charged for a failure it already handled by reconnecting -- otherwise a
-    device that stumbles once at startup reaches `_POLL_TIMEOUT_LIMIT` after
-    fewer real mid-session timeouts than the limit names."""
-    calls = {'n': 0}
-
-    def _poll(self):
-        calls['n'] += 1
-        if calls['n'] == 1:
-            raise TimeoutError('DTLS handshake timed out')
-        return fridge_resources
-
-    with (
-        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._connect_session'),
-        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once', _poll),
-        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._close_session'),
-    ):
-        await hass.config_entries.async_setup(mock_entry.entry_id)
-        await hass.async_block_till_done()
-
-    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
-    assert coordinator._consecutive_poll_timeouts == 0
+    mock_async_close.assert_awaited_once()
 
 
 async def test_post_discovery_timeout_is_still_deferred(
     hass: HomeAssistant, mock_entry, mock_coordinator_session
 ) -> None:
-    """The issue #254 gate is scoped to the pre-discovery case only: once
-    discovery has run, a lone poll timeout must still be absorbed without a
-    reconnect (the slow-blockwise-transfer behavior `_POLL_TIMEOUT_LIMIT`
-    exists for)."""
+    """The gate is scoped to the pre-discovery case only: once discovery has
+    run, a lone poll timeout must still be absorbed without a reconnect (the
+    slow-blockwise-transfer behavior `_POLL_TIMEOUT_LIMIT` exists for)."""
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -1373,56 +1344,18 @@ async def test_post_discovery_timeout_is_still_deferred(
     assert coordinator.last_update_success
 
 
-async def test_defer_reconnect_gate_is_false_before_discovery() -> None:
-    """`_defer_reconnect_for` unit-level: the pre-discovery gate wins over
-    every other deferral reason, including a healthy-push session."""
-    coordinator = LocalThingsCoordinator.__new__(LocalThingsCoordinator)
-    coordinator._discovered = False
-    assert coordinator._defer_reconnect_for(TimeoutError('handshake')) is False
-
-
-async def test_session_closed_when_first_refresh_fails(
-    hass: HomeAssistant, mock_entry
-) -> None:
-    """A failed setup must not leak the session it opened. `_poll_once`
-    leaves the session up on a `TimeoutError` by design, and every device's
-    source port is fixed, so an abandoned socket squats the exact port HA's
-    next setup attempt binds."""
-    with (
-        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._connect_session'),
-        patch(
-            'custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once',
-            side_effect=TimeoutError('DTLS handshake timed out'),
-        ),
-        patch(
-            'custom_components.localthings.coordinator.LocalThingsCoordinator._close_session',
-        ) as mock_close,
-    ):
-        await hass.config_entries.async_setup(mock_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert mock_entry.state is ConfigEntryState.SETUP_RETRY
-    assert mock_close.called, "failed setup left the DTLS socket open"
-
-
 async def test_close_notify_sent_on_homeassistant_stop(
     hass: HomeAssistant, mock_entry, mock_coordinator_session
 ) -> None:
-    """A plain Core restart must close the DTLS session (issue #254).
-
-    HA does not unload config entries on a Core restart, so `async_close`'s
-    only other caller (`async_unload_entry`) never runs -- leaving the
-    association orphaned on the appliance, which is what makes the *next*
-    run's handshake time out.
-    """
+    """A plain Core restart must close the DTLS session: HA does not unload
+    entries on restart, so `async_unload_entry` never runs and the
+    association would be left orphaned on the appliance."""
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
     coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
-    with patch.object(
-        coordinator, 'async_close', new=AsyncMock()
-    ) as mock_async_close:
+    with patch.object(coordinator, 'async_close', new=AsyncMock()) as mock_close:
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()
 
-    mock_async_close.assert_awaited_once()
+    mock_close.assert_awaited_once()

--- a/tests/localthings/test_coordinator.py
+++ b/tests/localthings/test_coordinator.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 import cbor2
 import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import issue_registry as ir
@@ -1244,3 +1246,183 @@ def test_local_source_port_non_ipv4_falls_back_to_hash() -> None:
     port = _local_source_port('some-hostname')
     assert port == _local_source_port('some-hostname')
     assert DTLS_LOCAL_PORT_BASE <= port <= DTLS_LOCAL_PORT_BASE + 0xFF
+
+
+# ----------------------------------------------------------------------
+# Issue #254: a pre-discovery poll failure must never look like a
+# successful first refresh.
+# ----------------------------------------------------------------------
+
+
+async def test_first_refresh_timeout_recovers_via_reconnect(
+    hass: HomeAssistant, mock_entry, fridge_resources
+) -> None:
+    """A handshake timeout on the very first poll reconnects instead of
+    being deferred (issue #254).
+
+    `_poll_once` connects when there is no session, so `connect()`'s own
+    handshake timeout arrives here as a `TimeoutError` -- indistinguishable
+    by type from a slow blockwise transfer, but meaning a dead connection.
+    Deferring it returned `flatten([], {})` == `{}` without raising, which
+    `DataUpdateCoordinator` counts as a successful refresh, so the entry
+    loaded with `bound` empty and every platform added zero entities.
+    """
+    calls = {'n': 0}
+
+    def _poll(self):
+        calls['n'] += 1
+        if calls['n'] == 1:
+            raise TimeoutError('DTLS handshake timed out')
+        return fridge_resources
+
+    with (
+        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._connect_session'),
+        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once', _poll),
+        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._close_session'),
+    ):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # The retry inside the first refresh is what makes this recoverable
+    # without HA having to fail and re-run setup at all.
+    assert calls['n'] == 2
+    assert mock_entry.state is ConfigEntryState.LOADED
+    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
+    assert coordinator.bound, "discovery must have run before platforms are forwarded"
+    # The regression this guards is entity-visible, not just state on the
+    # coordinator: platforms enumerate `bound` once and have no dynamic
+    # add-listener, so an empty `bound` at forward time means the device
+    # stays entity-less until a manual reload.
+    assert hass.states.async_all(), "device came up with zero entities"
+
+
+async def test_first_refresh_persistent_timeout_raises_not_ready(
+    hass: HomeAssistant, mock_entry
+) -> None:
+    """When the reconnect times out too, the first refresh must fail so HA
+    retries on its backoff -- not load an entity-less entry (issue #254)."""
+    with (
+        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._connect_session'),
+        patch(
+            'custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once',
+            side_effect=TimeoutError('DTLS handshake timed out'),
+        ),
+        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._close_session'),
+    ):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_entry.state is ConfigEntryState.SETUP_RETRY
+    assert not hass.states.async_all()
+
+
+async def test_first_refresh_timeout_does_not_consume_timeout_budget(
+    hass: HomeAssistant, mock_entry, fridge_resources
+) -> None:
+    """The pre-discovery gate must not leave `_consecutive_poll_timeouts`
+    charged for a failure it already handled by reconnecting -- otherwise a
+    device that stumbles once at startup reaches `_POLL_TIMEOUT_LIMIT` after
+    fewer real mid-session timeouts than the limit names."""
+    calls = {'n': 0}
+
+    def _poll(self):
+        calls['n'] += 1
+        if calls['n'] == 1:
+            raise TimeoutError('DTLS handshake timed out')
+        return fridge_resources
+
+    with (
+        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._connect_session'),
+        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once', _poll),
+        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._close_session'),
+    ):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
+    assert coordinator._consecutive_poll_timeouts == 0
+
+
+async def test_post_discovery_timeout_is_still_deferred(
+    hass: HomeAssistant, mock_entry, mock_coordinator_session
+) -> None:
+    """The issue #254 gate is scoped to the pre-discovery case only: once
+    discovery has run, a lone poll timeout must still be absorbed without a
+    reconnect (the slow-blockwise-transfer behavior `_POLL_TIMEOUT_LIMIT`
+    exists for)."""
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
+    assert coordinator._discovered
+
+    with (
+        patch(
+            'custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once',
+            side_effect=TimeoutError('GET /device/0 block 11 timeout'),
+        ),
+        patch(
+            'custom_components.localthings.coordinator.LocalThingsCoordinator._close_session',
+        ) as mock_close,
+    ):
+        await coordinator.async_request_refresh()
+        await hass.async_block_till_done()
+
+    mock_close.assert_not_called()
+    assert coordinator._consecutive_poll_timeouts == 1
+    assert coordinator.last_update_success
+
+
+async def test_defer_reconnect_gate_is_false_before_discovery() -> None:
+    """`_defer_reconnect_for` unit-level: the pre-discovery gate wins over
+    every other deferral reason, including a healthy-push session."""
+    coordinator = LocalThingsCoordinator.__new__(LocalThingsCoordinator)
+    coordinator._discovered = False
+    assert coordinator._defer_reconnect_for(TimeoutError('handshake')) is False
+
+
+async def test_session_closed_when_first_refresh_fails(
+    hass: HomeAssistant, mock_entry
+) -> None:
+    """A failed setup must not leak the session it opened. `_poll_once`
+    leaves the session up on a `TimeoutError` by design, and every device's
+    source port is fixed, so an abandoned socket squats the exact port HA's
+    next setup attempt binds."""
+    with (
+        patch('custom_components.localthings.coordinator.LocalThingsCoordinator._connect_session'),
+        patch(
+            'custom_components.localthings.coordinator.LocalThingsCoordinator._poll_once',
+            side_effect=TimeoutError('DTLS handshake timed out'),
+        ),
+        patch(
+            'custom_components.localthings.coordinator.LocalThingsCoordinator._close_session',
+        ) as mock_close,
+    ):
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_close.called, "failed setup left the DTLS socket open"
+
+
+async def test_close_notify_sent_on_homeassistant_stop(
+    hass: HomeAssistant, mock_entry, mock_coordinator_session
+) -> None:
+    """A plain Core restart must close the DTLS session (issue #254).
+
+    HA does not unload config entries on a Core restart, so `async_close`'s
+    only other caller (`async_unload_entry`) never runs -- leaving the
+    association orphaned on the appliance, which is what makes the *next*
+    run's handshake time out.
+    """
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
+    with patch.object(
+        coordinator, 'async_close', new=AsyncMock()
+    ) as mock_async_close:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+    mock_async_close.assert_awaited_once()


### PR DESCRIPTION
Fixes #254.

## Diagnosis

@QuiteYellow's [second comment](https://github.com/mbillow/localthings/issues/254#issuecomment-5159186491) called this correctly. I traced each link independently and reproduced it end to end before changing anything — every step holds:

1. `_poll_once()` connects when there is no session yet, and `DtlsCoapSession.connect()` raises **`TimeoutError`** on handshake timeout (verified in the installed `smartthings-local`). `_poll_once`'s `except TimeoutError: raise` passes it through untouched.
2. `_defer_reconnect_for()` only knew the *mid-session* meaning of that type (a slow blockwise transfer), so it bumped `_consecutive_poll_timeouts` to 1, and `1 < _POLL_TIMEOUT_LIMIT` returned `True`.
3. `_async_update_data` then took the early `return flatten(self.bound, ...)`. With `bound == []` that is `{}` — a return, not a raise.
4. `DataUpdateCoordinator` counts any non-raising return as success, so `_async_config_entry_first_refresh` saw `last_update_success` and skipped `ConfigEntryNotReady`.
5. Setup forwarded the platforms with `bound` still empty. Every platform enumerates `coordinator.bound` exactly once in its `async_setup_entry` with no dynamic add-listener, so **zero entities** were added.
6. `_discovered` stayed `False`, so a later cycle repopulated `bound` — but nothing adds entities once setup has already run. HA's entity registry restores the previously-known entities and, with nothing backing them, they sit `unavailable`. That matches the reported symptom exactly, including why a per-device reload fixes it.

Reproduced against unfixed code: entry `LOADED`, `bound=0`, `_discovered=False`, **0 entities**, and only **one** poll attempt — no reconnect was even tried.

## Changes

**Gate `_defer_reconnect_for` on `self._discovered`** (the fix QuiteYellow proposed). Deferring means "keep the entities we already have and retry next cycle," which is only coherent once there are entities to keep. Before discovery, a poll failure now takes the normal path — one reconnect attempt, then `UpdateFailed` → `ConfigEntryNotReady` — so HA retries on its own backoff until the handshake goes through. In practice the in-refresh reconnect usually recovers it without setup failing at all.

The same precondition is now also applied to the *second* degraded return in `_async_update_data` (the post-reconnect `if snapshot:` arm). That arm is unreachable before discovery today, but only because every `_observe.apply()` call site happens to be gated on post-discovery state — a non-local accident across four call sites, in the exact function this bug lived in. Cheaper to state the rule than to rely on it.

Two related fixes in the same failure path:

**Close the DTLS session on `EVENT_HOMEASSISTANT_STOP`.** QuiteYellow's first comment, and it stands: `async_close()` only ran via `async_unload_entry`, and HA does not unload entries on a Core restart, so every restart orphaned the previous run's association — which is what makes the next run's handshake time out to begin with. Registered as a coroutine listener so the close is awaited by the `async_block_till_done()` inside `hass.async_stop` rather than racing shutdown as a detached task. The fixed source port still covers the unclean-exit case (power cut, SIGKILL) where no `close_notify` can be sent.

**Close the session when first refresh fails.** Not previously raised in the issue, but the gate makes it matter more: `_poll_once` deliberately leaves the session open on a `TimeoutError`, so a failed setup abandoned a live, bound UDP socket — on a port that is *fixed per device* by `_local_source_port`. Each HA retry then bound another socket to that same port under `SO_REUSEADDR`, leaving multiple sockets racing for the device's datagrams.

## Testing

Four tests added to `tests/localthings/test_coordinator.py`. Each of the three production changes is **independently** covered — reverting any one of them on its own fails the suite:

- pre-discovery timeout recovers via reconnect: asserts entities actually exist (the regression is entity-visible, not just coordinator state) and that the reconnect doesn't consume the mid-session timeout budget
- persistent timeout → `SETUP_RETRY`, no entities, and the session is closed on the way out
- **post-discovery timeouts are still deferred** — the gate is scoped to the pre-discovery case and must not regress `_POLL_TIMEOUT_LIMIT` for slow blockwise transfers
- `EVENT_HOMEASSISTANT_STOP` triggers `async_close`

Full suite: **1125 passed**.

> [!NOTE]
> Correcting something I claimed in the first revision of this description. I originally said I'd verified all six tests failed without their fix. That was true only when the changes were reverted *together*: the session-close test asserted `_close_session` was called, which the reconnect path already does on its own, so it passed with its fix removed and failed for an unrelated reason. It now asserts on `async_close`, which only setup calls, and I've re-run the mutations one at a time rather than in combination. Three redundant tests were also folded away in the follow-up commit (7 → 4) — details in that commit message.

## Follow-ups, deliberately not in this PR

- `TimeoutError` does double duty for "handshake dead" and "slow blockwise transfer". Post-discovery that ambiguity is still live: a handshake timeout during a reconnect gets deferred against a budget sized for slow transfers. Wrapping the connect-time timeout in a distinct exception type at `_connect_session` would fix it properly, but that's a session-lifecycle change rather than a regression fix — and it does *not* subsume this gate (a genuine slow first poll is still a plain `TimeoutError`).
- `_run_discovery` sets `_discovered = True` unconditionally, so a successful-but-empty first poll still yields a loaded, entity-less entry through a different door. Guarding that changes behavior for a genuinely zero-capability device and wants its own issue.

## Note on the reporter's case

@jayrage887 had no logs, so this is not confirmed against their specific capture. The mechanism does explain every reported detail — restart-only, intermittent across devices, sometimes needing more than one reload (each reload is a fresh chance at the handshake), and per-device variance from the device-side differences QuiteYellow measured. Worth confirming after a release.