### PR TITLE
feat(airconditioner): say what an error code means, in the appliance's words

### DIFF
--- a/custom_components/localthings/registry/by_type/airconditioner.py
+++ b/custom_components/localthings/registry/by_type/airconditioner.py
@@ -14,6 +14,10 @@ every other AC family, so this registry needs two mutually-exclusive variants
 of that one capability instead of the single shared one every other registry
 uses unconditionally.
 
+common.ALARMS is swapped the same way, for ALARMS_WITH_MESSAGE -- the alarm
+code sensor is shared with every other family, and the added sensor that turns
+an air-conditioner error code into its message is not.
+
 Reuses dishwasher.DIAGNOSIS for /diagnosis/vs/0.
 """
 
@@ -25,7 +29,12 @@ REGISTRY = DeviceRegistry(
     capabilities=_build(
         [
             *ignored.IGNORED,
-            *[c for c in common.UNIVERSAL if c is not common.ENERGY_METER],
+            *[
+                c
+                for c in common.UNIVERSAL
+                if c is not common.ENERGY_METER and c is not common.ALARMS
+            ],
+            airconditioner.ALARMS_WITH_MESSAGE,
             airconditioner.ENERGY_METER_GENERIC,
             airconditioner.ENERGY_METER_LEGACY,
             dishwasher.DIAGNOSIS,

--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -266,6 +266,113 @@ def _legacy_cumulative_power_kwh(v):
     return round(n / 100000.0, 2)
 
 
+# ---------------------------------------------------------------------------
+# What an error code means, in the appliance's own words.
+#
+# /alarms/vs/0 carries the code as `ErrorCode_<code>`, and common.ALARMS surfaces
+# it verbatim -- useful for an automation, useless for a person: "E464" says
+# nothing. The appliance's own app resolves it against a catalog of 45 codes
+# (RACMOB_error_message_<code>_result in its language file, reached by taking the
+# part after the underscore and lower-casing it, exactly as below).
+#
+# The English strings here are Samsung's own, quoted from that catalog rather
+# than rewritten, so what Home Assistant shows is what the appliance's app would
+# have shown. They stay in English regardless of the user's language: they are
+# the message, not a label, and translating them here would mean inventing
+# wording the appliance never used.
+#
+# A code outside this table becomes the code itself rather than nothing -- the
+# table is what one app build knew, and an unrecognised code is still the thing a
+# service call will ask for.
+_ERROR_MESSAGES = {
+    "E101": "Indoor unit communication reception error",
+    "E121": "Short circuit or open circuit of the indoor temperature sensor",
+    "E122": "A short or open circuit of the Eva-in sensor of the indoor unit",
+    "E123": "A short or open circuit of the Eva-MID sensor of the indoor unit",
+    "E154": "Indoor fan error",
+    "E162": "EEPROM error",
+    "E163": "EEPROM option setting error",
+    "E201": "Indoor/outdoor unit communication error",
+    "E202": "Indoor/outdoor unit communication error",
+    "E203": "Main/Inv communication error",
+    "E221": "Short circuit or open circuit of the outdoor temperature sensor",
+    "E231": "Short circuit or open circuit of the cold temperature sensor",
+    "E237": "Outdoor Cond. Out Sensor Short/Open",
+    "E251": "Short circuit or open circuit of the output temperature sensor",
+    "E320": "OLP sensor error",
+    "E403": "Trip caused by indoor freeze",
+    "E404": "Heating overload trip",
+    "E416": "Output temperature trip",
+    "E422": "Pipe blockage error",
+    "E425": "Electric current error (INV)",
+    "E440": "Heating stop at temperatures above the Start inhibit activation",
+    "E441": "Cooling stop at temperatures above the Start inhibit activation",
+    "E458": "Fan speed error (INV)",
+    "E461": "Comp starting error (INV)",
+    "E462": "Electric current trip",
+    "E463": "OLP trip",
+    "E464": "IPM Over Current (INV)",
+    "E465": "Compressor overload protection (INV)",
+    "E466": "DC-link voltage under/over error (INV)",
+    "E467": "Comp rotation error (INV)",
+    "E468": "Current sensor error (INV)",
+    "E469": "DC-link voltage sensor error (INV)",
+    "E470": "Outdoor unit EEPROM Read/Write Error",
+    "E471": "INV/Outdoor transmission error EEPROM",
+    "E472": "AC Line Zero Cross Signal out (INV)",
+    "E473": "Comp Lock Error (INV)",
+    "E474": "Heat sink errors (INV)",
+    "E475": "FAN2 inverter error (INV)",
+    "E483": "H/W DC Link Over detection (INV)",
+    "E484": "PFC error (INV)",
+    "E485": "Input voltage sensor error (INV)",
+    "E488": "Input voltage sensor error (INV)",
+    "E500": "Heat sink overheat error (INV)",
+    "E554": "Gas shortage error",
+    "E660": "Bootcode inverter error (INV)",
+}
+
+
+def _error_message(items):
+    """The active error's message, its bare code if unknown, or 'none'.
+
+    Reads the same rows common._active_alarm_codes does -- a row is live only
+    when its state is not Deleted and its code does not carry the '_OFF'
+    placeholder suffix -- and looks only at ErrorCode_ rows: FilterAlarm and
+    friends are reminders with their own entities, not faults with a code.
+    """
+    if not items or not isinstance(items, list):
+        return "none"
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        code = str(item.get("x.com.samsung.da.code") or "")
+        if not code.upper().startswith("ERRORCODE_"):
+            continue
+        if str(item.get("x.com.samsung.da.state", "")).lower() == "deleted":
+            continue
+        value = code.split("_", 1)[1]
+        if value.upper() in ("OFF", ""):
+            continue
+        return _ERROR_MESSAGES.get(value.upper(), value.upper())
+    return "none"
+
+
+ALARMS_WITH_MESSAGE = replace(
+    common.ALARMS,
+    entities=(
+        *common.ALARMS.entities,
+        SensorDesc(
+            key="error_message",
+            field="x.com.samsung.da.items",
+            icon="mdi:alert-circle-outline",
+            entity_category="diagnostic",
+            value_fn=_error_message,
+        ),
+    ),
+)
+
+
 ENERGY_METER_LEGACY = replace(
     common.ENERGY_METER,
     match_fn=lambda rep, resources: is_legacy_board(resources),

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -684,6 +684,9 @@
       "alarm_code": {
         "name": "Kód alarmu"
       },
+      "error_message": {
+        "name": "Chybová hláška"
+      },
       "auto_ventilation_action": {
         "name": "Akce automatického větrání"
       },

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -684,6 +684,9 @@
       "alarm_code": {
         "name": "Alarm code"
       },
+      "error_message": {
+        "name": "Error message"
+      },
       "auto_ventilation_action": {
         "name": "Auto ventilation action"
       },

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -803,6 +803,9 @@
       "alarm_code": {
         "name": "Código de alarma"
       },
+      "error_message": {
+        "name": "Mensaje de error"
+      },
       "auto_ventilation_action": {
         "name": "Acción de ventilación automática"
       },

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -684,6 +684,9 @@
       "alarm_code": {
         "name": "Codice allarme"
       },
+      "error_message": {
+        "name": "Messaggio di errore"
+      },
       "auto_ventilation_action": {
         "name": "Azione ventilazione automatica"
       },

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -684,6 +684,9 @@
       "alarm_code": {
         "name": "알람 코드"
       },
+      "error_message": {
+        "name": "오류 메시지"
+      },
       "auto_ventilation_action": {
         "name": "자동 환기 동작"
       },

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -684,6 +684,9 @@
       "alarm_code": {
         "name": "Alarmcode"
       },
+      "error_message": {
+        "name": "Foutmelding"
+      },
       "auto_ventilation_action": {
         "name": "Actie automatische ventilatie"
       },

--- a/tests/fixtures/golden/airconditioner.json
+++ b/tests/fixtures/golden/airconditioner.json
@@ -5,6 +5,7 @@
     "air_filter_usage_hours",
     "air_purify",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_ara_ww_tp1_22.json
+++ b/tests/fixtures/golden/airconditioner_ara_ww_tp1_22.json
@@ -4,6 +4,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_artik051_dongle_fac_18k.json
+++ b/tests/fixtures/golden/airconditioner_artik051_dongle_fac_18k.json
@@ -1,6 +1,7 @@
 {
   "state_keys": [
     "alarm_code",
+    "error_message",
     "auto_clean_legacy",
     "auto_clean_progress_legacy",
     "beep",
@@ -18,6 +19,7 @@
     "power_watts",
     "super_fine_dust",
     "subdevice1_alarm_code",
+    "subdevice1_error_message",
     "subdevice1_auto_clean_legacy",
     "subdevice1_auto_clean_progress_legacy",
     "subdevice1_beep",

--- a/tests/fixtures/golden/airconditioner_artik051_krac_18k.json
+++ b/tests/fixtures/golden/airconditioner_artik051_krac_18k.json
@@ -2,6 +2,7 @@
   "state_keys": [
     "air_monitoring",
     "alarm_code",
+    "error_message",
     "auto_clean_legacy",
     "auto_clean_progress_legacy",
     "beep",

--- a/tests/fixtures/golden/airconditioner_artik051_krac_18k_slot.json
+++ b/tests/fixtures/golden/airconditioner_artik051_krac_18k_slot.json
@@ -2,6 +2,7 @@
   "state_keys": [
     "air_monitoring",
     "alarm_code",
+    "error_message",
     "auto_clean_legacy",
     "auto_clean_progress_legacy",
     "beep",

--- a/tests/fixtures/golden/airconditioner_artik051_krac_energy.json
+++ b/tests/fixtures/golden/airconditioner_artik051_krac_energy.json
@@ -2,6 +2,7 @@
   "state_keys": [
     "air_monitoring",
     "alarm_code",
+    "error_message",
     "auto_clean_legacy",
     "auto_clean_progress_legacy",
     "beep",

--- a/tests/fixtures/golden/airconditioner_cac.json
+++ b/tests/fixtures/golden/airconditioner_cac.json
@@ -10,6 +10,7 @@
     "air_filter_usage_hours",
     "air_purify",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_caww_tp2.json
+++ b/tests/fixtures/golden/airconditioner_caww_tp2.json
@@ -4,6 +4,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_fac_bora.json
+++ b/tests/fixtures/golden/airconditioner_fac_bora.json
@@ -5,6 +5,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_fac_bora_205_flat.json
+++ b/tests/fixtures/golden/airconditioner_fac_bora_205_flat.json
@@ -5,6 +5,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_fac_bora_2in1.json
+++ b/tests/fixtures/golden/airconditioner_fac_bora_2in1.json
@@ -5,6 +5,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_lnx_rac_heatpump.json
+++ b/tests/fixtures/golden/airconditioner_lnx_rac_heatpump.json
@@ -6,6 +6,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_tp1x_da_ac_rac_01011.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_da_ac_rac_01011.json
@@ -6,6 +6,7 @@
     "air_filter_usage_hours",
     "air_purify",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_tp1x_fac_time_23k.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_fac_time_23k.json
@@ -6,6 +6,7 @@
     "air_filter_usage_hours",
     "air_purify",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac.json
@@ -6,6 +6,7 @@
     "air_filter_usage_hours",
     "air_purify",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_01001.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_01001.json
@@ -4,6 +4,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_coolonly.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_coolonly.json
@@ -4,6 +4,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_odor_controller.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_odor_controller.json
@@ -6,6 +6,7 @@
     "air_filter_usage_hours",
     "air_purify",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_tp2x_rac_20k.json
+++ b/tests/fixtures/golden/airconditioner_tp2x_rac_20k.json
@@ -4,6 +4,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_windfree.json
+++ b/tests/fixtures/golden/airconditioner_windfree.json
@@ -5,6 +5,7 @@
     "air_filter_usage_hours",
     "air_purify",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_windfree_oscillation.json
+++ b/tests/fixtures/golden/airconditioner_windfree_oscillation.json
@@ -5,6 +5,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/fixtures/golden/airconditioner_window_ac.json
+++ b/tests/fixtures/golden/airconditioner_window_ac.json
@@ -4,6 +4,7 @@
     "air_filter_usage",
     "air_filter_usage_hours",
     "alarm_code",
+    "error_message",
     "auto_clean",
     "auto_clean_progress",
     "auto_clean_running",

--- a/tests/test_airconditioner_artik051_krac.py
+++ b/tests/test_airconditioner_artik051_krac.py
@@ -217,6 +217,30 @@ def _desc(resources, key):
     return None
 
 
+def test_error_message_resolves_the_code_the_way_the_appliance_does():
+    """The fixture is a healthy unit -- ErrorCode_OFF / Deleted -- so the codes
+    are injected. The strings are Samsung's own, from the catalog its app reads,
+    and an unrecognised code has to fall through to the code itself rather than
+    to nothing: this table is what one app build knew, not what the appliance can
+    report."""
+    assert _state()["error_message"] == "none"
+
+    def with_alarm(code, state="Created"):
+        fresh = _load_device(FIXTURE)
+        fresh["/alarms/vs/0"]["x.com.samsung.da.items"] = [
+            {"x.com.samsung.da.code": code, "x.com.samsung.da.state": state}
+        ]
+        bound, _ = _discover(fresh)
+        return flatten(bound, fresh)["error_message"]
+
+    assert with_alarm("ErrorCode_E464") == "IPM Over Current (INV)"
+    assert with_alarm("ErrorCode_E554") == "Gas shortage error"
+    assert with_alarm("ErrorCode_E999") == "E999"
+    assert with_alarm("ErrorCode_E464", state="Deleted") == "none"
+    # Reminders are not faults: they have their own entities and no code table.
+    assert with_alarm("FilterAlarm") == "none"
+
+
 def test_filter_alarm_time_reads_the_threshold_and_writes_one_token():
     """The interval FilterTime_ is measured against, offered by the app as a
     180/300/500/700 hour radio. All four were walked on hardware while watching


