### PR TITLE
Keep user input on error in the config flow

### DIFF
--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -777,7 +777,7 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id=step_id,
-            data_schema=schema,
+            data_schema=self.add_suggested_values_to_schema(schema, user_input),
             errors=errors,
         )
 


### PR DESCRIPTION
Keeps the user input on the config flow step `user` in case of an error, so the user doesn't need to insert again all data.
<img width="565" height="459" alt="image" src="https://github.com/user-attachments/assets/d5b1e9a0-2409-401f-af58-aa1debdd48ce" />
