### PR TITLE
airconditioner: ungate outdoor_temperature from is_legacy_board

### DIFF
--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -384,6 +384,21 @@ def _has_option_token_any_board(prefix):
     return lambda rep, resources: _option_token(rep, prefix) is not None
 
 
+def _reports_celsius(resources):
+    """Whether this subdevice's own /temperatures/vs/0 declares Celsius (or
+    says nothing at all, `_temps_vs_unit`'s default).
+
+    Guards `OutdoorTemp_`'s -55 offset below: issue #367's field validation
+    (48h against weather.forecast_home, r=0.92) ran on Celsius-locale boards
+    only -- 13 of the 14 non-legacy fixtures that carry the token declare
+    Celsius, and the offset's own calibration comment is a Celsius reading
+    too. The one Fahrenheit-locale exception on record
+    (`airconditioner_lnx_rac_heatpump`) has nothing to confirm the same
+    additive constant, or degrees C rather than F, still hold -- so this
+    stays off boards that declare anything else, rather than guess."""
+    return _temps_vs_unit(resources.get(HREF_TEMPS_VS) or {}) == "°C"
+
+
 def _option_token_on(prefix):
     return lambda rep: _option_token(rep, prefix) == "On"
 
@@ -795,13 +810,14 @@ CLIMATE = Capability(
         # Outdoor temperature, offset by 55 -- calibrated against an
         # independent thermometer (token 75 while it read 20.3°C).
         #
-        # exists_fn is token-presence-only (issue #367): the token was
-        # previously gated behind is_legacy_board for no reason tied to the
-        # token itself, which silently dropped the sensor on every
-        # non-legacy board that reports it -- 14 of 17 fixtures carrying the
-        # token in the issue's own survey. A 48h/289-sample field capture
-        # correlated it against weather.forecast_home at r=0.92, ruling out
-        # a firmware constant.
+        # exists_fn is token-presence-only (issue #367), not is_legacy_board:
+        # gating it there dropped the sensor on every non-legacy board that
+        # reports it -- 14 of 17 fixtures carrying the token in the issue's
+        # own survey. A 48h/289-sample field capture correlated it against
+        # weather.forecast_home at r=0.92, ruling out a firmware constant.
+        # `_reports_celsius` keeps that presence check from also claiming
+        # the -55 Celsius offset for board generations it was never
+        # validated on -- see its own docstring.
         #
         # enabled_default=False: multi-split installs (multiple indoor heads
         # on one outdoor condenser) report the same token on every head, so
@@ -813,7 +829,10 @@ CLIMATE = Capability(
         SensorDesc(
             key="outdoor_temperature",
             rep_fn=_option_token_num("OutdoorTemp", offset=55),
-            exists_fn=_has_option_token_any_board("OutdoorTemp"),
+            exists_fn=lambda rep, resources: (
+                _has_option_token_any_board("OutdoorTemp")(rep, resources)
+                and _reports_celsius(resources)
+            ),
             device_class="temperature",
             state_class="measurement",
             unit="°C",

--- a/custom_components/localthings/registry/capabilities/airconditioner.py
+++ b/custom_components/localthings/registry/capabilities/airconditioner.py
@@ -372,6 +372,18 @@ def _has_option_token(prefix):
     )
 
 
+def _has_option_token_any_board(prefix):
+    """Token-presence test with no board-generation gate.
+
+    `_has_option_token` above requires `is_legacy_board`, which was right for
+    the settings it guards but wrong for a token whose presence is itself the
+    only signal that needs checking -- issue #367 found `OutdoorTemp_` live
+    on 14 of 23 recorded fixtures despite none of them being legacy boards.
+    Same shape as `beep`'s Volume_ test and `_has_display_light_option`,
+    which already treat token presence as sufficient across generations."""
+    return lambda rep, resources: _option_token(rep, prefix) is not None
+
+
 def _option_token_on(prefix):
     return lambda rep: _option_token(rep, prefix) == "On"
 
@@ -782,13 +794,30 @@ CLIMATE = Capability(
         ),
         # Outdoor temperature, offset by 55 -- calibrated against an
         # independent thermometer (token 75 while it read 20.3°C).
+        #
+        # exists_fn is token-presence-only (issue #367): the token was
+        # previously gated behind is_legacy_board for no reason tied to the
+        # token itself, which silently dropped the sensor on every
+        # non-legacy board that reports it -- 14 of 17 fixtures carrying the
+        # token in the issue's own survey. A 48h/289-sample field capture
+        # correlated it against weather.forecast_home at r=0.92, ruling out
+        # a firmware constant.
+        #
+        # enabled_default=False: multi-split installs (multiple indoor heads
+        # on one outdoor condenser) report the same token on every head, so
+        # a fix here creates one identical sensor per head rather than one
+        # per physical unit (same duplication as the shared energy/power
+        # counters in issue #329). Left disabled so a user with several
+        # heads can enable just one instead of getting N duplicates active
+        # by default.
         SensorDesc(
             key="outdoor_temperature",
             rep_fn=_option_token_num("OutdoorTemp", offset=55),
-            exists_fn=_has_option_token("OutdoorTemp"),
+            exists_fn=_has_option_token_any_board("OutdoorTemp"),
             device_class="temperature",
             state_class="measurement",
             unit="°C",
+            enabled_default=False,
             icon="mdi:home-thermometer-outline",
         ),
         # Filter time in tenths of an hour, counting UP since last filter

--- a/tests/fixtures/golden/airconditioner.json
+++ b/tests/fixtures/golden/airconditioner.json
@@ -20,6 +20,7 @@
     "fine_dust",
     "humidity",
     "odor",
+    "outdoor_temperature",
     "power_watts",
     "super_fine_dust",
     "tropical_night_mode"

--- a/tests/fixtures/golden/airconditioner_ailp_fac.json
+++ b/tests/fixtures/golden/airconditioner_ailp_fac.json
@@ -25,6 +25,7 @@
     "mute_once",
     "odor_controller_active",
     "odor_controller_progress",
+    "outdoor_temperature",
     "power_energy_kwh",
     "power_watts",
     "selfcheck_error",

--- a/tests/fixtures/golden/airconditioner_ara_ww_tp1_22.json
+++ b/tests/fixtures/golden/airconditioner_ara_ww_tp1_22.json
@@ -18,6 +18,7 @@
     "mute_once",
     "odor_controller_active",
     "odor_controller_progress",
+    "outdoor_temperature",
     "power_watts",
     "tropical_night_mode"
   ]

--- a/tests/fixtures/golden/airconditioner_cac.json
+++ b/tests/fixtures/golden/airconditioner_cac.json
@@ -36,6 +36,7 @@
     "mute_once",
     "odor_controller_active",
     "odor_controller_progress",
+    "outdoor_temperature",
     "periodic_air_sensing",
     "periodic_sensing_skip_status",
     "power_watts",

--- a/tests/fixtures/golden/airconditioner_caww_tp2.json
+++ b/tests/fixtures/golden/airconditioner_caww_tp2.json
@@ -17,6 +17,7 @@
     "firmware_update",
     "humidity",
     "mute_once",
+    "outdoor_temperature",
     "power_watts",
     "tropical_night_mode"
   ]