### PR DESCRIPTION
`/alarms/vs/0` reports a fault as `ErrorCode_<code>` and `alarm_code` surfaces it verbatim. That is right for an automation and useless for a person: `E464` says nothing, and the code alone sends you to the manual. This adds an `error_message` sensor beside it, so the same fault reads **"IPM Over Current (INV)"**.

*Disclosure, as in #146, #168, #290 and #296: this account is @perseus177's — he owns the appliances and reads everything before it goes out — but the measuring and the writing here are Claude Code's.*

## Where the table comes from, and a call for you to make

The appliance's own app resolves the code against a catalog of 45 entries, reached by taking the part after the underscore and lower-casing it (`ErrorCode_E464` → `racmob_error_message_e464_result`). That table is what this PR adds.

**The English strings are Samsung's own, quoted rather than rewritten.** That is deliberate — Home Assistant then shows what the appliance's app would have shown, and nobody has to trust my paraphrase of what `E472` means — but it does mean 45 vendor strings land in your repository, and that is your call rather than mine. I raised it with the owner and his position is that a PR is exactly the place to decide it, so: if you would rather have wording of our own, say so and I will replace every line with mine (that is what our washer integration does for its own fault table, for the same reason).

They stay in English whatever the user's language, and only the entity's *name* is translated: the strings are the message, not a label, and rewording them per language would be inventing text the appliance never used.

