### PR TITLE
Explore identity-bound OCF endpoint selection for a WD86 washer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This integration uses the [`smartthings-local`](https://github.com/QuiteYellow/S
 
 ### What you get
 
-Adding a device just needs a host IP and your CA credentials in the UI. The integration reads the appliance's identity and picks the matching capability registry on its own, so there's no per-model descriptor to write for a new unit of a type that's already supported.
+Adding a device normally just needs a host IP and your CA credentials in the UI. The integration reads the appliance's identity and picks the matching capability registry on its own, so there's no per-model descriptor to write for a new unit of a type that's already supported. For the uncommon case where one physical host exposes several logical OCF devices, the advanced setup path can bind endpoint selection to one exact OCF device UUID.
 
 Credential setup is one-time. The first device you add asks for a CA certificate and key (see Part 2); every device after that reuses the same stored CA and only asks for the host IP, minting its own per-device leaf cert automatically.
 
@@ -81,9 +81,13 @@ This repo doesn't include the needed CA bundle. For an example of how to obtain 
 1. Copy `custom_components/localthings/` into your HA config's `custom_components/` directory. (Or add this repo as a custom repository in HACS — `Integration` category — and install it from there.)
 2. Restart HA.
 3. **Settings > Devices & Services > Add Integration > LocalThings.**
-4. First device: paste the appliance's IP, plus the contents of the CA private and public key from Part 2.
-5. The flow sends a DTLS `ClientHello` to every port in the `49152-49160` range at once and keeps the one that answers -- a real DTLS server identifies itself in about one round trip, and the probe stops there, so nothing is left behind on the appliance. Only that port is then given a real certificate handshake: it fetches the current UUID from Samsung's cloud gateway, mints a leaf cert signed by your CA, and reads the device's identity and `/device/0`. On success it creates the config entry, already knowing the appliance's serial, model, and type.
+4. First device: paste the appliance's IP, plus the contents of the CA private and public key from Part 2. Leave **Exact OCF device UUID (advanced)** blank for normal setup.
+5. With the advanced field left blank, the flow sends a DTLS `ClientHello` to every port in the `49152-49160` range at once and keeps the one that answers -- a real DTLS server identifies itself in about one round trip, and the probe stops there, so nothing is left behind on the appliance. Only that port is then given a real certificate handshake: it fetches the current UUID from Samsung's cloud gateway, mints a leaf cert signed by your CA, and reads the device's identity and `/device/0`. On success it creates the config entry, already knowing the appliance's serial, model, and type. Supplying an exact OCF device UUID uses the identity-bound path below instead and never scans or falls back to the fixed port band.
 6. Every subsequent device only asks for the host IP. The stored CA credentials are reused, and so is the leaf cert itself -- every appliance accepts the same one -- so adding a second appliance doesn't depend on Samsung's cloud being reachable at all. If a device rejects the reused cert (the UUID behind it does rotate), the flow mints a fresh one and retries by itself.
+
+For the uncommon case where one IP exposes several logical OCF devices, the advanced field accepts the exact OCF device UUID (`di`). This is the UUID reported by the target's authenticated OCF `/oic/d` resource, not the SmartThings platform device ID or a Samsung cloud certificate UUID. Use this path only when that exact value is already available from authenticated OCF diagnostics; LocalThings does not derive it from SmartThings metadata. The flow runs identity-aware multicast discovery on Home Assistant's route-selected IPv4 interface, accepts only a stable exact-`di` advertisement from the submitted IP, and statelessly probes only the advertised secure ports. After authentication it reads `/oic/d` and requires the same exact UUID before it requests `/device/0` or creates an entry. It never falls back to `pi`, a serial number, the host, or the normal fixed port band on this explicit path.
+
+This advanced field changes setup-time endpoint selection and identity verification only. It does not acquire credentials, perform ownership transfer, add reconnect-time rediscovery, or make an appliance compatible with the certificate authentication described in Part 2 if that appliance requires a different authentication method.
 
 Entities appear under one HA device per appliance, named for the appliance's type and model. Rename freely: the device is keyed on the appliance's own OCF device ID, not its name. (Some Samsung models ship the same serial number on every unit of a model, so the serial can't tell two of them apart -- the OCF device ID can.)
 

--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -52,6 +52,7 @@ from .const import (
     CONF_LEARN_MODES,
     CONF_MANUFACTURER,
     CONF_MODEL,
+    CONF_OCF_DEVICE_ID,
     CONF_PORT,
     CONF_SERIAL,
     DEFAULT_CLOUD_COURSES_ENABLED,
@@ -153,6 +154,42 @@ class UnexpectedResponse(CannotConnect):
     """We authenticated, but the device didn't return a usable description."""
 
     error_key = "unexpected_response"
+
+
+class IdentityDiscoveryUnavailable(CannotConnect):
+    """Identity-bound discovery is unavailable on this host or installation."""
+
+    error_key = "identity_discovery_unavailable"
+
+
+class IdentityTargetNotFound(CannotConnect):
+    """No stable advertisement matched the requested OCF device UUID."""
+
+    error_key = "identity_target_not_found"
+
+
+class IdentityTargetAmbiguous(CannotConnect):
+    """Discovery could not select one stable endpoint for the requested UUID."""
+
+    error_key = "identity_target_ambiguous"
+
+
+class IdentityAdvertisementInvalid(CannotConnect):
+    """The matching discovery response did not contain a safe endpoint."""
+
+    error_key = "identity_advertisement_invalid"
+
+
+class IdentityNoDtlsServer(CannotConnect):
+    """Advertised endpoint candidates did not identify one DTLS listener."""
+
+    error_key = "identity_no_dtls_server"
+
+
+class IdentityMismatch(CannotConnect):
+    """The authenticated endpoint did not report the requested OCF identity."""
+
+    error_key = "identity_mismatch"
 
 
 class InvalidCA(Exception):
@@ -478,6 +515,59 @@ def _scan_ports(host: str) -> _PortScan:
     return _PortScan(candidates, [], sweep)
 
 
+def _identity_discovery_failure(reason: str) -> CannotConnect:
+    """Map a low-level, redacted discovery reason to a stable UI failure."""
+
+    failures: dict[str, type[CannotConnect]] = {
+        "unavailable": IdentityDiscoveryUnavailable,
+        "not_found": IdentityTargetNotFound,
+        "ambiguous": IdentityTargetAmbiguous,
+        "invalid_advertisement": IdentityAdvertisementInvalid,
+        "address_mismatch": IdentityAdvertisementInvalid,
+    }
+    failure = failures.get(reason, IdentityAdvertisementInvalid)
+    return failure("Identity-bound endpoint discovery could not select a safe endpoint")
+
+
+def _scan_identity_endpoint(
+    host: str,
+    target_device_id: str,
+    interface_address: str,
+) -> _PortScan:
+    """Select and statelessly verify only the endpoint bound to one OCF ``di``.
+
+    This path intentionally has no fixed-band or known-host fallback.  Falling
+    back after the caller supplied an exact logical-device identity would lose
+    the identity-to-source binding that made this path necessary.
+    """
+
+    from .endpoint_discovery import (
+        IdentityEndpointDiscoveryError,
+        discover_identity_endpoint,
+    )
+
+    try:
+        endpoint = discover_identity_endpoint(host, target_device_id, interface_address)
+    except IdentityEndpointDiscoveryError as exc:
+        raise _identity_discovery_failure(exc.reason) from exc
+
+    try:
+        confirmed = _clienthello_scan(endpoint.address, list(endpoint.ports))
+    except Exception as exc:
+        raise IdentityDiscoveryUnavailable(
+            "Identity-bound endpoint candidates could not be checked"
+        ) from exc
+    if not confirmed:
+        raise IdentityNoDtlsServer(
+            "The identity-bound advertisement did not identify a live DTLS endpoint"
+        )
+    if len(confirmed) != 1:
+        raise IdentityTargetAmbiguous(
+            "More than one identity-bound endpoint answered the stateless DTLS probe"
+        )
+    return _PortScan(candidates=confirmed, confirmed=confirmed)
+
+
 # TLS alerts (RFC 5246 §7.2) that mean "I looked at your certificate and
 # said no", as opposed to a protocol/cipher disagreement -- what an
 # appliance sends when the CA behind the leaf isn't one it trusts, the
@@ -644,7 +734,12 @@ def _mint_credentials(ca_cert_pem: str, ca_key_pem: str) -> tuple[str, str]:
     return fullchain_pem, leaf_key_pem
 
 
-def _read_device(sess, host: str, port: int) -> dict:
+def _read_device(
+    sess,
+    host: str,
+    port: int,
+    expected_device_id: str | None = None,
+) -> dict:
     """Resolve this device's identity over an already-connected session.
 
     /oic/d before /device/0, deliberately: the device's own OCF device-type
@@ -671,6 +766,26 @@ def _read_device(sess, host: str, port: int) -> dict:
     )
 
     identity = read_identity(sess, None)
+    if expected_device_id is not None:
+        from .endpoint_discovery import normalize_ocf_device_id
+
+        raw_device = identity.raw.get("/oic/d")
+        raw_device_id = (
+            raw_device.get("di")
+            if isinstance(raw_device, dict) and "di" in raw_device
+            else identity.device_id
+        )
+        try:
+            actual_device_id = normalize_ocf_device_id(raw_device_id)
+        except ValueError:
+            actual_device_id = None
+        if actual_device_id != expected_device_id:
+            # Never fall back to pi, serial, or host here.  The caller chose
+            # this path specifically to bind one logical OCF device, and the
+            # authenticated /oic/d response is the authoritative final gate.
+            raise IdentityMismatch(
+                "The authenticated endpoint did not report the requested OCF device identity"
+            )
 
     code, payload = sess.get(["device", "0"], timeout=PROBE_GET_TIMEOUT_S)
     if code != 0x45 or not payload:
@@ -697,7 +812,7 @@ def _read_device(sess, host: str, port: int) -> dict:
         # kept alongside it because the coordinator corroborates a later
         # change of key against it (issue #381). read_identity has already
         # fetched /oic/p and /oic/d above, so this costs no extra round trip.
-        "device_key": resolve_device_key(identity, raw_serial, host),
+        "device_key": expected_device_id or resolve_device_key(identity, raw_serial, host),
         "serial": resolve_serial(raw_serial, host),
         "model": resolve_model(info.get("x.com.samsung.da.modelNum", ""), identity),
         "manufacturer": identity.manufacturer or "Samsung",
@@ -740,7 +855,13 @@ def _diagnose_failures(
     return {port: alert} if alert is not None else {}
 
 
-def _handshake_and_read(host: str, scan: _PortScan, cert_pem: str, key_pem: str) -> dict:
+def _handshake_and_read(
+    host: str,
+    scan: _PortScan,
+    cert_pem: str,
+    key_pem: str,
+    expected_device_id: str | None = None,
+) -> dict:
     """Handshake each candidate in turn, returning the first device that answers."""
     from smartthings_local.protocol.dtls_session import DtlsCoapSession
 
@@ -751,7 +872,7 @@ def _handshake_and_read(host: str, scan: _PortScan, cert_pem: str, key_pem: str)
             sess = DtlsCoapSession(host, port, cert_pem=cert_pem, key_pem=key_pem)
             sess.connect()
             sess.start_reader()
-            return _read_device(sess, host, port)
+            return _read_device(sess, host, port, expected_device_id)
         except CannotConnect:
             # The device answered, just not with something we can use --
             # trying the remaining ports can't improve on that.
@@ -772,6 +893,8 @@ def _probe_and_validate(
     ca_cert_pem: str,
     ca_key_pem: str,
     existing_leaf: tuple[str, str] | None = None,
+    target_device_id: str | None = None,
+    interface_address: str | None = None,
 ) -> dict:
     """Find the device's port, authenticate to it, and resolve its identity.
 
@@ -785,7 +908,14 @@ def _probe_and_validate(
     stale (the UUID does rotate), a confirmed-live device rejecting it
     re-mints and retries once, so the reuse stays self-correcting.
     """
-    scan = _scan_ports(host)
+    if target_device_id is None:
+        scan = _scan_ports(host)
+    else:
+        if interface_address is None:
+            raise IdentityDiscoveryUnavailable(
+                "No local IPv4 interface was available for identity-bound discovery"
+            )
+        scan = _scan_identity_endpoint(host, target_device_id, interface_address)
 
     if existing_leaf is not None:
         cert_pem, key_pem = existing_leaf
@@ -794,7 +924,7 @@ def _probe_and_validate(
         cert_pem, key_pem = _mint_credentials(ca_cert_pem, ca_key_pem)
 
     try:
-        info = _handshake_and_read(host, scan, cert_pem, key_pem)
+        info = _handshake_and_read(host, scan, cert_pem, key_pem, target_device_id)
     except CertRejected:
         # The only failure a fresh certificate can fix, and only worth a
         # second pass when the certificate wasn't freshly minted already.
@@ -802,7 +932,7 @@ def _probe_and_validate(
             raise
         _LOGGER.debug("Reused leaf rejected by %s; re-minting and retrying", host)
         cert_pem, key_pem = _mint_credentials(ca_cert_pem, ca_key_pem)
-        info = _handshake_and_read(host, scan, cert_pem, key_pem)
+        info = _handshake_and_read(host, scan, cert_pem, key_pem, target_device_id)
 
     return {**info, "leaf_cert_pem": cert_pem, "leaf_key_pem": key_pem}
 
@@ -862,7 +992,38 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors: dict[str, str] = {}
 
+        if has_creds:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_HOST): _TEXT,
+                    vol.Optional(CONF_OCF_DEVICE_ID): _TEXT,
+                }
+            )
+            step_id = "user_reuse"
+        else:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_HOST): _TEXT,
+                    vol.Optional(CONF_OCF_DEVICE_ID): _TEXT,
+                    vol.Required(CONF_CA_CERT_PEM): _MULTILINE,
+                    vol.Required(CONF_CA_KEY_PEM): _MULTILINE,
+                }
+            )
+            step_id = "user"
+
         if user_input is not None:
+            from .endpoint_discovery import normalize_ocf_device_id
+
+            try:
+                target_device_id = normalize_ocf_device_id(user_input.get(CONF_OCF_DEVICE_ID))
+            except ValueError:
+                errors[CONF_OCF_DEVICE_ID] = "invalid_ocf_device_id"
+                return self.async_show_form(
+                    step_id=step_id,
+                    data_schema=self.add_suggested_values_to_schema(schema, user_input),
+                    errors=errors,
+                )
+
             self._host = user_input[CONF_HOST].strip()
             existing_leaf = None
             if has_creds:
@@ -879,13 +1040,38 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._ca_key_pem = _normalize_pem(user_input[CONF_CA_KEY_PEM])
 
             try:
-                info = await self.hass.async_add_executor_job(
-                    _probe_and_validate,
-                    self._host,
-                    self._ca_cert_pem,
-                    self._ca_key_pem,
-                    existing_leaf,
-                )
+                if target_device_id is None:
+                    # Preserve the existing scan and executor call exactly for
+                    # ordinary setup.  Identity-aware discovery is opt-in and
+                    # cannot add latency to this path.
+                    info = await self.hass.async_add_executor_job(
+                        _probe_and_validate,
+                        self._host,
+                        self._ca_cert_pem,
+                        self._ca_key_pem,
+                        existing_leaf,
+                    )
+                else:
+                    from homeassistant.components import network
+
+                    try:
+                        interface_address = await network.async_get_source_ip(
+                            self.hass,
+                            target_ip=self._host,
+                        )
+                    except Exception as exc:
+                        raise IdentityDiscoveryUnavailable(
+                            "No local IPv4 route was available for identity-bound discovery"
+                        ) from exc
+                    info = await self.hass.async_add_executor_job(
+                        _probe_and_validate,
+                        self._host,
+                        self._ca_cert_pem,
+                        self._ca_key_pem,
+                        existing_leaf,
+                        target_device_id,
+                        interface_address,
+                    )
             except (CannotConnect, InvalidCA) as exc:
                 # Every probe failure carries the message that fits it (see
                 # CannotConnect); the log line is where the specifics live.
@@ -927,19 +1113,6 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return self._create_entry(info)
                 self._pending_info = info
                 return await self.async_step_confirm_unknown_type()
-
-        if has_creds:
-            schema = vol.Schema({vol.Required(CONF_HOST): _TEXT})
-            step_id = "user_reuse"
-        else:
-            schema = vol.Schema(
-                {
-                    vol.Required(CONF_HOST): _TEXT,
-                    vol.Required(CONF_CA_CERT_PEM): _MULTILINE,
-                    vol.Required(CONF_CA_KEY_PEM): _MULTILINE,
-                }
-            )
-            step_id = "user"
 
         return self.async_show_form(
             step_id=step_id,

--- a/custom_components/localthings/const.py
+++ b/custom_components/localthings/const.py
@@ -14,6 +14,7 @@ PLATFORMS = [
 ]
 
 CONF_HOST = "host"
+CONF_OCF_DEVICE_ID = "ocf_device_id"
 CONF_PORT = "port"
 CONF_CA_CERT_PEM = "ca_cert_pem"
 CONF_CA_KEY_PEM = "ca_key_pem"

--- a/custom_components/localthings/endpoint_discovery.py
+++ b/custom_components/localthings/endpoint_discovery.py
@@ -1,0 +1,167 @@
+"""Identity-bound OCF endpoint selection for composite appliance hosts.
+
+This is deliberately separate from the normal known-host port scan.  A host
+that exposes several logical OCF devices can advertise more than one secure
+endpoint, so callers holding an exact OCF device UUID (``di``) must preserve
+the discovery response's ``di -> source address -> secure ports`` binding.
+
+The low-level helper returns candidates, not authenticated identity.  The
+config flow still performs a stateless DTLS probe and, after authentication,
+checks ``/oic/d.di`` before it accepts the endpoint.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from ipaddress import IPv4Address, ip_address
+from typing import Final, Literal
+from uuid import UUID
+
+IdentityDiscoveryReason = Literal[
+    "unavailable",
+    "not_found",
+    "ambiguous",
+    "invalid_advertisement",
+    "address_mismatch",
+]
+
+_HELPER_ERROR_REASONS: Final[dict[str, IdentityDiscoveryReason]] = {
+    "interface_unavailable": "unavailable",
+    "no_ocf_response": "not_found",
+    "target_not_found": "not_found",
+    "ambiguous_target": "ambiguous",
+    "target_not_stable": "ambiguous",
+    "malformed_ocf_response": "invalid_advertisement",
+    "no_secure_ports": "invalid_advertisement",
+}
+
+
+class IdentityEndpointDiscoveryError(Exception):
+    """A redacted identity-bound discovery failure."""
+
+    def __init__(self, reason: IdentityDiscoveryReason) -> None:
+        self.reason = reason
+        super().__init__(f"identity-bound endpoint discovery failed ({reason})")
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class IdentityEndpoint:
+    """Source-bound secure-port candidates without sensitive ``repr`` output."""
+
+    address: str
+    ports: tuple[int, ...]
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} found=True port_count={len(self.ports)}>"
+
+
+def normalize_ocf_device_id(value: object) -> str | None:
+    """Return one canonical, non-zero OCF device UUID or reject the input."""
+
+    if value is None:
+        return None
+    if isinstance(value, UUID):
+        parsed = value
+        if parsed.int == 0:
+            raise ValueError("invalid OCF device UUID")
+        return str(parsed)
+    if isinstance(value, bytes):
+        if len(value) == 16:
+            parsed = UUID(bytes=value)
+            if parsed.int == 0:
+                raise ValueError("invalid OCF device UUID")
+            return str(parsed)
+        try:
+            value = value.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise ValueError("invalid OCF device UUID") from exc
+    if not isinstance(value, str):
+        raise ValueError("invalid OCF device UUID")
+    candidate = (value or "").strip()
+    if not candidate:
+        return None
+    folded = candidate.casefold()
+    for prefix in ("urn:uuid:", "uuid:"):
+        if folded.startswith(prefix):
+            candidate = candidate[len(prefix) :]
+            break
+    try:
+        parsed = UUID(candidate)
+    except (ValueError, AttributeError) as exc:
+        raise ValueError("invalid OCF device UUID") from exc
+    if parsed.int == 0 or candidate.casefold() != str(parsed):
+        raise ValueError("invalid OCF device UUID")
+    return str(parsed)
+
+
+def _literal_ipv4(value: str, *, mismatch: bool = False) -> IPv4Address:
+    try:
+        parsed = ip_address(value)
+    except ValueError as exc:
+        reason: IdentityDiscoveryReason = "address_mismatch" if mismatch else "unavailable"
+        raise IdentityEndpointDiscoveryError(reason) from exc
+    if not isinstance(parsed, IPv4Address):
+        reason = "address_mismatch" if mismatch else "unavailable"
+        raise IdentityEndpointDiscoveryError(reason)
+    return parsed
+
+
+def discover_identity_endpoint(
+    host: str,
+    target_device_id: str,
+    interface_address: str,
+) -> IdentityEndpoint:
+    """Discover source-bound secure ports for exactly ``target_device_id``.
+
+    ``host`` and ``interface_address`` must be literal IPv4 addresses.  The
+    multicast response is accepted only when its source address is the host
+    the user submitted; discovery can select a logical device, but it cannot
+    redirect the config flow to another physical host.
+    """
+
+    expected_host = _literal_ipv4(host)
+    _literal_ipv4(interface_address)
+    normalized_device_id = normalize_ocf_device_id(target_device_id)
+    if normalized_device_id is None:
+        raise IdentityEndpointDiscoveryError("invalid_advertisement")
+
+    try:
+        discovery_module = import_module("smartthings_local.protocol.ocf_discovery")
+        discover_ocf_secure_ports_multicast = discovery_module.discover_ocf_secure_ports_multicast
+    except (ImportError, AttributeError) as exc:
+        raise IdentityEndpointDiscoveryError("unavailable") from exc
+
+    try:
+        result = discover_ocf_secure_ports_multicast(
+            normalized_device_id,
+            interface_address=interface_address,
+        )
+    except Exception as exc:
+        raise IdentityEndpointDiscoveryError("unavailable") from exc
+
+    if not result.found:
+        reason = _HELPER_ERROR_REASONS.get(result.error_code, "invalid_advertisement")
+        raise IdentityEndpointDiscoveryError(reason)
+    if not isinstance(result.address, str):
+        raise IdentityEndpointDiscoveryError("invalid_advertisement")
+
+    response_host = _literal_ipv4(result.address, mismatch=True)
+    if response_host != expected_host:
+        raise IdentityEndpointDiscoveryError("address_mismatch")
+
+    raw_ports = result.ports
+    if not isinstance(raw_ports, tuple):
+        raise IdentityEndpointDiscoveryError("invalid_advertisement")
+    ports = tuple(
+        sorted(
+            {
+                port
+                for port in raw_ports
+                if isinstance(port, int) and not isinstance(port, bool) and 1 <= port <= 65535
+            }
+        )
+    )
+    if not ports or len(ports) != len(raw_ports):
+        raise IdentityEndpointDiscoveryError("invalid_advertisement")
+    return IdentityEndpoint(address=str(response_host), ports=ports)

--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -4,7 +4,7 @@
   "after_dependencies": ["recorder"],
   "codeowners": ["@mbillow"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["network"],
   "documentation": "https://github.com/mbillow/localthings",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mbillow/localthings/issues",

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -1500,11 +1500,13 @@
         "description": "Zadejte IP adresu vašeho spotřebiče Samsung a přihlašovací údaje CA AC14K_M použité k vydávání certifikátů zařízení.",
         "data": {
           "host": "IP adresa",
+          "ocf_device_id": "Přesné UUID zařízení OCF (pokročilé)",
           "ca_cert_pem": "Certifikát CA (PEM)",
           "ca_key_pem": "Privátní klíč CA (PEM)"
         },
         "data_description": {
           "host": "Lokální IP adresa vašeho spotřebiče Samsung (např. 192.168.1.50).",
+          "ocf_device_id": "Volitelné přesné UUID zařízení OCF (di) pro hostitele, který zpřístupňuje více logických zařízení. Pro běžné nastavení ponechte prázdné. Nejde o ID zařízení platformy SmartThings.",
           "ca_cert_pem": "Certifikát CA AC14K_M ve formátu PEM. Vložte celý obsah řetězce fullchain PEM včetně všech bloků BEGIN/END CERTIFICATE.",
           "ca_key_pem": "Privátní klíč AC14K_M ve formátu PEM. Vložte celý obsah včetně hlavičky a patičky BEGIN/END PRIVATE KEY."
         }
@@ -1513,10 +1515,12 @@
         "title": "Přidat spotřebič Samsung",
         "description": "Zadejte IP adresu vašeho spotřebiče Samsung. Přihlašovací údaje CA z existujícího spotřebiče LocalThings budou znovu použity.",
         "data": {
-          "host": "IP adresa"
+          "host": "IP adresa",
+          "ocf_device_id": "Přesné UUID zařízení OCF (pokročilé)"
         },
         "data_description": {
-          "host": "Lokální IP adresa vašeho spotřebiče Samsung (např. 192.168.1.50)."
+          "host": "Lokální IP adresa vašeho spotřebiče Samsung (např. 192.168.1.50).",
+          "ocf_device_id": "Volitelné přesné UUID zařízení OCF (di) pro hostitele, který zpřístupňuje více logických zařízení. Pro běžné nastavení ponechte prázdné. Nejde o ID zařízení platformy SmartThings."
         }
       },
       "confirm_unknown_type": {
@@ -1533,6 +1537,13 @@
       "handshake_failed": "Spotřebič odmítl DTLS handshake z důvodu, který nesouvisí s certifikátem — nejspíše kvůli neshodě protokolu nebo šifry. Přesný alert najdete v logu Home Assistanta.",
       "cloud_unreachable": "Nepodařilo se spojit s cloudovou bránou Samsung a získat UUID potřebné k vystavení certifikátu tohoto zařízení. Zkontrolujte přístup Home Assistanta k internetu a zkuste to znovu.",
       "unexpected_response": "Připojení k zařízení proběhlo úspěšně, ale nevrátilo použitelný popis zařízení. Nemusí jít o spotřebič, který tato integrace podporuje. Co zařízení odeslalo, najdete v logu Home Assistanta.",
+      "invalid_ocf_device_id": "Zadejte jedno kanonické nenulové UUID zařízení OCF (di), nebo toto pokročilé pole ponechte prázdné.",
+      "identity_discovery_unavailable": "Zjišťování podle identity nelze spustit. Ověřte, že Home Assistant má rozhraní IPv4 v síti spotřebiče a že tato verze obsahuje požadované rozhraní API smartthings-local.",
+      "identity_target_not_found": "Na zadané IP adrese nebyla nalezena stabilní reklama OCF odpovídající tomuto UUID. Ověřte IP adresu a přesné UUID zařízení OCF (di).",
+      "identity_target_ambiguous": "Zjišťování podle identity našlo více než jeden aktivní koncový bod nebo se výsledek mezi koly změnil. Nic nebylo vybráno.",
+      "identity_advertisement_invalid": "Odpovídající reklama OCF neobsahovala bezpečný zabezpečený koncový bod vázaný na zdroj. Nic nebylo vybráno.",
+      "identity_no_dtls_server": "Odpovídající reklama OCF vrátila kandidáty zabezpečených portů, ale neurčila právě jeden aktivní server DTLS.",
+      "identity_mismatch": "Ověřený koncový bod nahlásil jiné nebo chybějící UUID zařízení OCF. Nastavení bylo zastaveno před načtením nebo přidáním zařízení.",
       "cannot_connect": "Nelze se připojit k zařízení. Ověřte, že je IP adresa dostupná a že jsou přihlašovací údaje CA správné.",
       "invalid_ca": "Certifikát CA nebo privátní klíč se nepodařilo načíst. Ověřte, že obsah PEM je správný a že klíč odpovídá certifikátu.",
       "unknown": "Neočekávaná chyba. Podrobnosti najdete v protokolech Home Assistant."

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -1500,11 +1500,13 @@
         "description": "Geben Sie die IP-Adresse Ihres Samsung-Geräts sowie die AC14K_M-CA-Zugangsdaten ein, mit denen Gerätezertifikate erstellt werden.",
         "data": {
           "host": "IP-Adresse",
+          "ocf_device_id": "Exakte OCF-Geräte-UUID (erweitert)",
           "ca_cert_pem": "CA-Zertifikat (PEM)",
           "ca_key_pem": "CA-Privatschlüssel (PEM)"
         },
         "data_description": {
           "host": "Lokale IP-Adresse Ihres Samsung-Geräts (z. B. 192.168.1.50).",
+          "ocf_device_id": "Optionale exakte OCF-Geräte-UUID (di) für einen Host, der mehrere logische Geräte bereitstellt. Für die normale Einrichtung leer lassen. Dies ist nicht die SmartThings-Plattform-Geräte-ID.",
           "ca_cert_pem": "Die PEM-codierte AC14K_M-CA-Zertifikatskette. Fügen Sie den vollständigen Inhalt Ihrer Fullchain-PEM-Datei ein, einschließlich aller BEGIN/END CERTIFICATE-Blöcke.",
           "ca_key_pem": "Der PEM-codierte AC14K_M-Privatschlüssel. Fügen Sie den vollständigen Inhalt einschließlich der BEGIN/END PRIVATE KEY-Kopf- und Fußzeile ein."
         }
@@ -1513,10 +1515,12 @@
         "title": "Samsung-Gerät hinzufügen",
         "description": "Geben Sie die IP-Adresse Ihres Samsung-Geräts ein. Die CA-Zugangsdaten eines bereits vorhandenen LocalThings-Geräts werden wiederverwendet.",
         "data": {
-          "host": "IP-Adresse"
+          "host": "IP-Adresse",
+          "ocf_device_id": "Exakte OCF-Geräte-UUID (erweitert)"
         },
         "data_description": {
-          "host": "Lokale IP-Adresse Ihres Samsung-Geräts (z. B. 192.168.1.50)."
+          "host": "Lokale IP-Adresse Ihres Samsung-Geräts (z. B. 192.168.1.50).",
+          "ocf_device_id": "Optionale exakte OCF-Geräte-UUID (di) für einen Host, der mehrere logische Geräte bereitstellt. Für die normale Einrichtung leer lassen. Dies ist nicht die SmartThings-Plattform-Geräte-ID."
         }
       },
       "confirm_unknown_type": {
@@ -1533,6 +1537,13 @@
       "handshake_failed": "Das Gerät hat den DTLS-Handshake aus einem Grund abgelehnt, der nichts mit dem Zertifikat zu tun hat — höchstwahrscheinlich eine falsche Protokoll- oder Verschlüsselungsübereinstimmung. Weitere Informationen in den Logs.",
       "cloud_unreachable": "Das Cloud-Gateway von Samsung konnte nicht erreicht werden, um die für die Zertifikatserstellung dieses Geräts benötigte UUID abzurufen. Prüfen Sie den Internetzugang von Home Assistant und versuchen Sie es erneut.",
       "unexpected_response": "Die Verbindung zum Gerät war erfolgreich, es hat jedoch keine verwendbare Gerätebeschreibung zurückgegeben. Möglicherweise wird dieses Gerät von der Integration nicht unterstützt. Weitere Informationen in den Logs.",
+      "invalid_ocf_device_id": "Geben Sie eine kanonische OCF-Geräte-UUID (di) ungleich Null ein oder lassen Sie dieses erweiterte Feld leer.",
+      "identity_discovery_unavailable": "Die identitätsgebundene Suche konnte nicht ausgeführt werden. Stellen Sie sicher, dass Home Assistant eine IPv4-Schnittstelle im LAN des Geräts hat und dieser Build die erforderliche smartthings-local-API enthält.",
+      "identity_target_not_found": "An der angegebenen IP-Adresse wurde keine stabile OCF-Ankündigung für diese UUID gefunden. Prüfen Sie die IP-Adresse und die exakte OCF-Geräte-UUID (di).",
+      "identity_target_ambiguous": "Die identitätsgebundene Suche fand mehr als einen aktiven Endpunkt oder das Ergebnis änderte sich zwischen den Durchläufen. Es wurde nichts ausgewählt.",
+      "identity_advertisement_invalid": "Die passende OCF-Ankündigung enthielt keinen sicheren, an die Quelle gebundenen Endpunkt. Es wurde nichts ausgewählt.",
+      "identity_no_dtls_server": "Die passende OCF-Ankündigung lieferte sichere Portkandidaten, aber nicht genau einen aktiven DTLS-Listener.",
+      "identity_mismatch": "Der authentifizierte Endpunkt meldete eine andere oder keine OCF-Geräte-UUID. Die Einrichtung wurde vor dem Lesen oder Hinzufügen des Geräts beendet.",
       "cannot_connect": "Verbindung zum Gerät nicht möglich. Prüfen Sie, ob die IP-Adresse erreichbar und die CA-Zugangsdaten korrekt sind.",
       "invalid_ca": "Das CA-Zertifikat oder der Privatschlüssel konnte nicht geladen werden. Prüfen Sie, ob der PEM-Inhalt korrekt ist und der Schlüssel zum Zertifikat passt.",
       "unknown": "Unerwarteter Fehler. Weitere Informationen in den Logs."

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -1500,11 +1500,13 @@
         "description": "Enter the IP address of your Samsung appliance and the AC14K_M CA credentials used to mint device certificates.",
         "data": {
           "host": "IP address",
+          "ocf_device_id": "Exact OCF device UUID (advanced)",
           "ca_cert_pem": "CA certificate (PEM)",
           "ca_key_pem": "CA private key (PEM)"
         },
         "data_description": {
           "host": "Local IP address of your Samsung appliance (e.g. 192.168.1.50).",
+          "ocf_device_id": "Optional exact OCF device UUID (di) for a host that exposes multiple logical devices. Leave blank for normal setup. This is not the SmartThings platform device ID.",
           "ca_cert_pem": "The PEM-encoded AC14K_M CA certificate chain. Paste the full contents of your fullchain PEM including all BEGIN/END CERTIFICATE blocks.",
           "ca_key_pem": "The PEM-encoded AC14K_M private key. Paste the full contents including the BEGIN/END PRIVATE KEY header and footer."
         }
@@ -1513,10 +1515,12 @@
         "title": "Add Samsung appliance",
         "description": "Enter the IP address of your Samsung appliance. The CA credentials from an existing LocalThings appliance will be reused.",
         "data": {
-          "host": "IP address"
+          "host": "IP address",
+          "ocf_device_id": "Exact OCF device UUID (advanced)"
         },
         "data_description": {
-          "host": "Local IP address of your Samsung appliance (e.g. 192.168.1.50)."
+          "host": "Local IP address of your Samsung appliance (e.g. 192.168.1.50).",
+          "ocf_device_id": "Optional exact OCF device UUID (di) for a host that exposes multiple logical devices. Leave blank for normal setup. This is not the SmartThings platform device ID."
         }
       },
       "confirm_unknown_type": {
@@ -1533,6 +1537,13 @@
       "handshake_failed": "The appliance refused the DTLS handshake for a reason unrelated to the certificate, most likely a protocol or cipher mismatch. The Home Assistant log records the exact alert it sent.",
       "cloud_unreachable": "Couldn't reach Samsung's cloud gateway to fetch the UUID needed to mint this device's certificate. Check Home Assistant's internet access and try again.",
       "unexpected_response": "Connected to the device successfully, but it didn't return a usable device description. It may not be an appliance this integration supports. The Home Assistant log records what it sent.",
+      "invalid_ocf_device_id": "Enter one canonical, non-zero OCF device UUID (di), or leave this advanced field blank.",
+      "identity_discovery_unavailable": "Identity-bound discovery could not run. Make sure Home Assistant has an IPv4 interface on the appliance's LAN and that this build includes the required smartthings-local discovery API.",
+      "identity_target_not_found": "No stable OCF advertisement matched that device UUID at the submitted IP address. Confirm the appliance IP and its exact OCF device UUID (di).",
+      "identity_target_ambiguous": "Identity-bound discovery found more than one live endpoint or the result changed between rounds. Nothing was selected.",
+      "identity_advertisement_invalid": "The matching OCF advertisement did not contain a safe, source-bound secure endpoint. Nothing was selected.",
+      "identity_no_dtls_server": "The matching OCF advertisement returned secure-port candidates, but they did not identify exactly one live DTLS listener.",
+      "identity_mismatch": "The authenticated endpoint reported a different or missing OCF device UUID. Setup stopped before reading or adding the device.",
       "cannot_connect": "Cannot connect to the device. Verify the IP address is reachable and the CA credentials are correct.",
       "invalid_ca": "The CA certificate or private key could not be loaded. Verify the PEM contents are correct and the key matches the certificate.",
       "unknown": "Unexpected error. Check the Home Assistant logs for details."

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -6,11 +6,13 @@
         "description": "Introduce la dirección IP de tu electrodoméstico Samsung y las credenciales AC14K_M CA usadas para emitir los certificados de dispositivo.",
         "data": {
           "host": "Dirección IP",
+          "ocf_device_id": "UUID exacto del dispositivo OCF (avanzado)",
           "ca_cert_pem": "Certificado CA (PEM)",
           "ca_key_pem": "Clave privada CA (PEM)"
         },
         "data_description": {
           "host": "Dirección IP local de tu electrodoméstico Samsung (p. ej. 192.168.1.50).",
+          "ocf_device_id": "UUID exacto opcional del dispositivo OCF (di) para un host que expone varios dispositivos lógicos. Déjalo vacío para la configuración normal. No es el ID de dispositivo de la plataforma SmartThings.",
           "ca_cert_pem": "Cadena de certificados CA AC14K_M codificada en PEM. Pega el contenido completo de tu PEM fullchain incluyendo todos los bloques BEGIN/END CERTIFICATE.",
           "ca_key_pem": "Clave privada AC14K_M codificada en PEM. Pega el contenido completo incluyendo la cabecera y el pie BEGIN/END PRIVATE KEY."
         }
@@ -19,10 +21,12 @@
         "title": "Añadir electrodoméstico Samsung",
         "description": "Introduce la dirección IP de tu electrodoméstico Samsung. Se reutilizarán las credenciales CA de un electrodoméstico LocalThings existente.",
         "data": {
-          "host": "Dirección IP"
+          "host": "Dirección IP",
+          "ocf_device_id": "UUID exacto del dispositivo OCF (avanzado)"
         },
         "data_description": {
-          "host": "Dirección IP local de tu electrodoméstico Samsung (p. ej. 192.168.1.50)."
+          "host": "Dirección IP local de tu electrodoméstico Samsung (p. ej. 192.168.1.50).",
+          "ocf_device_id": "UUID exacto opcional del dispositivo OCF (di) para un host que expone varios dispositivos lógicos. Déjalo vacío para la configuración normal. No es el ID de dispositivo de la plataforma SmartThings."
         }
       },
       "confirm_unknown_type": {
@@ -39,6 +43,13 @@
       "handshake_failed": "El electrodoméstico rechazó el saludo DTLS por un motivo no relacionado con el certificado, probablemente una incompatibilidad de protocolo o de cifrado. El registro de Home Assistant recoge la alerta exacta que envió.",
       "cloud_unreachable": "No se pudo contactar con la pasarela en la nube de Samsung para obtener el UUID necesario para emitir el certificado de este dispositivo. Comprueba el acceso a internet de Home Assistant e inténtalo de nuevo.",
       "unexpected_response": "La conexión con el dispositivo se estableció correctamente, pero no devolvió una descripción de dispositivo utilizable. Puede que no sea un electrodoméstico compatible con esta integración. El registro de Home Assistant recoge lo que envió.",
+      "invalid_ocf_device_id": "Introduce un UUID de dispositivo OCF (di) canónico y distinto de cero, o deja vacío este campo avanzado.",
+      "identity_discovery_unavailable": "No se pudo ejecutar la detección vinculada a la identidad. Comprueba que Home Assistant tenga una interfaz IPv4 en la LAN del electrodoméstico y que esta compilación incluya la API de detección de smartthings-local necesaria.",
+      "identity_target_not_found": "No se encontró un anuncio OCF estable que coincida con ese UUID en la dirección IP indicada. Comprueba la IP y el UUID exacto del dispositivo OCF (di).",
+      "identity_target_ambiguous": "La detección vinculada a la identidad encontró más de un endpoint activo o el resultado cambió entre rondas. No se seleccionó ninguno.",
+      "identity_advertisement_invalid": "El anuncio OCF coincidente no contenía un endpoint seguro vinculado al origen. No se seleccionó ninguno.",
+      "identity_no_dtls_server": "El anuncio OCF coincidente devolvió candidatos de puertos seguros, pero no identificó exactamente un listener DTLS activo.",
+      "identity_mismatch": "El endpoint autenticado informó de un UUID de dispositivo OCF diferente o ausente. La configuración se detuvo antes de leer o añadir el dispositivo.",
       "cannot_connect": "No se puede conectar con el dispositivo. Comprueba que la dirección IP sea accesible y que las credenciales CA sean correctas.",
       "invalid_ca": "No se ha podido cargar el certificado CA o la clave privada. Comprueba que el contenido PEM sea correcto y que la clave coincida con el certificado.",
       "unknown": "Error inesperado. Consulta los registros de Home Assistant para más detalles."

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -1500,11 +1500,13 @@
         "description": "Inserisci l'indirizzo IP del tuo dispositivo Samsung e le credenziali CA AC14K_M utilizzate per generare i certificati del dispositivo.",
         "data": {
           "host": "Indirizzo IP",
+          "ocf_device_id": "UUID esatto del dispositivo OCF (avanzato)",
           "ca_cert_pem": "Certificato CA (PEM)",
           "ca_key_pem": "Chiave privata CA (PEM)"
         },
         "data_description": {
           "host": "Indirizzo IP locale del tuo dispositivo Samsung (ad esempio 192.168.1.50).",
+          "ocf_device_id": "UUID esatto opzionale del dispositivo OCF (di) per un host che espone più dispositivi logici. Lasciare vuoto per la configurazione normale. Non è l'ID dispositivo della piattaforma SmartThings.",
           "ca_cert_pem": "La catena di certificati CA AC14K_M codificata in formato PEM. Incolla l'intero contenuto del tuo file PEM dell'intera catena, inclusi tutti i blocchi BEGIN/END CERTIFICATE.",
           "ca_key_pem": "La chiave privata AC14K_M codificata in formato PEM. Incollare l'intero contenuto, inclusi l'intestazione e il piè di pagina BEGIN/END PRIVATE KEY."
         }
@@ -1513,10 +1515,12 @@
         "title": "Aggiungi un elettrodomestico Samsung",
         "description": "Inserisci l'indirizzo IP del tuo dispositivo Samsung. Le credenziali CA di un dispositivo LocalThings esistente verranno riutilizzate.",
         "data": {
-          "host": "Indirizzo IP"
+          "host": "Indirizzo IP",
+          "ocf_device_id": "UUID esatto del dispositivo OCF (avanzato)"
         },
         "data_description": {
-          "host": "Indirizzo IP locale del tuo dispositivo Samsung (ad esempio 192.168.1.50)."
+          "host": "Indirizzo IP locale del tuo dispositivo Samsung (ad esempio 192.168.1.50).",
+          "ocf_device_id": "UUID esatto opzionale del dispositivo OCF (di) per un host che espone più dispositivi logici. Lasciare vuoto per la configurazione normale. Non è l'ID dispositivo della piattaforma SmartThings."
         }
       },
       "confirm_unknown_type": {
@@ -1533,6 +1537,13 @@
       "handshake_failed": "L'apparecchio ha rifiutato l'handshake DTLS per un motivo non legato al certificato, molto probabilmente un'incompatibilità di protocollo o di cifratura. Il log di Home Assistant riporta l'alert esatto inviato.",
       "cloud_unreachable": "Impossibile raggiungere il gateway cloud di Samsung per ottenere l'UUID necessario a emettere il certificato di questo dispositivo. Verifica l'accesso a internet di Home Assistant e riprova.",
       "unexpected_response": "Connessione al dispositivo riuscita, ma non ha restituito una descrizione del dispositivo utilizzabile. Potrebbe non essere un apparecchio supportato da questa integrazione. Il log di Home Assistant riporta ciò che ha inviato.",
+      "invalid_ocf_device_id": "Inserire un UUID dispositivo OCF (di) canonico e diverso da zero oppure lasciare vuoto questo campo avanzato.",
+      "identity_discovery_unavailable": "Impossibile eseguire il rilevamento associato all'identità. Verificare che Home Assistant disponga di un'interfaccia IPv4 sulla LAN dell'apparecchio e che questa build includa l'API di rilevamento smartthings-local richiesta.",
+      "identity_target_not_found": "Nessun annuncio OCF stabile corrisponde a questo UUID all'indirizzo IP indicato. Verificare l'IP e l'UUID esatto del dispositivo OCF (di).",
+      "identity_target_ambiguous": "Il rilevamento associato all'identità ha trovato più di un endpoint attivo oppure il risultato è cambiato tra i round. Non è stato selezionato nulla.",
+      "identity_advertisement_invalid": "L'annuncio OCF corrispondente non conteneva un endpoint sicuro associato all'origine. Non è stato selezionato nulla.",
+      "identity_no_dtls_server": "L'annuncio OCF corrispondente ha restituito candidati di porte sicure, ma non ha identificato esattamente un listener DTLS attivo.",
+      "identity_mismatch": "L'endpoint autenticato ha riportato un UUID dispositivo OCF diverso o mancante. La configurazione è stata interrotta prima di leggere o aggiungere il dispositivo.",
       "cannot_connect": "Impossibile connettersi al dispositivo. Verificare che l'indirizzo IP sia raggiungibile e che le credenziali CA siano corrette.",
       "invalid_ca": "Impossibile caricare il certificato CA o la chiave privata. Verificare che il contenuto del file PEM sia corretto e che la chiave corrisponda al certificato.",
       "unknown": "Errore imprevisto. Controlla i registri di Home Assistant per i dettagli."

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -1500,11 +1500,13 @@
         "description": "삼성 가전제품의 IP 주소와 기기 인증서 발급에 사용할 AC14K_M CA 인증 정보를 입력하세요.",
         "data": {
           "host": "IP 주소",
+          "ocf_device_id": "정확한 OCF 기기 UUID(고급)",
           "ca_cert_pem": "CA 인증서(PEM)",
           "ca_key_pem": "CA 개인 키(PEM)"
         },
         "data_description": {
           "host": "삼성 가전제품의 로컬 IP 주소입니다(예: 192.168.1.50).",
+          "ocf_device_id": "하나의 호스트가 여러 논리 기기를 노출할 때 사용할 정확한 OCF 기기 UUID(di)입니다. 일반 설정에서는 비워 두세요. SmartThings 플랫폼 기기 ID와는 다릅니다.",
           "ca_cert_pem": "PEM으로 인코딩된 AC14K_M CA 인증서 체인입니다. 모든 BEGIN/END CERTIFICATE 블록을 포함한 전체 인증서 체인 PEM 내용을 붙여 넣으세요.",
           "ca_key_pem": "PEM으로 인코딩된 AC14K_M 개인 키입니다. BEGIN/END PRIVATE KEY 머리글과 바닥글을 포함한 전체 내용을 붙여 넣으세요."
         }
@@ -1513,10 +1515,12 @@
         "title": "삼성 가전제품 추가",
         "description": "삼성 가전제품의 IP 주소를 입력하세요. 기존 LocalThings 가전제품의 CA 인증 정보를 다시 사용합니다.",
         "data": {
-          "host": "IP 주소"
+          "host": "IP 주소",
+          "ocf_device_id": "정확한 OCF 기기 UUID(고급)"
         },
         "data_description": {
-          "host": "삼성 가전제품의 로컬 IP 주소입니다(예: 192.168.1.50)."
+          "host": "삼성 가전제품의 로컬 IP 주소입니다(예: 192.168.1.50).",
+          "ocf_device_id": "하나의 호스트가 여러 논리 기기를 노출할 때 사용할 정확한 OCF 기기 UUID(di)입니다. 일반 설정에서는 비워 두세요. SmartThings 플랫폼 기기 ID와는 다릅니다."
         }
       },
       "confirm_unknown_type": {
@@ -1533,6 +1537,13 @@
       "handshake_failed": "인증서와 관련 없는 이유로 가전제품이 DTLS 핸드셰이크를 거부했습니다. 프로토콜이나 암호화 방식이 일치하지 않을 가능성이 큽니다. 가전제품이 보낸 정확한 경고는 Home Assistant 로그에 기록됩니다.",
       "cloud_unreachable": "이 기기의 인증서 발급에 필요한 UUID를 가져오기 위해 삼성 클라우드 게이트웨이에 연결할 수 없습니다. Home Assistant의 인터넷 연결을 확인한 후 다시 시도하세요.",
       "unexpected_response": "기기에 연결했지만 사용할 수 있는 기기 설명을 반환하지 않았습니다. 이 통합 구성요소에서 지원하는 가전제품이 아닐 수 있습니다. 기기가 보낸 내용은 Home Assistant 로그에 기록됩니다.",
+      "invalid_ocf_device_id": "표준 형식의 0이 아닌 OCF 기기 UUID(di)를 입력하거나 이 고급 필드를 비워 두세요.",
+      "identity_discovery_unavailable": "UUID 기반 탐색을 실행할 수 없습니다. Home Assistant에 가전제품 LAN용 IPv4 인터페이스가 있고 이 빌드에 필요한 smartthings-local 탐색 API가 포함되어 있는지 확인하세요.",
+      "identity_target_not_found": "입력한 IP 주소에서 해당 UUID와 일치하는 안정적인 OCF 광고를 찾지 못했습니다. 가전제품 IP와 정확한 OCF 기기 UUID(di)를 확인하세요.",
+      "identity_target_ambiguous": "UUID 기반 탐색에서 둘 이상의 활성 엔드포인트가 발견되었거나 라운드 사이에 결과가 바뀌었습니다. 아무것도 선택하지 않았습니다.",
+      "identity_advertisement_invalid": "일치하는 OCF 광고에 안전하게 출처가 결합된 보안 엔드포인트가 없습니다. 아무것도 선택하지 않았습니다.",
+      "identity_no_dtls_server": "일치하는 OCF 광고가 보안 포트 후보를 반환했지만 정확히 하나의 활성 DTLS 리스너를 확인하지 못했습니다.",
+      "identity_mismatch": "인증된 엔드포인트가 다른 OCF 기기 UUID를 보고했거나 UUID를 보고하지 않았습니다. 기기를 읽거나 추가하기 전에 설정을 중단했습니다.",
       "cannot_connect": "기기에 연결할 수 없습니다. IP 주소에 연결할 수 있는지와 CA 인증 정보가 올바른지 확인하세요.",
       "invalid_ca": "CA 인증서 또는 개인 키를 불러올 수 없습니다. PEM 내용이 올바르고 키가 인증서와 일치하는지 확인하세요.",
       "unknown": "예기치 않은 오류가 발생했습니다. 자세한 내용은 Home Assistant 로그에서 확인하세요."

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -1500,11 +1500,13 @@
         "description": "Voer het IP-adres van je Samsung-apparaat en de AC14K_M-CA-inloggegevens in waarmee apparaatcertificaten worden aangemaakt.",
         "data": {
           "host": "IP-adres",
+          "ocf_device_id": "Exacte OCF-apparaat-UUID (geavanceerd)",
           "ca_cert_pem": "CA-certificaat (PEM)",
           "ca_key_pem": "Privésleutel van CA (PEM)"
         },
         "data_description": {
           "host": "Het lokale IP-adres van je Samsung-apparaat (bijvoorbeeld 192.168.1.50).",
+          "ocf_device_id": "Optionele exacte OCF-apparaat-UUID (di) voor een host die meerdere logische apparaten aanbiedt. Laat leeg voor normale configuratie. Dit is niet de apparaat-ID van het SmartThings-platform.",
           "ca_cert_pem": "De PEM-gecodeerde AC14K_M-CA-certificaatketen. Plak de volledige inhoud van je fullchain-PEM, inclusief alle blokken BEGIN CERTIFICATE en END CERTIFICATE.",
           "ca_key_pem": "De PEM-gecodeerde AC14K_M-privésleutel. Plak de volledige inhoud, inclusief de kop- en voettekst BEGIN PRIVATE KEY en END PRIVATE KEY."
         }
@@ -1513,10 +1515,12 @@
         "title": "Samsung-apparaat toevoegen",
         "description": "Voer het IP-adres van je Samsung-apparaat in. De CA-inloggegevens van een bestaand LocalThings-apparaat worden hergebruikt.",
         "data": {
-          "host": "IP-adres"
+          "host": "IP-adres",
+          "ocf_device_id": "Exacte OCF-apparaat-UUID (geavanceerd)"
         },
         "data_description": {
-          "host": "Het lokale IP-adres van je Samsung-apparaat (bijvoorbeeld 192.168.1.50)."
+          "host": "Het lokale IP-adres van je Samsung-apparaat (bijvoorbeeld 192.168.1.50).",
+          "ocf_device_id": "Optionele exacte OCF-apparaat-UUID (di) voor een host die meerdere logische apparaten aanbiedt. Laat leeg voor normale configuratie. Dit is niet de apparaat-ID van het SmartThings-platform."
         }
       },
       "confirm_unknown_type": {
@@ -1533,6 +1537,13 @@
       "handshake_failed": "Het apparaat weigerde de DTLS-handshake om een reden die niets met het certificaat te maken heeft, hoogstwaarschijnlijk een protocol- of cipher-mismatch. Het Home Assistant-logboek bevat de precieze alert die het stuurde.",
       "cloud_unreachable": "Kon de cloudgateway van Samsung niet bereiken om de UUID op te halen die nodig is om het certificaat van dit apparaat aan te maken. Controleer de internettoegang van Home Assistant en probeer het opnieuw.",
       "unexpected_response": "Verbinding met het apparaat is gelukt, maar het gaf geen bruikbare apparaatbeschrijving terug. Mogelijk is het geen apparaat dat deze integratie ondersteunt. Het Home Assistant-logboek bevat wat het stuurde.",
+      "invalid_ocf_device_id": "Voer één canonieke OCF-apparaat-UUID (di) in die niet nul is, of laat dit geavanceerde veld leeg.",
+      "identity_discovery_unavailable": "Identiteitsgebonden detectie kon niet worden uitgevoerd. Controleer of Home Assistant een IPv4-interface op het LAN van het apparaat heeft en of deze build de vereiste smartthings-local-detectie-API bevat.",
+      "identity_target_not_found": "Op het opgegeven IP-adres is geen stabiele OCF-advertentie gevonden die met deze UUID overeenkomt. Controleer het IP-adres en de exacte OCF-apparaat-UUID (di).",
+      "identity_target_ambiguous": "Identiteitsgebonden detectie vond meer dan één actief endpoint of het resultaat veranderde tussen rondes. Er is niets geselecteerd.",
+      "identity_advertisement_invalid": "De overeenkomende OCF-advertentie bevatte geen veilig, aan de bron gebonden beveiligd endpoint. Er is niets geselecteerd.",
+      "identity_no_dtls_server": "De overeenkomende OCF-advertentie leverde kandidaten voor beveiligde poorten op, maar identificeerde niet precies één actieve DTLS-listener.",
+      "identity_mismatch": "Het geverifieerde endpoint meldde een andere of ontbrekende OCF-apparaat-UUID. De configuratie is gestopt voordat het apparaat werd gelezen of toegevoegd.",
       "cannot_connect": "Kan geen verbinding maken met het apparaat. Controleer of het IP-adres bereikbaar is en de CA-inloggegevens juist zijn.",
       "invalid_ca": "Het CA-certificaat of de privésleutel kon niet worden geladen. Controleer of de PEM-inhoud juist is en of de sleutel bij het certificaat hoort.",
       "unknown": "Onverwachte fout. Raadpleeg de Home Assistant-logboeken voor meer informatie."

--- a/tests/localthings/test_config_flow.py
+++ b/tests/localthings/test_config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from typing import ClassVar, cast
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -21,6 +21,7 @@ from custom_components.localthings.const import (
     CONF_LEAF_CERT_PEM,
     CONF_LEARN_MODES,
     CONF_LEARNED_MODES,
+    CONF_OCF_DEVICE_ID,
     CONF_PORT,
     CONF_SERIAL,
     DOMAIN,
@@ -49,6 +50,7 @@ async def test_form_first_device(hass: HomeAssistant) -> None:
     assert data_schema is not None
     assert CONF_CA_CERT_PEM in data_schema.schema
     assert CONF_CA_KEY_PEM in data_schema.schema
+    assert CONF_OCF_DEVICE_ID in data_schema.schema
 
 
 async def test_form_second_device_reuses_creds(hass: HomeAssistant) -> None:
@@ -63,6 +65,115 @@ async def test_form_second_device_reuses_creds(hass: HomeAssistant) -> None:
     assert data_schema is not None
     assert CONF_CA_CERT_PEM not in data_schema.schema
     assert CONF_CA_KEY_PEM not in data_schema.schema
+    assert CONF_OCF_DEVICE_ID in data_schema.schema
+
+
+async def test_normal_setup_does_not_enter_identity_discovery(
+    hass: HomeAssistant, mock_probe
+) -> None:
+    """Leaving the advanced field blank preserves the original call contract."""
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: MOCK_HOST,
+            CONF_CA_CERT_PEM: MOCK_CA_CERT_PEM,
+            CONF_CA_KEY_PEM: MOCK_CA_KEY_PEM,
+        },
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    mock_probe.assert_called_once_with(
+        MOCK_HOST,
+        MOCK_CA_CERT_PEM,
+        MOCK_CA_KEY_PEM,
+        None,
+    )
+
+
+async def test_identity_setup_passes_canonical_di_and_route_interface(
+    hass: HomeAssistant, mock_probe
+) -> None:
+    """The opt-in path supplies one exact di and HA's route-selected IPv4 source."""
+
+    target = "1BB10CD6-3214-4BC5-842E-19A0FE2D8123"
+    source_ip = "10.0.0.10"
+    with patch(
+        "homeassistant.components.network.async_get_source_ip",
+        new=AsyncMock(return_value=source_ip),
+    ) as source:
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_OCF_DEVICE_ID: target,
+                CONF_CA_CERT_PEM: MOCK_CA_CERT_PEM,
+                CONF_CA_KEY_PEM: MOCK_CA_KEY_PEM,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    source.assert_awaited_once_with(hass, target_ip=MOCK_HOST)
+    mock_probe.assert_called_once_with(
+        MOCK_HOST,
+        MOCK_CA_CERT_PEM,
+        MOCK_CA_KEY_PEM,
+        None,
+        target.lower(),
+        source_ip,
+    )
+    assert CONF_OCF_DEVICE_ID not in result["data"]
+
+
+async def test_invalid_identity_is_a_field_error_without_network_io(
+    hass: HomeAssistant, mock_probe
+) -> None:
+    """A malformed or nil di is rejected before route selection or probing."""
+
+    with patch(
+        "homeassistant.components.network.async_get_source_ip",
+        new=AsyncMock(),
+    ) as source:
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_OCF_DEVICE_ID: "00000000-0000-0000-0000-000000000000",
+                CONF_CA_CERT_PEM: MOCK_CA_CERT_PEM,
+                CONF_CA_KEY_PEM: MOCK_CA_KEY_PEM,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {CONF_OCF_DEVICE_ID: "invalid_ocf_device_id"}
+    mock_probe.assert_not_called()
+    source.assert_not_awaited()
+
+
+async def test_identity_setup_reports_missing_ipv4_route(hass: HomeAssistant, mock_probe) -> None:
+    """Route selection failure is explicit and never enters the blocking probe."""
+
+    with patch(
+        "homeassistant.components.network.async_get_source_ip",
+        new=AsyncMock(side_effect=OSError("no route")),
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_OCF_DEVICE_ID: MOCK_DEVICE_KEY,
+                CONF_CA_CERT_PEM: MOCK_CA_CERT_PEM,
+                CONF_CA_KEY_PEM: MOCK_CA_KEY_PEM,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "identity_discovery_unavailable"}
+    mock_probe.assert_not_called()
 
 
 async def test_successful_setup(hass: HomeAssistant, mock_probe) -> None:
@@ -411,6 +522,249 @@ async def test_probe_falls_back_when_library_lacks_the_clienthello_probe(
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_PORT] == 49154
+
+
+def test_identity_scan_probes_only_advertised_ports(monkeypatch) -> None:
+    """Identity candidates are statelessly verified without unioning a fixed band."""
+
+    from custom_components.localthings import config_flow, endpoint_discovery
+
+    endpoint = endpoint_discovery.IdentityEndpoint(MOCK_HOST, (41000, 46060))
+    monkeypatch.setattr(
+        endpoint_discovery,
+        "discover_identity_endpoint",
+        lambda host, target_device_id, interface_address: endpoint,
+    )
+    calls = []
+
+    def scan(host, ports):
+        calls.append((host, ports))
+        return [46060]
+
+    monkeypatch.setattr(config_flow, "_clienthello_scan", scan)
+
+    result = config_flow._scan_identity_endpoint(
+        MOCK_HOST,
+        MOCK_DEVICE_KEY,
+        "10.0.0.10",
+    )
+
+    assert calls == [(MOCK_HOST, [41000, 46060])]
+    assert result.candidates == [46060]
+    assert result.confirmed == [46060]
+    assert result.swept is None
+
+
+def test_identity_scan_rejects_multiple_live_dtls_endpoints(monkeypatch) -> None:
+    from custom_components.localthings import config_flow, endpoint_discovery
+
+    monkeypatch.setattr(
+        endpoint_discovery,
+        "discover_identity_endpoint",
+        lambda host, target_device_id, interface_address: endpoint_discovery.IdentityEndpoint(
+            MOCK_HOST, (41000, 46060)
+        ),
+    )
+    monkeypatch.setattr(config_flow, "_clienthello_scan", lambda host, ports: list(ports))
+
+    with pytest.raises(config_flow.IdentityTargetAmbiguous):
+        config_flow._scan_identity_endpoint(MOCK_HOST, MOCK_DEVICE_KEY, "10.0.0.10")
+
+
+def test_identity_scan_rejects_no_live_dtls_endpoint_without_fallback(monkeypatch) -> None:
+    from custom_components.localthings import config_flow, endpoint_discovery
+
+    monkeypatch.setattr(
+        endpoint_discovery,
+        "discover_identity_endpoint",
+        lambda host, target_device_id, interface_address: endpoint_discovery.IdentityEndpoint(
+            MOCK_HOST, (46060,)
+        ),
+    )
+    monkeypatch.setattr(config_flow, "_clienthello_scan", lambda host, ports: [])
+    monkeypatch.setattr(
+        config_flow,
+        "_scan_ports",
+        lambda host: pytest.fail("the fixed-band fallback must not run"),
+    )
+
+    with pytest.raises(config_flow.IdentityNoDtlsServer):
+        config_flow._scan_identity_endpoint(MOCK_HOST, MOCK_DEVICE_KEY, "10.0.0.10")
+
+
+@pytest.mark.parametrize(
+    ("reason", "error_key"),
+    [
+        ("unavailable", "identity_discovery_unavailable"),
+        ("not_found", "identity_target_not_found"),
+        ("ambiguous", "identity_target_ambiguous"),
+        ("invalid_advertisement", "identity_advertisement_invalid"),
+        ("address_mismatch", "identity_advertisement_invalid"),
+        ("future_reason", "identity_advertisement_invalid"),
+    ],
+)
+def test_identity_discovery_reasons_map_to_stable_ui_errors(reason, error_key) -> None:
+    from custom_components.localthings import config_flow
+
+    assert config_flow._identity_discovery_failure(reason).error_key == error_key
+
+
+def test_probe_identity_path_has_no_fixed_scan_fallback(monkeypatch) -> None:
+    """An explicit di selects one fail-closed scan path and reaches auth with that same di."""
+
+    from custom_components.localthings import config_flow
+
+    scan = config_flow._PortScan([46060], [46060])
+    calls = []
+    monkeypatch.setattr(
+        config_flow,
+        "_scan_ports",
+        lambda host: pytest.fail("the fixed-band scan must not run for an exact di"),
+    )
+    monkeypatch.setattr(
+        config_flow,
+        "_scan_identity_endpoint",
+        lambda host, target_device_id, interface_address: scan,
+    )
+    monkeypatch.setattr(config_flow, "_mint_credentials", lambda ca, key: ("CERT", "KEY"))
+
+    def handshake(host, actual_scan, cert, key, expected_device_id):
+        calls.append((host, actual_scan, cert, key, expected_device_id))
+        return {"port": 46060}
+
+    monkeypatch.setattr(config_flow, "_handshake_and_read", handshake)
+
+    result = config_flow._probe_and_validate(
+        MOCK_HOST,
+        MOCK_CA_CERT_PEM,
+        MOCK_CA_KEY_PEM,
+        target_device_id=MOCK_DEVICE_KEY,
+        interface_address="10.0.0.10",
+    )
+
+    assert calls == [(MOCK_HOST, scan, "CERT", "KEY", MOCK_DEVICE_KEY)]
+    assert result == {"port": 46060, "leaf_cert_pem": "CERT", "leaf_key_pem": "KEY"}
+
+
+@pytest.mark.parametrize("actual_device_id", [None, "0d431826-546c-428f-86d1-63d8798f8742"])
+def test_authenticated_identity_must_match_exact_di_before_device_dump(
+    monkeypatch, actual_device_id
+) -> None:
+    """A missing or mismatched di cannot fall back to pi, serial, or host."""
+
+    from custom_components.localthings import config_flow
+    from custom_components.localthings.registry import identity as identity_module
+
+    identity = identity_module.DeviceIdentity(
+        manufacturer="Samsung",
+        model="model",
+        name="washer",
+        serial=None,
+        device_id=actual_device_id,
+        platform_id=MOCK_DEVICE_KEY,
+    )
+    monkeypatch.setattr(identity_module, "read_identity", lambda sess, serial: identity)
+
+    class Session:
+        def get(self, *args, **kwargs):
+            pytest.fail("/device/0 must not be read before exact di validation")
+
+    with pytest.raises(config_flow.IdentityMismatch):
+        config_flow._read_device(Session(), MOCK_HOST, 46060, MOCK_DEVICE_KEY)
+
+
+def test_authenticated_identity_match_allows_device_dump(monkeypatch) -> None:
+    from custom_components.localthings import config_flow
+    from custom_components.localthings.registry import identity as identity_module
+
+    identity = identity_module.DeviceIdentity(
+        manufacturer="Samsung",
+        model="model",
+        name="washer",
+        serial=None,
+        device_id=MOCK_DEVICE_KEY.upper(),
+        platform_id=None,
+        device_types=("oic.d.washer",),
+    )
+    monkeypatch.setattr(identity_module, "read_identity", lambda sess, serial: identity)
+
+    class Session:
+        def get(self, path, timeout=15.0):
+            import cbor2
+
+            assert path == ["device", "0"]
+            return 0x45, cbor2.dumps(WASHER_DEVICE0)
+
+    result = config_flow._read_device(Session(), MOCK_HOST, 46060, MOCK_DEVICE_KEY)
+
+    assert result["port"] == 46060
+    assert result["device_key"] == MOCK_DEVICE_KEY
+
+
+@pytest.mark.parametrize(
+    "raw_device_id",
+    [
+        f"uuid:{MOCK_DEVICE_KEY}",
+        f"URN:UUID:{MOCK_DEVICE_KEY}",
+        bytes.fromhex(MOCK_DEVICE_KEY.replace("-", "")),
+    ],
+)
+def test_authenticated_raw_di_is_canonicalized_for_device_key(
+    monkeypatch,
+    raw_device_id,
+) -> None:
+    from custom_components.localthings import config_flow
+    from custom_components.localthings.registry import identity as identity_module
+
+    identity = identity_module.DeviceIdentity(
+        manufacturer="Samsung",
+        model="model",
+        name="washer",
+        serial=None,
+        device_id=None,
+        platform_id=None,
+        device_types=("oic.d.washer",),
+        raw={"/oic/d": {"di": raw_device_id}},
+    )
+    monkeypatch.setattr(identity_module, "read_identity", lambda sess, serial: identity)
+
+    class Session:
+        def get(self, path, timeout=15.0):
+            import cbor2
+
+            assert path == ["device", "0"]
+            return 0x45, cbor2.dumps(WASHER_DEVICE0)
+
+    result = config_flow._read_device(Session(), MOCK_HOST, 46060, MOCK_DEVICE_KEY)
+
+    assert result["device_key"] == MOCK_DEVICE_KEY
+
+
+def test_authenticated_identity_rejects_malformed_raw_di_before_device_dump(
+    monkeypatch,
+) -> None:
+    """Untrusted CBOR types fail as an identity mismatch, without a fallback."""
+
+    from custom_components.localthings import config_flow
+    from custom_components.localthings.registry import identity as identity_module
+
+    identity = identity_module.DeviceIdentity(
+        manufacturer="Samsung",
+        model="model",
+        name="washer",
+        serial=None,
+        device_id=MOCK_DEVICE_KEY,
+        platform_id=None,
+        raw={"/oic/d": {"di": []}},
+    )
+    monkeypatch.setattr(identity_module, "read_identity", lambda sess, serial: identity)
+
+    class Session:
+        def get(self, *args, **kwargs):
+            pytest.fail("/device/0 must not be read after malformed raw di")
+
+    with pytest.raises(config_flow.IdentityMismatch):
+        config_flow._read_device(Session(), MOCK_HOST, 46060, MOCK_DEVICE_KEY)
 
 
 async def test_entry_stores_resolved_identity(hass: HomeAssistant, monkeypatch, fake_dtls) -> None:
@@ -930,6 +1284,7 @@ def test_every_error_key_the_flow_can_raise_has_a_message() -> None:
         and issubclass(cls, (config_flow.CannotConnect, config_flow.InvalidCA))
     }
     keys.add("unknown")
+    keys.add("invalid_ocf_device_id")
 
     catalog = json.loads(
         (

--- a/tests/localthings/test_endpoint_discovery.py
+++ b/tests/localthings/test_endpoint_discovery.py
@@ -1,0 +1,156 @@
+"""Tests for identity-bound OCF endpoint selection."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from custom_components.localthings.endpoint_discovery import (
+    IdentityEndpointDiscoveryError,
+    discover_identity_endpoint,
+    normalize_ocf_device_id,
+)
+
+TARGET_DEVICE_ID = "1bb10cd6-3214-4bc5-842e-19a0fe2d8123"
+
+
+class _DiscoveryModule(ModuleType):
+    discover_ocf_secure_ports_multicast: object
+
+
+def _helper_module(monkeypatch, discover) -> None:
+    module = _DiscoveryModule("smartthings_local.protocol.ocf_discovery")
+    if discover is not None:
+        module.discover_ocf_secure_ports_multicast = discover
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+
+def test_normalize_ocf_device_id() -> None:
+    assert normalize_ocf_device_id(None) is None
+    assert normalize_ocf_device_id("  ") is None
+    assert normalize_ocf_device_id(TARGET_DEVICE_ID.upper()) == TARGET_DEVICE_ID
+    assert normalize_ocf_device_id(f"uuid:{TARGET_DEVICE_ID}") == TARGET_DEVICE_ID
+    assert normalize_ocf_device_id(f"URN:UUID:{TARGET_DEVICE_ID}") == TARGET_DEVICE_ID
+    assert (
+        normalize_ocf_device_id(bytes.fromhex(TARGET_DEVICE_ID.replace("-", "")))
+        == TARGET_DEVICE_ID
+    )
+
+    for invalid in (
+        "not-a-uuid",
+        "00000000-0000-0000-0000-000000000000",
+        f"{{{TARGET_DEVICE_ID}}}",
+        42,
+        [],
+        {},
+    ):
+        with pytest.raises(ValueError, match="invalid OCF device UUID"):
+            normalize_ocf_device_id(invalid)
+
+
+def test_discovery_returns_only_source_bound_candidates(monkeypatch) -> None:
+    calls = []
+
+    def discover(target_device_id, *, interface_address):
+        calls.append((target_device_id, interface_address))
+        return SimpleNamespace(
+            found=True,
+            address="192.0.2.20",
+            ports=(46060,),
+            error_code=None,
+        )
+
+    _helper_module(monkeypatch, discover)
+
+    result = discover_identity_endpoint(
+        "192.0.2.20",
+        TARGET_DEVICE_ID,
+        "192.0.2.10",
+    )
+
+    assert result.address == "192.0.2.20"
+    assert result.ports == (46060,)
+    assert calls == [(TARGET_DEVICE_ID, "192.0.2.10")]
+    rendered = repr(result)
+    assert "192.0.2.20" not in rendered
+    assert "46060" not in rendered
+    assert TARGET_DEVICE_ID not in rendered
+
+
+@pytest.mark.parametrize(
+    ("error_code", "reason"),
+    [
+        ("interface_unavailable", "unavailable"),
+        ("no_ocf_response", "not_found"),
+        ("target_not_found", "not_found"),
+        ("ambiguous_target", "ambiguous"),
+        ("target_not_stable", "ambiguous"),
+        ("malformed_ocf_response", "invalid_advertisement"),
+        ("no_secure_ports", "invalid_advertisement"),
+        ("future_error", "invalid_advertisement"),
+    ],
+)
+def test_discovery_maps_helper_failures(monkeypatch, error_code, reason) -> None:
+    _helper_module(
+        monkeypatch,
+        lambda *args, **kwargs: SimpleNamespace(
+            found=False,
+            address=None,
+            ports=(),
+            error_code=error_code,
+        ),
+    )
+
+    with pytest.raises(IdentityEndpointDiscoveryError) as raised:
+        discover_identity_endpoint("192.0.2.20", TARGET_DEVICE_ID, "192.0.2.10")
+
+    assert raised.value.reason == reason
+    rendered = str(raised.value)
+    assert "192.0.2.20" not in rendered
+    assert TARGET_DEVICE_ID not in rendered
+
+
+def test_discovery_rejects_a_different_response_source(monkeypatch) -> None:
+    _helper_module(
+        monkeypatch,
+        lambda *args, **kwargs: SimpleNamespace(
+            found=True,
+            address="192.0.2.21",
+            ports=(46060,),
+            error_code=None,
+        ),
+    )
+
+    with pytest.raises(IdentityEndpointDiscoveryError) as raised:
+        discover_identity_endpoint("192.0.2.20", TARGET_DEVICE_ID, "192.0.2.10")
+
+    assert raised.value.reason == "address_mismatch"
+
+
+@pytest.mark.parametrize("ports", [(), (0,), (65536,), (True,), (46060, 46060), [46060]])
+def test_discovery_rejects_invalid_port_sets(monkeypatch, ports) -> None:
+    _helper_module(
+        monkeypatch,
+        lambda *args, **kwargs: SimpleNamespace(
+            found=True,
+            address="192.0.2.20",
+            ports=ports,
+            error_code=None,
+        ),
+    )
+
+    with pytest.raises(IdentityEndpointDiscoveryError) as raised:
+        discover_identity_endpoint("192.0.2.20", TARGET_DEVICE_ID, "192.0.2.10")
+
+    assert raised.value.reason == "invalid_advertisement"
+
+
+def test_discovery_fails_closed_when_helper_api_is_unavailable(monkeypatch) -> None:
+    _helper_module(monkeypatch, None)
+
+    with pytest.raises(IdentityEndpointDiscoveryError) as raised:
+        discover_identity_endpoint("192.0.2.20", TARGET_DEVICE_ID, "192.0.2.10")
+
+    assert raised.value.reason == "unavailable"


### PR DESCRIPTION
Hi @mbillow,

Thank you for the work you and the other contributors have been putting into
LocalThings, particularly the recent washer, device-identity, and config-flow
improvements.

I’m opening this as an early draft so the prototype is visible and I can ask
whether the direction would be useful to the project before taking it any
further. This is not a request to merge or begin a full review yet.

I would be very happy to adjust the design, wait for the related work to
settle, or keep this only as supporting evidence if another approach would fit
LocalThings better.

## Background

I have been investigating local connectivity for one Samsung washer-dryer
reporting the internal device family `AWM-KR-M64-24-WD86`.

In redacted, read-only testing, the physical host appeared to expose multiple
logical OCF devices. The washer was represented by its own top-level OCF
device UUID (`di`), while the host’s representative/root OCF identity was
different.

The matching logical-device container advertised a secure endpoint, and that
endpoint answered a stateless DTLS probe. This raised the possibility that an
IP-only setup flow may not always preserve the relationship between:

- the intended logical device;
- its exact OCF `di`;
- the discovery response source; and
- its advertised secure endpoint.

I may be overlooking a simpler integration point, so I would appreciate
guidance before treating this prototype as a final design.

## What the prototype currently does

The branch adds an optional advanced OCF device UUID field to the setup flow.

When an exact `di` is supplied, the flow:

- uses Home Assistant’s route-selected IPv4 interface;
- performs identity-aware discovery for that exact device;
- accepts the advertisement only from the host entered by the user;
- probes only the advertised secure-port candidates;
- requires one unambiguous live DTLS endpoint; and
- verifies the authenticated `/oic/d.di` before requesting `/device/0` or
  creating the config entry.

When the advanced field is left empty, the existing LocalThings setup path
remains unchanged and does not incur additional discovery work.

## Why I’m sharing this now

This prototype may provide a concrete LocalThings consumer for the
identity-aware discovery work that was held out of
QuiteYellow/SmartThings-Local#36.

I also noticed that #392 is revising the config flow and that #388 discusses
PSK credentials and automatic endpoint rediscovery. I would prefer to
coordinate with those efforts rather than duplicate work or make either PR
more difficult to integrate.

Depending on your preference, I can:

- wait for #392 and rebase the prototype onto the resulting flow;
- adapt it to a shared endpoint-resolver abstraction discussed in #388;
- reduce it to consumer-side tests for the SmartThings-Local helper; or
- leave it on the branch until there is a clearer integration point.

## Current limitations

For clarity, this draft does not yet make the WD86 connectable through
LocalThings.

The appliance rejected the existing certificate authentication path with
`unknown_ca`. A bounded diagnostic probe showed that it selected the expected
PSK cipher profile, but I do not currently have a legitimate OwnerPSK for the
device.

This prototype therefore does not currently:

- acquire, derive, store, or provision an OwnerPSK;
- perform ownership transfer or write OCF security resources;
- add PSK credentials to a LocalThings config entry;
- provide a general way for users to obtain the exact OCF `di`;
- rediscover an endpoint during reconnect;
- add WD86-specific capabilities or entities; or
- demonstrate an authenticated `/oic/d`, `/device/0`, or completed Home
  Assistant registration.

It would also not help an appliance that exposes no local DTLS listener.

## Current validation

- 1,769 LocalThings tests pass against the current released
  `smartthings-local` package, covering the unchanged normal path and mocked
  adapter boundaries.
- 1,769 tests pass with the local identity-aware discovery follow-up connected.
- Ruff format and lint pass.
- `ty check` and `git diff --check` pass.
- The diff contains no real device UUID, address, serial number, certificate,
  key, or account identifier.

The advanced path still depends on an unreleased SmartThings-Local API.
Hassfest, HACS validation, released-package integration, and real authenticated
device acceptance remain pending.

## Guidance welcome

Whenever convenient, I would appreciate your thoughts on the following:

1. Would an explicit, opt-in exact-`di` setup path be useful to LocalThings?
2. Would you prefer that I wait for #392 before adapting the config flow?
3. Should this be aligned with the PSK and reconnect-time endpoint work
   discussed in #388?
4. Is there another existing or planned implementation that this prototype
   should defer to?

There is no urgency from my side. I will keep the PR in draft and will not
request merge review until the surrounding direction is clearer.

Thank you for taking the time to look at this, and please feel free to suggest
a smaller or different scope if that would be more helpful to the project.