--- a/tests/fixtures/golden/airconditioner_lnx_rac_heatpump.json
+++ b/tests/fixtures/golden/airconditioner_lnx_rac_heatpump.json
@@ -22,7 +22,6 @@
     "mute_once",
     "odor_controller_active",
     "odor_controller_progress",
-    "outdoor_temperature",
     "power_watts",
     "tropical_night_mode"
   ]

--- a/tests/fixtures/golden/airconditioner_lnx_rac_heatpump.json
+++ b/tests/fixtures/golden/airconditioner_lnx_rac_heatpump.json
@@ -22,6 +22,7 @@
     "mute_once",
     "odor_controller_active",
     "odor_controller_progress",
+    "outdoor_temperature",
     "power_watts",
     "tropical_night_mode"
   ]

--- a/tests/fixtures/golden/airconditioner_tp1x_da_ac_rac_01011.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_da_ac_rac_01011.json
@@ -23,6 +23,7 @@
     "last_air_sensing_level",
     "last_air_sensing_time",
     "mute_once",
+    "outdoor_temperature",
     "periodic_air_sensing",
     "periodic_sensing_skip_status",
     "selfcheck_error",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac.json
@@ -19,6 +19,7 @@
     "energy_saved_kwh",
     "firmware_update",
     "mute_once",
