### PR TITLE
dryer/dishwasher: dryer_type translation (#366) + missing progress state

### DIFF
--- a/custom_components/localthings/registry/capabilities/dryer.py
+++ b/custom_components/localthings/registry/capabilities/dryer.py
@@ -27,7 +27,17 @@ DRYER_SETTINGS = Capability(
     entities=(
         SensorDesc(key="dry_level", field="x.com.samsung.da.dryLevel", icon="mdi:water-percent"),
         SensorDesc(key="dry_time", field="x.com.samsung.da.dryTime", icon="mdi:timer"),
-        SensorDesc(key="dryer_type", field="x.com.samsung.da.dryerType", icon="mdi:tumble-dryer"),
+        SensorDesc(
+            key="dryer_type",
+            field="x.com.samsung.da.dryerType",
+            icon="mdi:tumble-dryer",
+            device_class="enum",
+            # Only 'Electricity' confirmed across shipped fixtures (#366); an
+            # unrecognized value still passes through raw via sensor.py's
+            # options property rather than breaking the entity.
+            options=("electricity",),
+            value_fn=lambda v: v.lower() if isinstance(v, str) else v,
+        ),
         SwitchDesc(
             key="wrinkle_prevent",
             field="x.com.samsung.da.wrinklePrevent",

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -958,7 +958,10 @@
         "name": "Doba sušení"
       },
       "dryer_type": {
-        "name": "Typ sušičky"
+        "name": "Typ sušičky",
+        "state": {
+          "electricity": "Elektřina"
+        }
       },
       "dust": {
         "name": "Prach"

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -1101,6 +1101,7 @@
           "steaming": "Napařování",
           "airwashing": "Osvěžení vzduchem",
           "drying": "Sušení",
+          "dryingwithdooropen": "Větrání",
           "cooling": "Chlazení",
           "predrain": "Vypouštění",
           "prewash": "Předpírka"

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -952,7 +952,10 @@
         "name": "Trockenzeit"
       },
       "dryer_type": {
-        "name": "Trocknertyp"
+        "name": "Trocknertyp",
+        "state": {
+          "electricity": "Strom"
+        }
       },
       "dust": {
         "name": "Staub"

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -1095,6 +1095,7 @@
           "steaming": "Dämpfen",
           "airwashing": "Luftreinigung",
           "drying": "Trocknen",
+          "dryingwithdooropen": "Lüften",
           "cooling": "Abkühlen",
           "predrain": "Abpumpen",
           "prewash": "Vorwäsche"

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -1101,6 +1101,7 @@
           "steaming": "Steaming",
           "airwashing": "Air washing",
           "drying": "Drying",
+          "dryingwithdooropen": "Venting",
           "cooling": "Cooling",
           "predrain": "Pre-drain",
           "prewash": "Pre-wash"

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -958,7 +958,10 @@
         "name": "Dry time"
       },
       "dryer_type": {
-        "name": "Dryer type"
+        "name": "Dryer type",
+        "state": {
+          "electricity": "Electricity"
+        }
       },
       "dust": {
         "name": "Dust"

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -1151,7 +1151,10 @@
         "name": "Tiempo de secado"
       },
       "dryer_type": {
-        "name": "Tipo de secadora"
+        "name": "Tipo de secadora",
+        "state": {
+          "electricity": "Electricidad"
+        }
       },
       "dust": {
         "name": "Polvo"

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -1294,6 +1294,7 @@
           "steaming": "Vaporización",
           "airwashing": "Lavado con aire",
           "drying": "Secado",
+          "dryingwithdooropen": "Ventilación",
           "cooling": "Enfriamiento",
           "predrain": "Drenaje previo",
           "prewash": "Prelavado"

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -1101,6 +1101,7 @@
           "steaming": "Vapore",
           "airwashing": "Lavaggio ad aria",
           "drying": "Asciugatura",
+          "dryingwithdooropen": "Ventilazione",
           "cooling": "Raffreddamento",
           "predrain": "Scarico preliminare",
           "prewash": "Prelavaggio"

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -958,7 +958,10 @@
         "name": "Tempo di asciugatura"
       },
       "dryer_type": {
-        "name": "Tipo di asciugatrice"
+        "name": "Tipo di asciugatrice",
+        "state": {
+          "electricity": "Elettricità"
+        }
       },
       "dust": {
         "name": "Polvere"

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -1101,6 +1101,7 @@
           "steaming": "스팀",
           "airwashing": "에어워시",
           "drying": "건조",
+          "dryingwithdooropen": "환기",
           "cooling": "냉각",
           "predrain": "사전 배수",
           "prewash": "애벌빨래"

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -958,7 +958,10 @@
         "name": "건조 시간"
       },
       "dryer_type": {
-        "name": "건조기 유형"
+        "name": "건조기 유형",
+        "state": {
+          "electricity": "전기"
+        }
       },
       "dust": {
         "name": "미세먼지"

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -1101,6 +1101,7 @@
           "steaming": "Stomen",
           "airwashing": "Luchtreiniging",
           "drying": "Drogen",
+          "dryingwithdooropen": "Ventileren",
           "cooling": "Koelen",
           "predrain": "Vooraf afpompen",
           "prewash": "Voorwas"

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -958,7 +958,10 @@
         "name": "Droogtijd"
       },
       "dryer_type": {
-        "name": "Type droger"
+        "name": "Type droger",
+        "state": {
+          "electricity": "Elektriciteit"
+        }
       },
       "dust": {
         "name": "Stof"


### PR DESCRIPTION
## Summary

Folds #366 (@Pastaloverzzz's "Dutch translations for the state of progress and type dryer") into main, updated for what's changed since it was opened, plus one more missing `progress` state found along the way.

- **`progress`** — #366's additions are superseded. #371 (merged since) already gave every locale, Dutch included, a complete lowercase `progress.state` table — more complete than #366's (which was missing 4 of 12 states and still used the pre-#371 capitalized keys). Nothing to carry over there.
- **`dryer_type`** — this was the real gap, and a deeper one than a missing translation: `dryer_type` had never been wired for translation at all. No `device_class`, no `options` — so a `state` table under it, in any locale, was inert. #366's Dutch text would never have been read.
- **`progress.dryingwithdooropen`** — confirmed on a live dishwasher's `sensor.*_progress` history (not in any shipped fixture): `Prewash → Wash → Rinse → Drying → DryingWithDoorOpen → Finish → Idle`. The door-open drying-assist stage had no catalog entry, so it fell through to the untranslated-value fallback and rendered as the raw lowercased string `dryingwithdooropen`. Added as "Venting" (and each locale's equivalent) across all seven catalogs — no code change needed, since `progress`'s `options` are derived from the catalog via `translated_states()`.

## What this does

- `dryer.py`: gives `dryer_type` `device_class="enum"`, `options=("electricity",)` — the only value confirmed across shipped fixtures — and the same lowercase `value_fn` normalization #371 established for `progress`/`diagnosis`/`buzzer_sound`. An unrecognized future value still passes through raw instead of breaking the entity, via the same `options` fallback #371 built into `sensor.py`.
- Adds the `electricity` state translation across all seven locale catalogs (cs, de, en, es, it, ko, nl), not just Dutch, per the project's now-established rule that a translatable state ships to every shipped language at once.
- Adds `progress.dryingwithdooropen` ("Venting") across all seven locale catalogs.

## Testing

`1555 passed`; `ruff check`/`ruff format --check` and `ty check custom_components tests` all clean.