### PR TITLE
Add microwave lamp brightness control

### DIFF
--- a/custom_components/localthings/const.py
+++ b/custom_components/localthings/const.py
@@ -4,6 +4,7 @@ PLATFORMS = [
     "sensor",
     "binary_sensor",
     "switch",
+    "light",
     "number",
     "select",
     "button",

--- a/custom_components/localthings/light.py
+++ b/custom_components/localthings/light.py
@@ -1,0 +1,51 @@
+"""Light platform for Local Things."""
+
+from __future__ import annotations
+
+from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import LocalThingsCoordinator
+from .entity import LocalThingsEntity, _is_included
+from .registry.entities import LightDesc
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        LocalThingsLight(coordinator, bound)
+        for bound in coordinator.bound
+        if isinstance(bound.desc, LightDesc) and _is_included(bound, coordinator)
+    )
+
+
+class LocalThingsLight(LocalThingsEntity, LightEntity):
+    _attr_color_mode = ColorMode.BRIGHTNESS
+
+    def __init__(self, coordinator: LocalThingsCoordinator, bound) -> None:
+        super().__init__(coordinator, bound)
+        self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+
+    @property
+    def is_on(self) -> bool | None:
+        brightness = self.brightness
+        return brightness > 0 if brightness is not None else None
+
+    @property
+    def brightness(self) -> int | None:
+        value = (self.coordinator.data or {}).get(self._state_key)
+        return int(value) if value is not None else None
+
+    async def async_turn_on(self, **kwargs) -> None:
+        brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        await self.coordinator.async_send_command(self._bound, brightness)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self.coordinator.async_send_command(self._bound, 0)

--- a/custom_components/localthings/registry/capabilities/microwave.py
+++ b/custom_components/localthings/registry/capabilities/microwave.py
@@ -17,10 +17,9 @@ different from an oven, and defined fresh here:
     that plain ovens don't report -- exposed as its own sensor.
   * Lamp: this family's option-array token is bare 'Lamp' (issue #137), not
     oven.py's 'UpperLamp', and genuinely absent on the combi dump (issue