+    "outdoor_temperature",
     "selfcheck_error",
     "selfcheck_result",
     "selfcheck_status",

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_01001.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_01001.json
@@ -18,6 +18,7 @@
     "mute_once",
     "odor_controller_active",
     "odor_controller_progress",
+    "outdoor_temperature",
     "power_watts",
     "tropical_night_mode"
   ]

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_coolonly.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_coolonly.json
@@ -16,6 +16,7 @@
     "firmware_update",
     "humidity",
     "mute_once",
+    "outdoor_temperature",
     "power_watts",
     "tropical_night_mode"
   ]

--- a/tests/fixtures/golden/airconditioner_tp1x_rac_odor_controller.json
+++ b/tests/fixtures/golden/airconditioner_tp1x_rac_odor_controller.json
@@ -20,6 +20,7 @@
     "mute_once",
     "odor_controller_active",
     "odor_controller_progress",
+    "outdoor_temperature",
     "selfcheck_error",
     "selfcheck_result",
     "selfcheck_status",

--- a/tests/fixtures/golden/airconditioner_tp2x_rac_20k.json
+++ b/tests/fixtures/golden/airconditioner_tp2x_rac_20k.json
@@ -15,6 +15,7 @@
     "firmware_update",
     "humidity",
     "mute_once",
+    "outdoor_temperature",
     "power_watts",
     "tropical_night_mode"
   ]

--- a/tests/fixtures/golden/airconditioner_windfree.json
+++ b/tests/fixtures/golden/airconditioner_windfree.json
@@ -19,6 +19,7 @@
     "fine_dust",
     "humidity",
     "odor",
+    "outdoor_temperature",
     "power_watts",
     "super_fine_dust",
     "tropical_night_mode"

--- a/tests/fixtures/golden/airconditioner_window_ac.json
+++ b/tests/fixtures/golden/airconditioner_window_ac.json
@@ -16,6 +16,7 @@
     "firmware_update",
     "humidity",
     "mute_once",
+    "outdoor_temperature",
     "power_watts",
     "selfcheck_error",
     "selfcheck_result",

--- a/tests/test_airconditioner_artik051_krac.py
+++ b/tests/test_airconditioner_artik051_krac.py
@@ -129,20 +129,33 @@ def test_token_entities_present_with_calibrated_values():
 
 
 def test_token_entities_stay_off_newer_boards():
-    """Newer families carry Volume/Sleep/OutdoorTemp/Autoclean tokens too,
-    while also exposing those settings as dedicated resources -- ungated, the
-    token entities would duplicate them (auto clean) or apply a scale
-    calibrated on another board generation (outdoor temperature)."""
+    """Newer families carry Volume/Sleep/Autoclean tokens too, while also
+    exposing those settings as dedicated resources -- ungated, the token
+    entities would duplicate them."""
     state = _state("airconditioner_tp1x_rac")
     for key in (
         "spi",
         "auto_clean_legacy",
         "air_monitoring",
         "good_sleep",
-        "outdoor_temperature",
         "filter_time",
     ):
         assert key not in state, key
+
+
+def test_outdoor_temperature_is_not_gated_to_legacy_boards():
+    """issue #367: OutdoorTemp_ is not paired with any dedicated resource on
+    newer boards -- /temperatures/vs/0 carries indoor temperature only, no
+    outdoor equivalent exists anywhere in this fixture's 23 hrefs -- so unlike
+    auto_clean_legacy et al. above, gating it to is_legacy_board only dropped
+    a real reading. A 48h field capture correlated the token against
+    weather.forecast_home at r=0.92 across several non-legacy boards,
+    confirming it is live per-site data rather than a firmware constant."""
+    resources = _load_device("airconditioner_tp1x_rac")
+    assert is_legacy_board(resources) is False
+    bound, _ = _discover(resources)
+    state = flatten(bound, resources)
+    assert state["outdoor_temperature"] == 37.0  # OutdoorTemp_92, the fixture's own value
 
 
 def test_climate_legacy_airflow_gate_agrees_with_is_legacy_board():

--- a/tests/test_airconditioner_capabilities.py
+++ b/tests/test_airconditioner_capabilities.py
@@ -654,6 +654,22 @@ def test_lnx_rac_heatpump_no_unbound_hrefs():
     assert unbound == []
 
 
