### PR TITLE
Stop importing the deprecated CONCENTRATION_MICROGRAMS_PER_CUBIC_METER

### DIFF
--- a/custom_components/localthings/__init__.py
+++ b/custom_components/localthings/__init__.py
@@ -7,10 +7,8 @@ import logging
 import re
 from typing import Any
 
+from homeassistant import const as ha_const
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as PARTICULATE_UNIT,
-)
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -24,6 +22,22 @@ from .registry.identity import resolve_serial
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
+
+# UnitOfDensity is the non-deprecated home for this value from whichever HA
+# release introduces it; CONCENTRATION_MICROGRAMS_PER_CUBIC_METER logs a
+# removal warning (2027.8) on those releases every time it's accessed.
+# hacs.json's floor (2025.1.0) predates UnitOfDensity existing at all, so
+# this is a runtime getattr rather than a static import ty could only ever
+# resolve against one HA generation -- see _relabel_particulate_statistics'
+# own new_unit_class feature-detection below for the same pattern. The
+# getattr short-circuits before the deprecated name is ever touched on a
+# release new enough to have UnitOfDensity.
+_unit_of_density = getattr(ha_const, "UnitOfDensity", None)
+PARTICULATE_UNIT = (
+    _unit_of_density.MICROGRAMS_PER_CUBIC_METER
+    if _unit_of_density is not None
+    else ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:


### PR DESCRIPTION
## Why

```
WARNING:homeassistant.const:The deprecated constant CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
was used from localthings. It will be removed in HA Core 2027.8. Use
UnitOfDensity.MICROGRAMS_PER_CUBIC_METER instead, please report it to the author of the
'localthings' custom integration
```

`__init__.py` had a plain `from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as PARTICULATE_UNIT` at module scope, so every load of the integration touched the deprecated name on any HA release that's added the deprecation wrapper.

## Why not just switch to `UnitOfDensity`

`hacs.json`'s floor is `2025.1.0`, and `UnitOfDensity` doesn't exist yet even in `pytest-homeassistant-custom-component` 0.13.316 (the newest available, resolving to `homeassistant` 2026.2.3) — so a straight `from homeassistant.const import UnitOfDensity` would break every HA release this integration still claims to support, and `ty check` (CI's own step) can't statically resolve it either.

## Fix

Runtime `getattr` instead of a static import:

```python
_unit_of_density = getattr(ha_const, "UnitOfDensity", None)
PARTICULATE_UNIT = (
    _unit_of_density.MICROGRAMS_PER_CUBIC_METER
    if _unit_of_density is not None
    else ha_const.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
)
```

On a release with `UnitOfDensity`, the ternary short-circuits before the deprecated name is ever touched — no warning. On an older release, it falls back to the plain (still not-yet-deprecated there) constant. Same feature-detection shape `_relabel_particulate_statistics` already uses a few lines down for `new_unit_class`, just applied to an import instead of a call signature.

Verified the branch logic directly rather than trusting it blind: against the installed HA (2026.2.3, pre-`UnitOfDensity`) it resolves to the plain constant. A simulated future `homeassistant.const` with `UnitOfDensity` added, plus a guard that raises if the deprecated name is ever accessed, resolves through the new path with the guard never firing.

## Tests

Full suite (1573 tests), `ruff check`, `ruff format --check`, and `ty check custom_components tests` (CI's exact invocation) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFT1irpwHpWRmTCkHuK5F5)_