### PR TITLE
Bump smartthings-local floor to 0.1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ FROM ghcr.io/home-assistant/home-assistant:stable
 # repeats the install attempt on every container recreate. Baking
 # smartthings-local into the image keeps the dev container usable
 # offline and avoids relying on that runtime install path.
-RUN pip3 install --no-cache-dir "smartthings-local>=0.1.6"
+RUN pip3 install --no-cache-dir "smartthings-local>=0.1.8"

--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -11,7 +11,7 @@
   "requirements": [
     "cbor2>=5.4.6",
     "pyOpenSSL>=23.0",
-    "smartthings-local>=0.1.6"
+    "smartthings-local>=0.1.8"
   ],
   "version": "0.22.0"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest-homeassistant-custom-component>=0.13.316
 
 # Integration runtime deps, needed to import the component under test
 # (also declared in custom_components/localthings/manifest.json).
-smartthings-local>=0.1.6
+smartthings-local>=0.1.8
 cbor2>=5.4.6
 pyOpenSSL>=23.0
 cryptography>=41.0


### PR DESCRIPTION
## Why

Two `smartthings-local` releases landed since our `>=0.1.6` pin (both today), and one of them fixes a bug already reported against this repo in #361.

- **0.1.7** — server-certificate profiles (`SamsungServerProfile`), a bounded DTLS handshake deadline (`connect()` now defaults to a 12s bound instead of none), and a cancellable `connect()` via `ConnectCancellation`. Confirmed by upstream ([issue #361 comment](https://github.com/mbillow/localthings/issues/361#issuecomment-5301886346)) as additive/opt-in. Our `connect()` call sites in `coordinator.py`/`config_flow.py` pass no args, so they pick up the bounded handshake automatically; the cert-profile and cancellation pieces are opt-in and unused here.
- **0.1.8** — fixes blockwise OBSERVE notification reassembly ([QuiteYellow/SmartThings-Local#39](https://github.com/QuiteYellow/SmartThings-Local/issues/39)). A notification carrying only the first Block2 block was handed straight to `on_notification` unreassembled, and separately the Block2 loop could append a retransmitted/late block as if it were the next one, or miscompute the next offset after a mid-transfer block-size downshift. Both corrupt a multi-block observed resource — this is what's behind the `poll cbor decode: premature end of stream` / `error decoding unicode string` failures on `/mode/vs/0` reported in #361.

All new error paths stay within the existing compatible-built-in table (`ConnectionError`/`TimeoutError` subclasses per the library's README), so no exception-handling changes are needed on our side — verified by reading the 0.1.6→0.1.8 diff directly, not just the release notes.

## Why bump the floor instead of leaving `>=0.1.6`

`>=0.1.6` already lets pip resolve 0.1.8 on a **fresh** install. But an environment that already has 0.1.6 or 0.1.7 satisfying that floor won't be upgraded by Home Assistant's requirement check on integration reload — which is very likely what #361's reporter is still hitting on 0.22.0 even after the 0.1.8 release. Raising the floor to `>=0.1.8` forces that upgrade on the next LocalThings release.

## Changes

- `custom_components/localthings/manifest.json`: `smartthings-local>=0.1.6` → `>=0.1.8`
- `requirements-dev.txt`: same bump
- `Dockerfile`: same bump (baked-in dev-container install)

No source changes — confirmed via the upstream diff that `DtlsCoapSession.__init__`/`connect()` signatures, `StateCache`, and `ObserveRefreshTask` are all unchanged and backward compatible.

## Tests

Verified against `smartthings-local` 0.1.8 installed from PyPI: full suite (1573 tests), `ruff check`, `ruff format --check`, and `ty check` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFT1irpwHpWRmTCkHuK5F5)_