### PR TITLE
Normalize appliance enums for HA translations

### DIFF
--- a/custom_components/localthings/registry/capabilities/dishwasher.py
+++ b/custom_components/localthings/registry/capabilities/dishwasher.py
@@ -67,6 +67,12 @@ CYCLE_OPTIONS = Capability(
 # Self-diagnostic trigger and last-operation-source sensor
 # ---------------------------------------------------------------------------
 
+
+def _diagnosis_status(value):
+    """Normalize the confirmed idle diagnosis state for HA translation."""
+    return "ready" if value == "Ready" else value
+
+
 DIAGNOSIS = Capability(
     href="/diagnosis/vs/0",
     poll_tier="cold",
@@ -76,6 +82,9 @@ DIAGNOSIS = Capability(
             field="x.com.samsung.da.diagnosisStart",
             icon="mdi:stethoscope",
             entity_category="diagnostic",
+            device_class="enum",
+            options=("ready",),
+            value_fn=_diagnosis_status,
         ),
         ButtonDesc(
             key="diagnosis_start",

--- a/custom_components/localthings/registry/capabilities/dryer.py
+++ b/custom_components/localthings/registry/capabilities/dryer.py
@@ -11,6 +11,7 @@ the /course/vs/0 cycle select -- lives in laundry.py.
 
 from ..capability import Capability
 from ..entities import SensorDesc, SwitchDesc
+from .dishwasher import _diagnosis_status
 from .laundry import cycle_select, drum_clean_cycles_remaining, drum_clean_last_cleaned
 
 
@@ -62,7 +63,6 @@ DRYER_COURSE = Capability(
         ),
         SensorDesc(
             key="drum_clean_cycles_remaining",
-            unit="cycles",
             icon="mdi:tumble-dryer-alert",
             state_class="measurement",
             exists_fn=lambda rep, resources: drum_clean_cycles_remaining(rep) is not None,
@@ -84,7 +84,12 @@ DRYER_DIAGNOSIS = Capability(
     poll_tier="warm",
     entities=(
         SensorDesc(
-            key="diagnosis", field="x.com.samsung.da.diagnosisStart", entity_category="diagnostic"
+            key="diagnosis",
+            field="x.com.samsung.da.diagnosisStart",
+            entity_category="diagnostic",
+            device_class="enum",
+            options=("ready",),
+            value_fn=_diagnosis_status,
         ),
     ),
 )

--- a/custom_components/localthings/registry/capabilities/operational.py
+++ b/custom_components/localthings/registry/capabilities/operational.py
@@ -24,8 +24,25 @@ def _to_ocf(v):
     return _SAMSUNG_STATE_TO_OCF.get(v, v) if v is not None else None
 
 
+_PROGRESS_STATES = {
+    "None": "idle",
+    "Weightsensing": "weight_sensing",
+    "Wash": "wash",
+    "Rinse": "rinse",
+    "Spin": "spin",
+    "Finish": "finish",
+    "Steaming": "steaming",
+    "Airwashing": "air_washing",
+    "Drying": "drying",
+    "Cooling": "cooling",
+    "Predrain": "pre_drain",
+    "Prewash": "pre_wash",
+}
+
+
 def _progress(v):
-    return "Idle" if v in (None, "None") else v
+    """Normalize known Samsung phase tokens for Home Assistant enum translation."""
+    return _PROGRESS_STATES.get(v, v)
 
 
 def _int(v):
@@ -161,8 +178,10 @@ OPERATIONAL_STATE = Capability(
         SensorDesc(
             key="progress",
             icon="mdi:progress-wrench",
+            device_class="enum",
+            options=tuple(_PROGRESS_STATES.values()),
             rep_fn=lambda rep: (
-                "Idle"
+                "idle"
                 if _SAMSUNG_STATE_TO_OCF.get(rep.get("x.com.samsung.da.state")) != "active"
                 else _progress(rep.get("x.com.samsung.da.progress"))
             ),

--- a/custom_components/localthings/registry/capabilities/operational.py
+++ b/custom_components/localthings/registry/capabilities/operational.py
@@ -6,6 +6,7 @@ Shared by dryer/dishwasher/oven/washer families.
 import math
 from datetime import UTC, datetime, timedelta
 
+from ...catalog import translated_states
 from ..capability import Capability
 from ..entities import BinarySensorDesc, ButtonDesc, NumberDesc, SensorDesc
 
@@ -24,25 +25,8 @@ def _to_ocf(v):
     return _SAMSUNG_STATE_TO_OCF.get(v, v) if v is not None else None
 
 
-_PROGRESS_STATES = {
-    "None": "idle",
-    "Weightsensing": "weight_sensing",
-    "Wash": "wash",
-    "Rinse": "rinse",
-    "Spin": "spin",
-    "Finish": "finish",
-    "Steaming": "steaming",
-    "Airwashing": "air_washing",
-    "Drying": "drying",
-    "Cooling": "cooling",
-    "Predrain": "pre_drain",
-    "Prewash": "pre_wash",
-}
-
-
 def _progress(v):
-    """Normalize known Samsung phase tokens for Home Assistant enum translation."""
-    return _PROGRESS_STATES.get(v, v)
+    return "idle" if v in (None, "None") else v.lower()
 
 
 def _int(v):
@@ -179,7 +163,7 @@ OPERATIONAL_STATE = Capability(
             key="progress",
             icon="mdi:progress-wrench",
             device_class="enum",
-            options=tuple(_PROGRESS_STATES.values()),
+            options=tuple(sorted(translated_states("sensor", "progress"))),
             rep_fn=lambda rep: (
                 "idle"
                 if _SAMSUNG_STATE_TO_OCF.get(rep.get("x.com.samsung.da.state")) != "active"

--- a/custom_components/localthings/registry/capabilities/washer.py
+++ b/custom_components/localthings/registry/capabilities/washer.py
@@ -263,7 +263,6 @@ WASHER_COURSE = Capability(
         ),
         SensorDesc(
             key="drum_clean_cycles_remaining",
-            unit="cycles",
             icon="mdi:washing-machine-alert",
             state_class="measurement",
             exists_fn=lambda rep, resources: drum_clean_cycles_remaining(rep) is not None,

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -1045,17 +1045,17 @@
         "name": "Průběh",
         "state": {
           "idle": "Nečinný",
-          "weight_sensing": "Detekce náplně",
+          "weightsensing": "Detekce náplně",
           "wash": "Praní",
           "rinse": "Máchání",
           "spin": "Odstřeďování",
           "finish": "Dokončeno",
           "steaming": "Napařování",
-          "air_washing": "Osvěžení vzduchem",
+          "airwashing": "Osvěžení vzduchem",
           "drying": "Sušení",
           "cooling": "Chlazení",
-          "pre_drain": "Vypouštění",
-          "pre_wash": "Předpírka"
+          "predrain": "Vypouštění",
+          "prewash": "Předpírka"
         }
       },
       "progress_percentage": {

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -258,7 +258,11 @@
         "name": "Zvuk bzučáku",
         "state": {
           "off": "Vypnuto",
-          "on": "Zapnuto"
+          "on": "Zapnuto",
+          "volume_off": "Vypnuto",
+          "volume_low": "Nízká",
+          "volume_med": "Střední",
+          "volume_high": "Vysoká"
         }
       },
       "discharging_time": {
@@ -884,13 +888,20 @@
         "name": "Teplota"
       },
       "diagnosis": {
-        "name": "Diagnostika"
+        "name": "Diagnostika",
+        "state": {
+          "ready": "Připraveno"
+        }
       },
       "diagnosis_status": {
-        "name": "Stav diagnostiky"
+        "name": "Stav diagnostiky",
+        "state": {
+          "ready": "Připraveno"
+        }
       },
       "drum_clean_cycles_remaining": {
-        "name": "Čištění bubnu za"
+        "name": "Čištění bubnu za",
+        "unit_of_measurement": "cyklů"
       },
       "drum_clean_last_cleaned": {
         "name": "Poslední čištění bubnu"
@@ -1031,7 +1042,21 @@
         "name": "Teplota sondy"
       },
       "progress": {
-        "name": "Průběh"
+        "name": "Průběh",
+        "state": {
+          "idle": "Nečinný",
+          "weight_sensing": "Detekce náplně",
+          "wash": "Praní",
+          "rinse": "Máchání",
+          "spin": "Odstřeďování",
+          "finish": "Dokončeno",
+          "steaming": "Napařování",
+          "air_washing": "Osvěžení vzduchem",
+          "drying": "Sušení",
+          "cooling": "Chlazení",
+          "pre_drain": "Vypouštění",
+          "pre_wash": "Předpírka"
+        }
       },
       "progress_percentage": {
         "name": "Průběh v procentech"

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -1039,17 +1039,17 @@
         "name": "Fortschritt",
         "state": {
           "idle": "Leerlauf",
-          "weight_sensing": "Beladungserkennung",
+          "weightsensing": "Beladungserkennung",
           "wash": "Waschen",
           "rinse": "Spülen",
           "spin": "Schleudern",
           "finish": "Fertig",
           "steaming": "Dämpfen",
-          "air_washing": "Luftreinigung",
+          "airwashing": "Luftreinigung",
           "drying": "Trocknen",
           "cooling": "Abkühlen",
-          "pre_drain": "Abpumpen",
-          "pre_wash": "Vorwäsche"
+          "predrain": "Abpumpen",
+          "prewash": "Vorwäsche"
         }
       },
       "progress_percentage": {

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -258,7 +258,11 @@
         "name": "Signalton",
         "state": {
           "off": "Aus",
-          "on": "Ein"
+          "on": "Ein",
+          "volume_off": "Aus",
+          "volume_low": "Niedrig",
+          "volume_med": "Mittel",
+          "volume_high": "Hoch"
         }
       },
       "discharging_time": {
@@ -878,13 +882,20 @@
         "name": "Temperatur"
       },
       "diagnosis": {
-        "name": "Diagnose"
+        "name": "Diagnose",
+        "state": {
+          "ready": "Bereit"
+        }
       },
       "diagnosis_status": {
-        "name": "Diagnosestatus"
+        "name": "Diagnosestatus",
+        "state": {
+          "ready": "Bereit"
+        }
       },
       "drum_clean_cycles_remaining": {
-        "name": "Trommelreinigung fällig in"
+        "name": "Trommelreinigung fällig in",
+        "unit_of_measurement": "Zyklen"
       },
       "drum_clean_last_cleaned": {
         "name": "Trommel zuletzt gereinigt"
@@ -1025,7 +1036,21 @@
         "name": "Fühlertemperatur"
       },
       "progress": {
-        "name": "Fortschritt"
+        "name": "Fortschritt",
+        "state": {
+          "idle": "Leerlauf",
+          "weight_sensing": "Beladungserkennung",
+          "wash": "Waschen",
+          "rinse": "Spülen",
+          "spin": "Schleudern",
+          "finish": "Fertig",
+          "steaming": "Dämpfen",
+          "air_washing": "Luftreinigung",
+          "drying": "Trocknen",
+          "cooling": "Abkühlen",
+          "pre_drain": "Abpumpen",
+          "pre_wash": "Vorwäsche"
+        }
       },
       "progress_percentage": {
         "name": "Fortschritt in Prozent"

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -1045,17 +1045,17 @@
         "name": "Progress",
         "state": {
           "idle": "Idle",
-          "weight_sensing": "Weight sensing",
+          "weightsensing": "Weight sensing",
           "wash": "Washing",
           "rinse": "Rinsing",
           "spin": "Spinning",
           "finish": "Finished",
           "steaming": "Steaming",
-          "air_washing": "Air washing",
+          "airwashing": "Air washing",
           "drying": "Drying",
           "cooling": "Cooling",
-          "pre_drain": "Pre-drain",
-          "pre_wash": "Pre-wash"
+          "predrain": "Pre-drain",
+          "prewash": "Pre-wash"
         }
       },
       "progress_percentage": {

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -258,7 +258,11 @@
         "name": "Buzzer sound",
         "state": {
           "off": "Off",
-          "on": "On"
+          "on": "On",
+          "volume_off": "Off",
+          "volume_low": "Low",
+          "volume_med": "Medium",
+          "volume_high": "High"
         }
       },
       "discharging_time": {
@@ -884,13 +888,20 @@
         "name": "Temperature"
       },
       "diagnosis": {
-        "name": "Diagnosis"
+        "name": "Diagnosis",
+        "state": {
+          "ready": "Ready"
+        }
       },
       "diagnosis_status": {
-        "name": "Diagnosis status"
+        "name": "Diagnosis status",
+        "state": {
+          "ready": "Ready"
+        }
       },
       "drum_clean_cycles_remaining": {
-        "name": "Drum clean due in"
+        "name": "Drum clean due in",
+        "unit_of_measurement": "cycles"
       },
       "drum_clean_last_cleaned": {
         "name": "Drum last cleaned"
@@ -1031,7 +1042,21 @@
         "name": "Probe temperature"
       },
       "progress": {
-        "name": "Progress"
+        "name": "Progress",
+        "state": {
+          "idle": "Idle",
+          "weight_sensing": "Weight sensing",
+          "wash": "Washing",
+          "rinse": "Rinsing",
+          "spin": "Spinning",
+          "finish": "Finished",
+          "steaming": "Steaming",
+          "air_washing": "Air washing",
+          "drying": "Drying",
+          "cooling": "Cooling",
+          "pre_drain": "Pre-drain",
+          "pre_wash": "Pre-wash"
+        }
       },
       "progress_percentage": {
         "name": "Progress percent"

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -407,7 +407,11 @@
         "name": "Volumen",
         "state": {
           "off": "Apagado",
-          "on": "Encendido"
+          "on": "Encendido",
+          "volume_off": "Apagado",
+          "volume_low": "Bajo",
+          "volume_med": "Medio",
+          "volume_high": "Alto"
         }
       },
       "discharging_time": {
@@ -1030,13 +1034,20 @@
         "name": "Temperatura"
       },
       "diagnosis": {
-        "name": "Diagnóstico"
+        "name": "Diagnóstico",
+        "state": {
+          "ready": "Listo"
+        }
       },
       "diagnosis_status": {
-        "name": "Estado del diagnóstico"
+        "name": "Estado del diagnóstico",
+        "state": {
+          "ready": "Listo"
+        }
       },
       "drum_clean_cycles_remaining": {
-        "name": "Limpieza de tambor en"
+        "name": "Limpieza de tambor en",
+        "unit_of_measurement": "ciclos"
       },
       "drum_clean_last_cleaned": {
         "name": "Última limpieza del tambor"
@@ -1177,7 +1188,21 @@
         "name": "Temperatura de la sonda"
       },
       "progress": {
-        "name": "Progreso"
+        "name": "Progreso",
+        "state": {
+          "idle": "Inactiva",
+          "weight_sensing": "Detección de carga",
+          "wash": "Lavado",
+          "rinse": "Aclarado",
+          "spin": "Centrifugado",
+          "finish": "Finalizado",
+          "steaming": "Vaporización",
+          "air_washing": "Lavado con aire",
+          "drying": "Secado",
+          "cooling": "Enfriamiento",
+          "pre_drain": "Drenaje previo",
+          "pre_wash": "Prelavado"
+        }
       },
       "progress_percentage": {
         "name": "Porcentaje de progreso"

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -1191,17 +1191,17 @@
         "name": "Progreso",
         "state": {
           "idle": "Inactiva",
-          "weight_sensing": "Detección de carga",
+          "weightsensing": "Detección de carga",
           "wash": "Lavado",
           "rinse": "Aclarado",
           "spin": "Centrifugado",
           "finish": "Finalizado",
           "steaming": "Vaporización",
-          "air_washing": "Lavado con aire",
+          "airwashing": "Lavado con aire",
           "drying": "Secado",
           "cooling": "Enfriamiento",
-          "pre_drain": "Drenaje previo",
-          "pre_wash": "Prelavado"
+          "predrain": "Drenaje previo",
+          "prewash": "Prelavado"
         }
       },
       "progress_percentage": {

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -258,7 +258,11 @@
         "name": "Suono cicalino",
         "state": {
           "off": "Spento",
-          "on": "Acceso"
+          "on": "Acceso",
+          "volume_off": "Spento",
+          "volume_low": "Basso",
+          "volume_med": "Medio",
+          "volume_high": "Alto"
         }
       },
       "discharging_time": {
@@ -884,13 +888,20 @@
         "name": "Temperatura"
       },
       "diagnosis": {
-        "name": "Diagnosi"
+        "name": "Diagnosi",
+        "state": {
+          "ready": "Pronto"
+        }
       },
       "diagnosis_status": {
-        "name": "Stato diagnosi"
+        "name": "Stato diagnosi",
+        "state": {
+          "ready": "Pronto"
+        }
       },
       "drum_clean_cycles_remaining": {
-        "name": "Pulizia cestello fra"
+        "name": "Pulizia cestello fra",
+        "unit_of_measurement": "cicli"
       },
       "drum_clean_last_cleaned": {
         "name": "Ultima pulizia cestello"
@@ -1031,7 +1042,21 @@
         "name": "Temperatura sonda"
       },
       "progress": {
-        "name": "Avanzamento"
+        "name": "Avanzamento",
+        "state": {
+          "idle": "Inattivo",
+          "weight_sensing": "Rilevamento del carico",
+          "wash": "Lavaggio",
+          "rinse": "Risciacquo",
+          "spin": "Centrifuga",
+          "finish": "Completato",
+          "steaming": "Vapore",
+          "air_washing": "Lavaggio ad aria",
+          "drying": "Asciugatura",
+          "cooling": "Raffreddamento",
+          "pre_drain": "Scarico preliminare",
+          "pre_wash": "Prelavaggio"
+        }
       },
       "progress_percentage": {
         "name": "Avanzamento percentuale"

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -1045,17 +1045,17 @@
         "name": "Avanzamento",
         "state": {
           "idle": "Inattivo",
-          "weight_sensing": "Rilevamento del carico",
+          "weightsensing": "Rilevamento del carico",
           "wash": "Lavaggio",
           "rinse": "Risciacquo",
           "spin": "Centrifuga",
           "finish": "Completato",
           "steaming": "Vapore",
-          "air_washing": "Lavaggio ad aria",
+          "airwashing": "Lavaggio ad aria",
           "drying": "Asciugatura",
           "cooling": "Raffreddamento",
-          "pre_drain": "Scarico preliminare",
-          "pre_wash": "Prelavaggio"
+          "predrain": "Scarico preliminare",
+          "prewash": "Prelavaggio"
         }
       },
       "progress_percentage": {

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -1045,17 +1045,17 @@
         "name": "진행률",
         "state": {
           "idle": "대기",
-          "weight_sensing": "세탁물 감지",
+          "weightsensing": "세탁물 감지",
           "wash": "세탁",
           "rinse": "헹굼",
           "spin": "탈수",
           "finish": "완료",
           "steaming": "스팀",
-          "air_washing": "에어워시",
+          "airwashing": "에어워시",
           "drying": "건조",
           "cooling": "냉각",
-          "pre_drain": "사전 배수",
-          "pre_wash": "애벌빨래"
+          "predrain": "사전 배수",
+          "prewash": "애벌빨래"
         }
       },
       "progress_percentage": {

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -258,7 +258,11 @@
         "name": "부저음",
         "state": {
           "off": "끄기",
-          "on": "켜기"
+          "on": "켜기",
+          "volume_off": "끔",
+          "volume_low": "낮음",
+          "volume_med": "중간",
+          "volume_high": "높음"
         }
       },
       "discharging_time": {
@@ -884,13 +888,20 @@
         "name": "온도"
       },
       "diagnosis": {
-        "name": "진단"
+        "name": "진단",
+        "state": {
+          "ready": "준비됨"
+        }
       },
       "diagnosis_status": {
-        "name": "진단 상태"
+        "name": "진단 상태",
+        "state": {
+          "ready": "준비됨"
+        }
       },
       "drum_clean_cycles_remaining": {
-        "name": "통세척까지 남은 횟수"
+        "name": "통세척까지 남은 횟수",
+        "unit_of_measurement": "회"
       },
       "drum_clean_last_cleaned": {
         "name": "마지막 통세척"
@@ -1031,7 +1042,21 @@
         "name": "탐침 온도계 현재 온도"
       },
       "progress": {
-        "name": "진행률"
+        "name": "진행률",
+        "state": {
+          "idle": "대기",
+          "weight_sensing": "세탁물 감지",
+          "wash": "세탁",
+          "rinse": "헹굼",
+          "spin": "탈수",
+          "finish": "완료",
+          "steaming": "스팀",
+          "air_washing": "에어워시",
+          "drying": "건조",
+          "cooling": "냉각",
+          "pre_drain": "사전 배수",
+          "pre_wash": "애벌빨래"
+        }
       },
       "progress_percentage": {
         "name": "진행률"

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -258,7 +258,11 @@
         "name": "Zoemergeluid",
         "state": {
           "off": "Uit",
-          "on": "Aan"
+          "on": "Aan",
+          "volume_off": "Uit",
+          "volume_low": "Laag",
+          "volume_med": "Gemiddeld",
+          "volume_high": "Hoog"
         }
       },
       "discharging_time": {
@@ -884,13 +888,20 @@
         "name": "Temperatuur"
       },
       "diagnosis": {
-        "name": "Diagnose"
+        "name": "Diagnose",
+        "state": {
+          "ready": "Gereed"
+        }
       },
       "diagnosis_status": {
-        "name": "Diagnosestatus"
+        "name": "Diagnosestatus",
+        "state": {
+          "ready": "Gereed"
+        }
       },
       "drum_clean_cycles_remaining": {
-        "name": "Trommelreiniging over"
+        "name": "Trommelreiniging over",
+        "unit_of_measurement": "cycli"
       },
       "drum_clean_last_cleaned": {
         "name": "Trommel laatst gereinigd"
@@ -1031,7 +1042,21 @@
         "name": "Sondetemperatuur"
       },
       "progress": {
-        "name": "Voortgang"
+        "name": "Voortgang",
+        "state": {
+          "idle": "Inactief",
+          "weight_sensing": "Beladingsdetectie",
+          "wash": "Wassen",
+          "rinse": "Spoelen",
+          "spin": "Centrifugeren",
+          "finish": "Voltooid",
+          "steaming": "Stomen",
+          "air_washing": "Luchtreiniging",
+          "drying": "Drogen",
+          "cooling": "Koelen",
+          "pre_drain": "Vooraf afpompen",
+          "pre_wash": "Voorwas"
+        }
       },
       "progress_percentage": {
         "name": "Voortgangspercentage"

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -1045,17 +1045,17 @@
         "name": "Voortgang",
         "state": {
           "idle": "Inactief",
-          "weight_sensing": "Beladingsdetectie",
+          "weightsensing": "Beladingsdetectie",
           "wash": "Wassen",
           "rinse": "Spoelen",
           "spin": "Centrifugeren",
           "finish": "Voltooid",
           "steaming": "Stomen",
-          "air_washing": "Luchtreiniging",
+          "airwashing": "Luchtreiniging",
           "drying": "Drogen",
           "cooling": "Koelen",
-          "pre_drain": "Vooraf afpompen",
-          "pre_wash": "Voorwas"
+          "predrain": "Vooraf afpompen",
+          "prewash": "Voorwas"
         }
       },
       "progress_percentage": {

--- a/tests/test_dishwasher_capabilities.py
+++ b/tests/test_dishwasher_capabilities.py
@@ -59,3 +59,10 @@ class TestDishwasherOptions:
         assert desc.exists_fn is not None
         assert desc.exists_fn({"x.com.samsung.da.options": []}, {}) is False
         assert desc.exists_fn({"x.com.samsung.da.options": ["AutoDoorRelease_On"]}, {}) is True
+
+
+def test_diagnosis_status_is_a_translatable_enum():
+    desc = next(e for e in dishwasher.DIAGNOSIS.entities if e.key == "diagnosis_status")
+    assert desc.device_class == "enum"
+    assert desc.options == ("ready",)
+    assert desc.value_fn("Ready") == "ready"

--- a/tests/test_operational_capability.py
+++ b/tests/test_operational_capability.py
@@ -15,6 +15,7 @@ def test_progress_is_a_translatable_enum():
     desc = next(e for e in OPERATIONAL_STATE.entities if e.key == "progress")
     assert desc.device_class == "enum"
     assert "rinse" in desc.options
+    assert "Rinse" not in desc.options
     assert desc.rep_fn is not None
     assert (
         desc.rep_fn({"x.com.samsung.da.state": "Run", "x.com.samsung.da.progress": "Rinse"})

--- a/tests/test_operational_capability.py
+++ b/tests/test_operational_capability.py
@@ -11,6 +11,17 @@ def test_machine_state_maps_samsung_to_ocf():
     assert ms.value_fn("Ready") == "idle"
 
 
+def test_progress_is_a_translatable_enum():
+    desc = next(e for e in OPERATIONAL_STATE.entities if e.key == "progress")
+    assert desc.device_class == "enum"
+    assert "rinse" in desc.options
+    assert desc.rep_fn is not None
+    assert (
+        desc.rep_fn({"x.com.samsung.da.state": "Run", "x.com.samsung.da.progress": "Rinse"})
+        == "rinse"
+    )
+
+
 class TestProgressPercentage:
     """issue #9: device firmware leaves progressPercentage stale (e.g. '1')
     after a cycle ends instead of resetting it, so it must be gated on

--- a/tests/test_select_options.py
+++ b/tests/test_select_options.py
@@ -7,6 +7,7 @@ from typing import ClassVar, cast
 
 from custom_components.localthings.coordinator import LocalThingsCoordinator
 from custom_components.localthings.registry.capabilities.laundry import (
+    BUZZER_SOUND,
     cycle_select,
     washer_cycle_fallback,
 )
@@ -45,6 +46,25 @@ def test_options_field_unaffected():
     desc = SelectDesc(key="x", options_field="supported")
     entity = _make_select(desc, "/x/vs/0", {"/x/vs/0": {"supported": ["Lo", "Hi"]}})
     assert entity.options == ["Lo", "Hi"]
+
+
+def test_buzzer_volume_options_normalize_to_translation_keys():
+    desc = next(e for e in BUZZER_SOUND.entities if e.key == "buzzer_sound")
+    entity = _make_select(
+        desc,
+        "/buzzersound/vs/0",
+        {
+            "/buzzersound/vs/0": {
+                "supportedBuzzerSound": [
+                    "Volume_Off",
+                    "Volume_Low",
+                    "Volume_Med",
+                    "Volume_High",
+                ]
+            }
+        },
+    )
+    assert entity.options == ["volume_off", "volume_low", "volume_med", "volume_high"]
 
 
 def test_callable_options_receives_full_resource_snapshot():


### PR DESCRIPTION
## Summary

Translates previously English Samsung status values in the Home Assistant integration.

- Cycle progress, e.g. `Rinse` → “Rinsing”
- Drum-clean counter, e.g. `3 cycles`
- Diagnosis status, e.g. `Ready`
- Buzzer volume options, e.g. `Volume_High` → “High”

## Testing

- Validated translation catalogs and key structure
- Checked Python syntax