### PR TITLE
feat(airconditioner): stop a running auto clean, and read its progress

### DIFF
--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -20,6 +20,7 @@ from dataclasses import replace
 from ..capability import Capability
 from ..entities import (
     BinarySensorDesc,
+    ButtonDesc,
     ClimateDesc,
     NumberDesc,
     SelectDesc,
@@ -622,6 +623,45 @@ CLIMATE = Capability(
             write_fn=_option_switch_write("Autoclean"),
             icon="mdi:fan-auto",
             entity_category="config",
+        ),
+        # A drying cycle the unit runs after cooling, to keep the coil from going
+        # mouldy. Three tokens describe it and the switch above only covered the
+        # first: Autoclean_ is the setting, AutocleanProgress_ is how far a
+        # running cycle has got, and StopAutoClean_ is a channel for ending one
+        # early -- its presence is what says the appliance takes that at all
+        # (the app gates its own stop button on exactly that), and the value it
+        # reports while nothing is running is Idle.
+        #
+        # The percentage scale is the app's own: `<progress max="100">` with the
+        # token rendered as "{{value}}%" beside it. An idle unit here reports 1
+        # rather than 0, the same floor the laundry firmware's progressPercentage
+        # sits at when Ready, so 0-vs-1 is not a reliable "is it running" test --
+        # which is why the button below is not gated on it.
+        #
+        # The sensor shares AUTO_CLEAN's catalog entry, like auto_clean_legacy
+        # above: same figure, different board generation. Distinct key, so
+        # nothing collides if a board ever reported both.
+        SensorDesc(
+            key="auto_clean_progress_legacy",
+            translation_key="auto_clean_progress",
+            rep_fn=_option_token_num("AutocleanProgress"),
+            exists_fn=_has_option_token("AutocleanProgress"),
+            unit="%",
+            state_class="measurement",
+            icon="mdi:progress-check",
+            entity_category="diagnostic",
+        ),
+        ButtonDesc(
+            key="auto_clean_stop",
+            field="",
+            payload="StopAutoClean_Set",
+            icon="mdi:fan-off",
+            entity_category="config",
+            exists_fn=_has_option_token("StopAutoClean"),
+            write_fn=lambda p, rep, href=None: (
+                ["mode", "vs", "0"],
+                {"x.com.samsung.da.options": [p]},
+            ),
         ),
         SwitchDesc(
             key="air_monitoring",

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -117,6 +117,9 @@
       "diagnosis_start": {
         "name": "Spustit diagnostiku"
       },
+      "auto_clean_stop": {
+        "name": "Zastavit samočištění"
+      },
       "pause": {
         "name": "Pozastavit"
       },

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -117,6 +117,9 @@
       "diagnosis_start": {
         "name": "Start diagnosis"
       },
+      "auto_clean_stop": {
+        "name": "Stop auto clean"
+      },
       "pause": {
         "name": "Pause"
       },

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -239,6 +239,9 @@
       "diagnosis_start": {
         "name": "Iniciar diagnóstico"
       },
+      "auto_clean_stop": {
+        "name": "Detener la autolimpieza"
+      },
       "pause": {
         "name": "Pausar"
       },

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -117,6 +117,9 @@
       "diagnosis_start": {
         "name": "Avvia diagnosi"
       },
+      "auto_clean_stop": {
+        "name": "Arresta autopulizia"
+      },
       "pause": {
         "name": "Pausa"
       },

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -117,6 +117,9 @@
       "diagnosis_start": {
         "name": "Diagnose starten"
       },
+      "auto_clean_stop": {
+        "name": "Zelfreiniging stoppen"
+      },
       "pause": {
         "name": "Pauzeren"
       },

--- a/tests/fixtures/golden/airconditioner_artik051_dongle_fac_18k.json
+++ b/tests/fixtures/golden/airconditioner_artik051_dongle_fac_18k.json
@@ -2,6 +2,7 @@
   "state_keys": [
     "alarm_code",
     "auto_clean_legacy",
+    "auto_clean_progress_legacy",
     "beep",
     "clean_level",
     "climate",
@@ -18,6 +19,7 @@
     "super_fine_dust",
     "subdevice1_alarm_code",
     "subdevice1_auto_clean_legacy",
+    "subdevice1_auto_clean_progress_legacy",
     "subdevice1_beep",
     "subdevice1_climate",
     "subdevice1_current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_artik051_krac_18k.json
+++ b/tests/fixtures/golden/airconditioner_artik051_krac_18k.json
@@ -3,6 +3,7 @@
     "air_monitoring",
     "alarm_code",
     "auto_clean_legacy",
+    "auto_clean_progress_legacy",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_artik051_krac_18k_slot.json
+++ b/tests/fixtures/golden/airconditioner_artik051_krac_18k_slot.json
@@ -3,6 +3,7 @@
     "air_monitoring",
     "alarm_code",
     "auto_clean_legacy",
+    "auto_clean_progress_legacy",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/fixtures/golden/airconditioner_artik051_krac_energy.json
+++ b/tests/fixtures/golden/airconditioner_artik051_krac_energy.json
@@ -3,6 +3,7 @@
     "air_monitoring",
     "alarm_code",
     "auto_clean_legacy",
+    "auto_clean_progress_legacy",
     "beep",
     "climate",
     "current_temperature_c",

--- a/tests/test_airconditioner_artik051_krac.py
+++ b/tests/test_airconditioner_artik051_krac.py
@@ -235,6 +235,32 @@ def test_filter_alarm_time_reads_the_threshold_and_writes_one_token():
     )
 
 
+def test_auto_clean_progress_and_stop_come_off_their_own_tokens():
+    """Three tokens describe the drying cycle and the switch only covered the
+    first. AutocleanProgress_ is a percentage -- the app renders it into a
+    `<progress max="100">` beside a "{{value}}%" label -- and StopAutoClean_ is
+    the channel for ending a cycle early, whose presence is what says the
+    appliance accepts that at all (the fixture reports Idle, this unit's
+    resting value)."""
+    assert _state()["auto_clean_progress_legacy"] == 1.0  # the fixture's own value
+
+    desc = _desc(_load_device(FIXTURE), "auto_clean_stop")
+    assert desc is not None
+    assert desc.write_fn(desc.payload, {}) == (
+        ["mode", "vs", "0"],
+        {"x.com.samsung.da.options": ["StopAutoClean_Set"]},
+    )
+
+
+def test_auto_clean_stop_stays_off_boards_without_the_token():
+    """Newer boards run the same cycle off /option/autoclean/vs/0 and say
+    nothing about stopping it, so writing a legacy token there would be a
+    guess."""
+    newer = _load_device("airconditioner_tp1x_rac")
+    assert _desc(newer, "auto_clean_stop") is None
+    assert "auto_clean_progress_legacy" not in _state("airconditioner_tp1x_rac")
+
+
 def test_filter_alarm_time_stays_off_boards_with_a_real_threshold_resource():
     """Newer boards carry air_filter_threshold off supportedFilterDesiredUsage;
     two thresholds on one device would be a coin flip for the user.


### PR DESCRIPTION
The drying cycle these boards run after cooling is described by three `options[]` tokens, and the existing switch only covers the first. This adds the other two: how far a running cycle has got, and a way to end one early.

*Disclosure, as in #146, #168 and #289: this account is @perseus177's — he owns the appliances and reads everything before it goes out — but the measuring and the writing here are Claude Code's.*

| token | what it is | this unit reports |
|---|---|---|
| `Autoclean_On/Off` | the setting — already a switch | `Autoclean_Off` |
| `AutocleanProgress_<n>` | progress of a running cycle, **percent** | `1` idle, `0` on the sibling |
| `StopAutoClean_<state>` | the channel for ending a cycle early; **presence** is what says the appliance takes it | `StopAutoClean_Idle` |

Every KRAC fixture in the repository carries all three, including the `ARTIK051_KRAC_18K` from #136.

## Where the meanings come from

The percentage is the appliance's own app, not an inference: it renders the token into a `<progress max="100">` with a `{{value}}%` label beside it, and it gates its own stop button on `autoClean && stopAutoCleanSupported && progress !== 0`, where `stopAutoCleanSupported` is set purely by the token being present.

Two deliberate departures from what that app does:

* **The button is not gated on progress.** An entity that appears and disappears is worse than one that is occasionally a no-op, and the 0-vs-1 reading is not a reliable "is it running" test: the two units here report `1` (off, idle) and `0` (actively cooling), which is the opposite way round from what an idle floor would give.
* **The sensor shares `AUTO_CLEAN`'s catalog entry** the way `auto_clean_legacy` already shares the switch's — same figure, different board generation — so it takes a distinct key (`auto_clean_progress_legacy`) and no new string.

## Tested

The progress sensor reads on hardware (two `ARTIK051_KRAC_18K` units, deployed here for a day): `1 %` and `0 %` as above, moving with the token.

**The button's write is untested on hardware**, and I would rather say so than imply otherwise: it needs a cycle actually running, which means driving an air conditioner through a cool-then-off cycle at a time when someone wants that. The write itself is the same single-token options merge as #289's filter reset, which *is* measured (2.04 Changed, value held) — so the transport is not in question, only whether this particular token is accepted while a cycle runs. Happy to hold this until it is confirmed if you would rather not carry an unverified write.

## Overlap with #289

Both branches add `ButtonDesc` to the same import list in `airconditioner.py`, so whichever lands second needs that one line dropped. Nothing else touches the same region — #289 works near `filter_time`, this near `air_monitoring`. This branch is cut from current `main` and does not carry #289's commits.