## Behaviour

| the appliance reports | the sensor reads |
|---|---|
| `ErrorCode_E464`, state `Created` | `IPM Over Current (INV)` |
| `ErrorCode_E554` | `Gas shortage error` |
| a code outside the 45 (`ErrorCode_E999`) | `E999` |
| `ErrorCode_OFF`, or any `Deleted` row | `none` |
| `FilterAlarm` | `none` |

The unknown-code case is on purpose: 45 is what one app build knew, not what the firmware can report, and an unrecognised code is still the thing a service call asks for. Deleted rows and the `_OFF` placeholder are skipped, the same rows `common._active_alarm_codes` already skips. Reminders like `FilterAlarm` are left alone — they have their own entities and are not faults with a code.

## Shape

- `_ERROR_MESSAGES` plus `_error_message()` in `capabilities/airconditioner.py`.
- `common.ALARMS` swapped for `ALARMS_WITH_MESSAGE` in the AC registry, the same pattern `ENERGY_METER` already uses there, so the shared `alarm_code` sensor is untouched for every other family.
- One name string in each of the five catalogs; 22 AC goldens gain the key.
- Five assertions covering the table hit, the unknown code, the deleted row and the reminder.

Cut from current `main`. Independent of #293 and #296.

**One caveat I would rather state than hide:** the 45 strings were transcribed from an extraction run against the app's catalog, and the machine holding it is currently powered down, so I have not re-verified them byte for byte since. I will do that when it is back on and push a correction if anything differs.
