### PR TITLE
feat(climate): expose Smart Saver on legacy AC boards

### DIFF
--- a/custom_components/localthings/climate.py
+++ b/custom_components/localthings/climate.py
@@ -265,7 +265,13 @@ class LocalThingsClimate(LocalThingsEntity, ClimateEntity):
     # Preset codes on legacy ARTIK051 boards, learned by driving the same unit
     # through its cloud integration and reading the local token back each time:
     # Nano=windFree, Quiet, Comfort, 2Step, Speed=Fast Turbo, Off=none.
-    _LEGACY_PRESET_CODES = ("Off", "Nano", "Quiet", "Comfort", "2Step", "Speed")
+    #
+    # Smart is Samsung's "Smart Saver", which has no cloud counterpart to learn
+    # it from -- it was read out of the appliance's own app and then confirmed
+    # on hardware: writing Comode_Smart moved the unit's reported min_temp from
+    # 16 to 24 and lifted a 22 target to 24, which is exactly what Samsung
+    # documents Smart Saver doing, and Comode_Off put both back.
+    _LEGACY_PRESET_CODES = ("Off", "Nano", "Quiet", "Comfort", "2Step", "Speed", "Smart")
 
     def _legacy_convenient(self) -> dict:
         """A /mode/convenient/vs/0-shaped rep built from the Comode_* token in

--- a/tests/test_airconditioner_artik051_krac.py
+++ b/tests/test_airconditioner_artik051_krac.py
@@ -398,6 +398,7 @@ def test_preset_comes_from_the_comode_token():
         "comfort",
         "2step",
         "speed",
+        "smart",
     ]
 
     options = resources["/mode/vs/0"]["x.com.samsung.da.options"]
@@ -405,6 +406,19 @@ def test_preset_comes_from_the_comode_token():
         "Comode_Nano" if option.startswith("Comode_") else option for option in options
     ]
     assert _climate(resources).preset_mode == "nano"
+
+
+def test_smart_saver_is_a_preset_like_any_other_token():
+    """Comode_Smart is Samsung's Smart Saver: confirmed on an ARTIK051_KRAC_18K,
+    where writing it moved the reported min_temp from 16 to 24 and lifted a 22
+    target to 24. It reads and writes through the same token path as the codes
+    learned from the cloud -- the only difference is where the name came from."""
+    resources = _load_device(FIXTURE)
+    options = resources["/mode/vs/0"]["x.com.samsung.da.options"]
+    resources["/mode/vs/0"]["x.com.samsung.da.options"] = [
+        "Comode_Smart" if option.startswith("Comode_") else option for option in options
+    ]
+    assert _climate(resources).preset_mode == "smart"
 
 
 async def test_preset_write_uses_the_token_path():


### PR DESCRIPTION
`Comode_Smart` is Samsung's **Smart Saver**, and it is the one legacy preset code that could not be learned the way the other six were — by driving a unit through its cloud integration and reading the token back. The cloud has no counterpart for it. So it came out of the appliance's own app, and then went onto hardware before this PR was written.

*Disclosure, as in #146, #168, #290, #296 and #297: this account is @perseus177's — he owns the appliances and reads everything before it goes out — but the measuring and the writing here are Claude Code's.*

## What the unit did

Written with `climate.set_preset_mode` on an ARTIK051_KRAC_18K running in Cool, then read back off the appliance:

| Samsung's description of Smart Saver | this unit |
|---|---|
| limits the range to 24–30 °C | `min_temp` 16 → **24**, and back to 16 on `Comode_Off` |
| a setpoint below 24 is raised to 24 | target **22 → 24**, immediately |
| Cool only | tested in Cool; other modes untested |
| driven by a Smart Saver button on the remote | which is why it is absent from the owner's app |

`min_temp` and the target are both fields the *device* reports, so this is the unit's own answer, not the optimistic value this integration writes. The preset held across several polls.

Sources for the name: [Samsung India support](https://www.samsung.com/in/support/home-appliances/smart-saver-mode-in-air-conditioner/) and the AQV09U / AQV09K / AQ07R / AVXWVH manuals. Models carrying it: the AQV series (09/12/18, T/K/U), AQ07R, system AVXWVH, and AR units such as AR18JC2UFUQNNA — an older feature that survived into the AR generation.

## One thing worth flagging

The app's own `getSingleUserCommand()` sends this same `Comode_Smart` token, so the two features cannot be told apart by the token alone, and Samsung gives both the same 24 °C floor — so not by behaviour either. Two things point at Smart Saver rather than Single User:

- `OptionCode` bit 3 (`isSingleUserOption`) is **0** on this unit, and pressing Single User on its remote changes nothing locally — the range stays 16–30. Smart Saver has no bit at all, and works.
- `getSingleUserCommand()` hard-codes its 24 with the comment *"The value need to be hard coded. The set doesn't send threshold values to us."*, i.e. the app is filling in a number the appliance never sent.

No new translation string: `smart` is already in every catalog, from the newer boards that expose it as a convenient mode. If you would rather the label read "Smart Saver" on these boards specifically, say so — but that string is shared with those boards, so I left it alone rather than rename it for everyone.

## Shape

One code added to `_LEGACY_PRESET_CODES`, which both the read and the write path already resolve dynamically. Reading it back as a preset and writing it are the same mechanism as `Nano`/`Quiet`/`2Step` — the only new thing is the name.

Cut from current `main`. Independent of the Good Sleep PR, except that both touch that tuple, so whichever lands second wants a one-line rebase.