-    #121), so it's exists_fn-gated rather than assumed universal. 'On' has
-    never been observed as a value; the only confirmed non-Off token is
-    'High' (issue #152) -- the switch treats any non-Off/non-None value as
-    "on" for reads and writes back 'High'/'Off'.
+    #121), so it's exists_fn-gated rather than assumed universal. The three
+    confirmed tokens are Off/Low/High (issues #152/#181), exposed as a native
+    HA brightness light at 0/50/100 percent.
   * Filter reminder / end signal reminder: bare 'FilterRemind'/'RemindBeep'
     option-array tokens (issue #181), gated with exists_fn like Lamp since
     the MW7300B combi dump has neither.
@@ -46,7 +45,14 @@ always error.
 """
 
 from ..capability import Capability
-from ..entities import BinarySensorDesc, NumberDesc, SelectDesc, SensorDesc, SwitchDesc
+from ..entities import (
+    BinarySensorDesc,
+    LightDesc,
+    NumberDesc,
+    SelectDesc,
+    SensorDesc,
+    SwitchDesc,
+)
 from .common import int_or_none, normalize_temp_unit, parse_iso_utc
 from .laundry import option_value, option_write
 
@@ -149,6 +155,14 @@ def _lamp_exists(rep, resources):
     return option_value(rep.get("x.com.samsung.da.options"), "Lamp") is not None
 
 
+def _lamp_brightness(options):
+    return {
+        "Off": 0,
+        "Low": 128,
+        "High": 255,
+    }.get(option_value(options, "Lamp"))
+
+
 def _filter_remind_exists(rep, resources):
     return option_value(rep.get("x.com.samsung.da.options"), "FilterRemind") is not None
 
@@ -158,13 +172,18 @@ def _remind_beep_exists(rep, resources):
 
 
 def _lamp_write(p, rep, href=None):
-    if p not in ("On", "Off"):
+    try:
+        brightness = float(p)
+    except (TypeError, ValueError):
         return None
     if not rep.get("x.com.samsung.da.options"):
         return None
-    # 'High'/'Off' are the two confirmed tokens (see module docstring);
-    # 'On' has never been observed and likely isn't recognized.
-    token = "High" if p == "On" else "Off"
+    if brightness <= 0:
+        token = "Off"
+    elif brightness <= 128:
+        token = "Low"
+    else:
+        token = "High"
     return ["mode", "vs", "0"], {
         "x.com.samsung.da.options": option_write("Lamp", token),
     }
@@ -261,12 +280,12 @@ MICROWAVE_MODE = Capability(
             value_fn=lambda opts: option_value(opts, "Sound") == "On",
             write_fn=_sound_write,
         ),
-        SwitchDesc(
+        LightDesc(
             key="lamp",
             field="x.com.samsung.da.options",
             icon="mdi:track-light",
             exists_fn=_lamp_exists,
-            value_fn=lambda opts: option_value(opts, "Lamp") not in (None, "Off"),
+            value_fn=_lamp_brightness,
             write_fn=_lamp_write,
         ),
         # issue #181: Filter Reminder / End Signal Reminder toggles, only on

--- a/custom_components/localthings/registry/entities.py
+++ b/custom_components/localthings/registry/entities.py
@@ -111,6 +111,11 @@ class SwitchDesc(SamsungEntityDescription):
 
 
 @dataclass(frozen=True, kw_only=True)
+class LightDesc(SamsungEntityDescription):
+    write_fn: WriteFn = None
+
+
+@dataclass(frozen=True, kw_only=True)
 class ButtonDesc(SamsungEntityDescription):
     payload: Any = ""
     # Optional press-time payload generation. The button platform supplies
@@ -173,6 +178,7 @@ PLATFORM_OF: dict[type, str] = {
     BinarySensorDesc: "binary_sensor",
     SelectDesc: "select",
     SwitchDesc: "switch",
+    LightDesc: "light",
     ButtonDesc: "button",
     NumberDesc: "number",
     TimeDesc: "time",

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -228,6 +228,11 @@
         }
       }
     },
+    "light": {
+      "lamp": {
+        "name": "Lampa"
+      }
+    },
     "number": {
       "cook_time": {
         "name": "Doba vaření"

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -228,6 +228,11 @@
         }
       }
     },
+    "light": {
+      "lamp": {
+        "name": "Lampe"
+      }
+    },
     "number": {
       "cook_time": {
         "name": "Kochzeit"

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -228,6 +228,11 @@
         }
       }
     },
+    "light": {
+      "lamp": {
+        "name": "Lamp"
+      }
+    },
     "number": {
       "cook_time": {
         "name": "Cook time"

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -428,6 +428,11 @@
         }
       }
     },
+    "light": {
+      "lamp": {
+        "name": "Lámpara"
+      }
+    },
     "number": {
       "cook_time": {
         "name": "Tiempo de cocción"

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -228,6 +228,11 @@
         }
       }
     },
+    "light": {
+      "lamp": {
+        "name": "Lampada"
+      }
+    },
     "number": {
       "cook_time": {
         "name": "Tempo di cottura"

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -228,6 +228,11 @@
         }
       }
     },
+    "light": {
+      "lamp": {
+        "name": "램프"
+      }
+    },
     "number": {
       "cook_time": {
         "name": "조리 시간"

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -228,6 +228,11 @@
         }
       }
     },
+    "light": {
+      "lamp": {
+        "name": "Lamp"
+      }
+    },
     "number": {
       "cook_time": {
         "name": "Bereidingstijd"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -5,6 +5,7 @@ from custom_components.localthings.registry.entities import (
     ButtonDesc,
     ClimateDesc,
     FanDesc,
+    LightDesc,
     NumberDesc,
     SelectDesc,
     SensorDesc,
@@ -39,6 +40,7 @@ def test_platform_mapping_covers_all_subclasses():
     assert PLATFORM_OF[BinarySensorDesc] == "binary_sensor"
     assert PLATFORM_OF[SelectDesc] == "select"
     assert PLATFORM_OF[SwitchDesc] == "switch"
+    assert PLATFORM_OF[LightDesc] == "light"
     assert PLATFORM_OF[ButtonDesc] == "button"
     assert PLATFORM_OF[NumberDesc] == "number"
     assert PLATFORM_OF[TimeDesc] == "time"

--- a/tests/test_golden_regression.py
+++ b/tests/test_golden_regression.py
@@ -930,8 +930,8 @@ def test_registry_reproduces_golden_state_keys_for_microwave_me7500d():
 def test_registry_reproduces_golden_state_keys_for_microwave_me7500d_lamp_high():
     """Same TP1X_DA-KS-MICROWAVE-01051/ME7500D board as microwave_me7500d
     above, but this live capture (issue #152) is the first to report a
-    non-Off Lamp token ('Lamp_High'). Locks in that the lamp switch reads
-    it as on rather than the previously-hardcoded 'On'-only comparison."""
+    non-Off Lamp token ('Lamp_High'). Locks in that the native light remains
+    present when the device is at its high brightness step."""
     from tests.conftest import _load_device
 
     resources = _load_device("microwave_me7500d_lamp_high")

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,58 @@
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+from custom_components.localthings.coordinator import LocalThingsCoordinator
+from custom_components.localthings.light import LocalThingsLight
+from custom_components.localthings.registry.discovery import BoundEntity
+
+
+def _light(brightness):
+    light = LocalThingsLight.__new__(LocalThingsLight)
+    send_command = AsyncMock()
+    light.coordinator = cast(
+        LocalThingsCoordinator,
+        SimpleNamespace(data={"lamp": brightness}, async_send_command=send_command),
+    )
+    light._state_key = "lamp"
+    light._bound = cast(BoundEntity, object())
+    return light, send_command
+
+
+def test_light_reports_off_low_and_high():
+    light, _send_command = _light(0)
+    assert light.is_on is False
+    assert light.brightness == 0
+
+    light.coordinator.data["lamp"] = 128
+    assert light.is_on is True
+    assert light.brightness == 128
+
+    light.coordinator.data["lamp"] = 255
+    assert light.is_on is True
+    assert light.brightness == 255
+
+
+def test_light_reports_unknown_state():
+    light, _send_command = _light(None)
+    assert light.is_on is None
+    assert light.brightness is None
+
+
+def test_light_commands_brightness_and_off():
+    light, send_command = _light(0)
+
+    asyncio.run(light.async_turn_on(brightness=128))
+    send_command.assert_awaited_once_with(light._bound, 128)
+
+    send_command.reset_mock()
+    asyncio.run(light.async_turn_off())
+    send_command.assert_awaited_once_with(light._bound, 0)
+
+
+def test_light_turn_on_defaults_to_high():
+    light, send_command = _light(0)
+
+    asyncio.run(light.async_turn_on())
+    send_command.assert_awaited_once_with(light._bound, 255)

--- a/tests/test_microwave_capabilities.py
+++ b/tests/test_microwave_capabilities.py
@@ -9,6 +9,7 @@ from custom_components.localthings.registry.capabilities import microwave, range
 from custom_components.localthings.registry.discovery import discover
 from custom_components.localthings.registry.entities import (
     BinarySensorDesc,
+    LightDesc,
     NumberDesc,
     SelectDesc,
     SwitchDesc,
@@ -183,6 +184,10 @@ def _microwave_cooking_mode_desc():
     return next(e for e in microwave.MICROWAVE_MODE.entities if isinstance(e, SelectDesc))
 
 
+def _microwave_lamp_desc():
+    return next(e for e in microwave.MICROWAVE_MODE.entities if isinstance(e, LightDesc))
+
+
 def test_microwave_mode_options_nonempty():
     desc = _microwave_cooking_mode_desc()
     assert callable(desc.options)
@@ -261,11 +266,7 @@ def test_sound_write_is_single_token():
 def test_lamp_gated_absent_when_no_lamp_option():
     """Issue #121's combi dump has no 'Lamp_*' token at all -- unlike
     oven.py's lamp switch (assumed universal), this one self-gates off."""
-    desc = next(
-        e
-        for e in microwave.MICROWAVE_MODE.entities
-        if e.key == "lamp" and isinstance(e, SwitchDesc)
-    )
+    desc = _microwave_lamp_desc()
     rep = {"x.com.samsung.da.options": ["DeviceType_MW7300B-/EU1", "Sound_Off"]}
     assert desc.exists_fn is not None
     assert desc.exists_fn(rep, {}) is False
@@ -273,54 +274,64 @@ def test_lamp_gated_absent_when_no_lamp_option():
 
 def test_lamp_gated_present_when_lamp_option_reported():
     """Issue #137's plain microwave reports 'Lamp_Off'."""
-    desc = next(
-        e
-        for e in microwave.MICROWAVE_MODE.entities
-        if e.key == "lamp" and isinstance(e, SwitchDesc)
-    )
+    desc = _microwave_lamp_desc()
     rep = {"x.com.samsung.da.options": ["Lamp_Off", "Sound_On"]}
     assert desc.exists_fn is not None
     assert desc.exists_fn(rep, {}) is True
 
 
-def test_lamp_write_is_single_token():
-    """issue #152: the device has never been observed accepting 'On' --
-    only 'High'/'Off' -- so the switch's "on" write uses 'High'."""
-    desc = next(
-        e
-        for e in microwave.MICROWAVE_MODE.entities
-        if e.key == "lamp" and isinstance(e, SwitchDesc)
-    )
+def test_lamp_high_write_is_single_token():
+    desc = _microwave_lamp_desc()
     rep = {"x.com.samsung.da.options": ["Lamp_Off"]}
     assert desc.write_fn is not None
-    result = desc.write_fn("On", rep)
+    result = desc.write_fn(255, rep)
     assert result is not None
     path, body = result
     assert path == ["mode", "vs", "0"]
     assert body == {"x.com.samsung.da.options": ["Lamp_High"]}
 
 
-def test_lamp_write_requires_existing_options():
-    desc = next(
-        e
-        for e in microwave.MICROWAVE_MODE.entities
-        if e.key == "lamp" and isinstance(e, SwitchDesc)
-    )
+def test_lamp_low_write_is_single_token():
+    desc = _microwave_lamp_desc()
+    rep = {"x.com.samsung.da.options": ["Lamp_High"]}
     assert desc.write_fn is not None
-    assert desc.write_fn("On", {}) is None
+    result = desc.write_fn(128, rep)
+    assert result is not None
+    path, body = result
+    assert path == ["mode", "vs", "0"]
+    assert body == {"x.com.samsung.da.options": ["Lamp_Low"]}
 
 
-def test_lamp_reads_off_as_false():
-    desc = next(e for e in microwave.MICROWAVE_MODE.entities if e.key == "lamp")
-    assert desc.value_fn(["Lamp_Off"]) is False
+def test_lamp_off_write_is_single_token():
+    desc = _microwave_lamp_desc()
+    rep = {"x.com.samsung.da.options": ["Lamp_High"]}
+    assert desc.write_fn is not None
+    result = desc.write_fn(0, rep)
+    assert result is not None
+    _path, body = result
+    assert body == {"x.com.samsung.da.options": ["Lamp_Off"]}
 
 
-def test_lamp_reads_any_non_off_level_as_true():
-    """issue #152's ME7500D reports 'Lamp_High', not the binary 'Lamp_On'
-    #137's dump implied -- any non-Off/non-absent value must read as on, not
-    just a literal 'On'."""
-    desc = next(e for e in microwave.MICROWAVE_MODE.entities if e.key == "lamp")
-    assert desc.value_fn(["Lamp_High"]) is True
+def test_lamp_write_requires_existing_options():
+    desc = _microwave_lamp_desc()
+    assert desc.write_fn is not None
+    assert desc.write_fn(255, {}) is None
+
+
+def test_lamp_reads_off_as_zero_brightness():
+    desc = _microwave_lamp_desc()
+    assert desc.value_fn(["Lamp_Off"]) == 0
+
+
+def test_lamp_reads_low_and_high_brightness():
+    desc = _microwave_lamp_desc()
+    assert desc.value_fn(["Lamp_Low"]) == 128
+    assert desc.value_fn(["Lamp_High"]) == 255
+
+
+def test_lamp_reads_unknown_level_as_unknown():
+    desc = _microwave_lamp_desc()
+    assert desc.value_fn(["Lamp_Night"]) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a native Home Assistant light platform for writable LocalThings lights
- expose the microwave lamp's confirmed `Lamp_Off`, `Lamp_Low`, and `Lamp_High` tokens as 0%, 50%, and 100% brightness
- add platform, capability, translation, golden-regression, and entity behavior coverage

This addresses the microwave lamp level/control portion discussed in #181. It does not resolve the other topics covered by that issue.

## Validation

- `ruff format --check custom_components tests`
- `ruff check custom_components tests`
- `ty check custom_components tests`
- 1,242 HA-independent tests passed on Windows
- focused light, microwave, translation, unique-ID, and golden tests passed
- confirmed on a Samsung ME7500D through Home Assistant: Low reported brightness 128, High reported 255, and Off returned the lamp to off