+def test_lnx_rac_heatpump_outdoor_temperature_stays_off_fahrenheit_boards():
+    """issue #367's -55 offset was field-validated on Celsius-locale boards
+    only; this fixture's own /temperatures/vs/0 declares Fahrenheit despite
+    carrying an OutdoorTemp_ token, so the sensor stays off rather than
+    apply an unvalidated offset/unit to it (see _reports_celsius)."""
+    reg, resources = _ac_lnx_rac_heatpump()
+    temps_item = resources["/temperatures/vs/0"]["x.com.samsung.da.items"][0]
+    assert temps_item["x.com.samsung.da.unit"] == "Fahrenheit"
+    options = resources["/mode/vs/0"]["x.com.samsung.da.options"]
+    assert any(o.startswith("OutdoorTemp_") for o in options)
+
+    bound = discover(resources, reg.capabilities, reg.pattern_capabilities)
+    state = flatten(bound, resources)
+    assert "outdoor_temperature" not in state
+
+
 def test_lnx_rac_heatpump_absence_power_saving_state():
     reg, resources = _ac_lnx_rac_heatpump()
     bound = discover(resources, reg.capabilities, reg.pattern_capabilities)


### PR DESCRIPTION
Fixes #367.

## Problem

`outdoor_temperature`'s `exists_fn` required `is_legacy_board`, but that gate has nothing to do with whether the `OutdoorTemp_` token itself is present. The issue's own fixture survey found 14 of 17 fixtures carrying the token are *non*-legacy boards, all silently dropping the sensor. A 48h/289-sample field capture (r=0.92 against `weather.forecast_home`) confirmed the token tracks real outdoor temperature, and no non-legacy board exposes an alternative outdoor-temperature resource.

## Fix

- Added `_has_option_token_any_board(prefix)` — a token-presence-only test with no board-generation gate — and used it just for `outdoor_temperature`. Every other `_has_option_token(...)` caller (`spi`, `auto_clean_legacy`, `air_monitoring`, `good_sleep`, `filter_time`, `filter_alarm_time`, `auto_clean_progress_legacy`, `auto_clean_stop`) is untouched, since only `OutdoorTemp_` has evidence backing an ungated read.
- Added `_reports_celsius(resources)` as a second gate. The `-55` offset was only field-validated on Celsius-locale boards (13 of the 14 non-legacy fixtures carrying the token declare Celsius on their own `/temperatures/vs/0`); the one Fahrenheit-locale fixture on record (`airconditioner_lnx_rac_heatpump`) has nothing confirming the same additive constant or unit still apply, so the sensor stays off there rather than guess.
- `enabled_default=False`: multi-split installs (several indoor heads sharing one outdoor condenser) report the identical token on every head, so ungating this would otherwise create one duplicate *active* sensor per head instead of one per physical unit.

## Tests

- Updated 13 golden fixtures (Celsius-locale, non-legacy) under `tests/fixtures/golden/` to include the new `outdoor_temperature` key.
- `tests/test_airconditioner_artik051_krac.py`: removed an assertion that had incorrectly claimed `outdoor_temperature` stays off newer boards for a "different calibrated scale" reason that doesn't hold (the board in question has no alternative outdoor-temperature resource at all); added `test_outdoor_temperature_is_not_gated_to_legacy_boards` locking in the fixed non-legacy value.
- `tests/test_airconditioner_capabilities.py`: added `test_lnx_rac_heatpump_outdoor_temperature_stays_off_fahrenheit_boards` locking in the Fahrenheit-locale gate.
- Full suite (1573 tests), `ruff check`, and `ruff format --check` all pass.

## Review

Ran an Opus-level code review pass before opening this PR. It confirmed the golden bookkeeping and blast radius were correct, but flagged that hardcoding `unit="°C"` and applying the Celsius-calibrated `-55` offset to *all* non-legacy boards was unvalidated for boards using a different temperature locale — `airconditioner_lnx_rac_heatpump` declares Fahrenheit on its own `/temperatures/vs/0`. Added the `_reports_celsius` gate above in response, with a test locking it in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFT1irpwHpWRmTCkHuK5F5)_