### PR TITLE
Make the dryer's dry level a writable select

### DIFF
--- a/custom_components/localthings/__init__.py
+++ b/custom_components/localthings/__init__.py
@@ -193,6 +193,37 @@ def _relabel_particulate_statistics(hass: HomeAssistant, entry: ConfigEntry) -> 
     return True
 
 
+# Tail-matched for the same reason as _PARTICULATE_KEY_RE above. No
+# device-type gate: no registry binds a sensor-domain dry_level any more,
+# so the domain check plus this tail is already exact.
+_DRY_LEVEL_KEY_RE = re.compile(r"_dry_level(?:_\d+)?$")
+
+
+@callback
+def _drop_orphaned_dry_level_sensors(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove the sensor row dryer.py's dry_level select supersedes.
+
+    unique_ids are scoped by (integration, platform), so a platform change
+    can't rewrite the old row -- it can only be dropped. dryer.py's select
+    is field-gated, not exists_fn-gated, precisely so it appears wherever
+    the sensor did and this removal is never left unmatched.
+    """
+    ent_reg = er.async_get(hass)
+    for registry_entry in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if registry_entry.domain != "sensor":
+            continue
+        if not _DRY_LEVEL_KEY_RE.search(registry_entry.unique_id):
+            continue
+        # INFO, not debug: this is irreversible and takes the user's rename,
+        # area and any automation reference with it.
+        _LOGGER.info(
+            "removing %s; dry level is now select.%s",
+            registry_entry.entity_id,
+            registry_entry.entity_id.partition(".")[2],
+        )
+        ent_reg.async_remove(registry_entry.entity_id)
+
+
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate an entry to the current version.
 
@@ -214,11 +245,14 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     a UUID to rewrite *to*.
 
     The version is still bumped now rather than at that point, because the
-    bump's real job is the `entry.version > 4` downgrade guard below: an
+    bump's real job is the `entry.version > 5` downgrade guard below: an
     entry re-keyed onto a UUID and then loaded by a release that reads
     CONF_SERIAL as the key would silently orphan every entity it has.
+
+    v4 -> v5 drops the entity-registry row dryer.py's dry_level leaves
+    behind when it moves from a sensor to a select.
     """
-    if entry.version > 4:
+    if entry.version > 5:
         return False  # downgrade: this release doesn't know the newer shape
 
     if entry.version == 1:
@@ -257,6 +291,11 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.entry_id,
             legacy_key,
         )
+
+    if entry.version == 4:
+        _drop_orphaned_dry_level_sensors(hass, entry)
+        hass.config_entries.async_update_entry(entry, version=5)
+        _LOGGER.debug("migrated entry %s to version 5 (dry_level moved to select)", entry.entry_id)
 
     return True
 

--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -814,7 +814,9 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # v4 keys the entry on the OCF device UUID (issue #381), which the probe
     # below resolves up front -- so a new entry is already on the v4 shape
     # and has nothing to re-key either.
-    VERSION = 4
+    # v5 drops the sensor-domain dry_level registry row a dryer's platform
+    # move orphans; a freshly created entry never had that row.
+    VERSION = 5
 
     def __init__(self) -> None:
         self._host: str = ""

--- a/custom_components/localthings/registry/capabilities/dryer.py
+++ b/custom_components/localthings/registry/capabilities/dryer.py
@@ -10,7 +10,7 @@ the /course/vs/0 cycle select -- lives in laundry.py.
 """
 
 from ..capability import Capability
-from ..entities import SensorDesc, SwitchDesc
+from ..entities import SelectDesc, SensorDesc, SwitchDesc
 from .common import diagnosis_status
 from .laundry import cycle_select, drum_clean_cycles_remaining, drum_clean_last_cleaned
 
@@ -25,7 +25,39 @@ DRYER_SETTINGS = Capability(
     href="/washer/vs/0",
     poll_tier="warm",
     entities=(
-        SensorDesc(key="dry_level", field="x.com.samsung.da.dryLevel", icon="mdi:water-percent"),
+        # dryLevel here is a dryness dial with a live supportedDryLevel
+        # list, in one of two vocabularies: Damp/Less/Normal/More/Very on
+        # the TP1_21 dryers, or a numeric 1/2/3 on both DV5000T (TP2_20)
+        # and DV6800N (A51_20). Hence its own translation_key rather than
+        # washer.py's washer_dry_level, whose state table is that field's
+        # *other* meaning on a combo (minutes, "30" -> "30 min").
+        #
+        # The write was exercised on a DV5000T, which reports
+        # isModelSettingWithoutSC true and so takes it with Smart Control
+        # off (see common.remote_control_required_for_write).
+        #
+        # Deliberately field-gated rather than carrying washer.py's
+        # exists_fn on supportedDryLevel: there the gate discriminates a
+        # combo from a plain washer, but every dryer has a dry level, so
+        # here it would only suppress the entity -- including on a rep that
+        # is merely a stub at discovery (entity._is_included) and would
+        # have populated on the next sub-poll.
+        #
+        # No entity_category either, unlike washer.py's: this is a per-load
+        # choice made alongside the cycle, not device configuration, so it
+        # belongs in Controls next to the cycle select and wrinkle_prevent
+        # -- and that is where the sensor it replaces already sat.
+        SelectDesc(
+            key="dry_level",
+            field="x.com.samsung.da.dryLevel",
+            icon="mdi:tumble-dryer",
+            translation_key="dryer_dry_level",
+            options_field="x.com.samsung.da.supportedDryLevel",
+            write_fn=lambda p, rep, href=None: (
+                ["washer", "vs", "0"],
+                {"x.com.samsung.da.dryLevel": p},
+            ),
+        ),
         SensorDesc(key="dry_time", field="x.com.samsung.da.dryTime", icon="mdi:timer"),
         SensorDesc(
             key="dryer_type",

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -416,6 +416,17 @@
           "3d": "Džíny"
         }
       },
+      "dryer_dry_level": {
+        "name": "Úroveň sušení",
+        "state": {
+          "none": "Vypnuto",
+          "damp": "Vlhké",
+          "less": "Méně",
+          "normal": "Normální",
+          "more": "Více",
+          "very": "Velmi"
+        }
+      },
       "favorite_capacity": {
         "name": "Oblíbené množství"
       },

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -416,6 +416,17 @@
           "3d": "Jeansstoff"
         }
       },
+      "dryer_dry_level": {
+        "name": "Trockenstufe",
+        "state": {
+          "none": "Aus",
+          "damp": "Feucht",
+          "less": "Weniger",
+          "normal": "Normal",
+          "more": "Mehr",
+          "very": "Sehr"
+        }
+      },
       "favorite_capacity": {
         "name": "Favoritenmenge"
       },

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -416,6 +416,17 @@
           "3d": "Denim"
         }
       },
+      "dryer_dry_level": {
+        "name": "Dry level",
+        "state": {
+          "none": "Off",
+          "damp": "Damp",
+          "less": "Less",
+          "normal": "Normal",
+          "more": "More",
+          "very": "Very"
+        }
+      },
       "favorite_capacity": {
         "name": "Favorite capacity"
       },

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -613,6 +613,17 @@
           "3d": "Denim"
         }
       },
+      "dryer_dry_level": {
+        "name": "Nivel de secado",
+        "state": {
+          "none": "Desactivado",
+          "damp": "Húmedo",
+          "less": "Menos",
+          "normal": "Normal",
+          "more": "Más",
+          "very": "Muy"
+        }
+      },
       "favorite_capacity": {
         "name": "Capacidad favorita"
       },

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -416,6 +416,17 @@
           "3d": "Jeans"
         }
       },
+      "dryer_dry_level": {
+        "name": "Livello asciugatura",
+        "state": {
+          "none": "Spento",
+          "damp": "Umido",
+          "less": "Meno",
+          "normal": "Normale",
+          "more": "Più",
+          "very": "Molto"
+        }
+      },
       "favorite_capacity": {
         "name": "Capacità preferita"
       },

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -416,6 +416,17 @@
           "3d": "데님"
         }
       },
+      "dryer_dry_level": {
+        "name": "건조 단계",
+        "state": {
+          "none": "끄기",
+          "damp": "촉촉",
+          "less": "적게",
+          "normal": "표준",
+          "more": "많이",
+          "very": "매우 많이"
+        }
+      },
       "favorite_capacity": {
         "name": "즐겨찾기 출수량"
       },

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -416,6 +416,17 @@
           "3d": "Spijkergoed"
         }
       },
+      "dryer_dry_level": {
+        "name": "Droogniveau",
+        "state": {
+          "none": "Uit",
+          "damp": "Vochtig",
+          "less": "Minder",
+          "normal": "Normaal",
+          "more": "Meer",
+          "very": "Zeer"
+        }
+      },
       "favorite_capacity": {
         "name": "Favoriete capaciteit"
       },

--- a/tests/localthings/conftest.py
+++ b/tests/localthings/conftest.py
@@ -252,7 +252,7 @@ def mock_entry(hass):
         domain=DOMAIN,
         data=ENTRY_DATA,
         unique_id=f"localthings_{MOCK_DEVICE_KEY}",
-        version=4,
+        version=5,
     )
     entry.add_to_hass(hass)
     return entry

--- a/tests/localthings/test_identity_migration.py
+++ b/tests/localthings/test_identity_migration.py
@@ -172,7 +172,7 @@ async def test_v3_entry_moves_onto_the_device_uuid_keeping_its_entity_ids(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.version == 4
+    assert entry.version == 5
     assert entry.data[CONF_DEVICE_KEY] == UUID_A
     # The serial is kept alongside the key, not replaced by it: it is what
     # corroborates a later change of UUID.
@@ -194,7 +194,8 @@ async def test_the_oldest_install_walks_all_the_way_from_v1(
     hass: HomeAssistant, fridge_resources
 ) -> None:
     """A v1 entry -- no stored identity at all, from before issue #236 --
-    walks v1 -> v2 -> v3 -> v4 and then adopts the UUID on its first poll.
+    walks v1 -> v2 -> v3 -> v4 -> v5 and then adopts the UUID on its first
+    poll.
 
     The oldest installs take the longest path, and each step rewrites what
     the next one reads, so the chain is worth pinning as one journey rather
@@ -209,7 +210,7 @@ async def test_the_oldest_install_walks_all_the_way_from_v1(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.version == 4
+    assert entry.version == 5
     assert entry.data[CONF_DEVICE_KEY] == UUID_A
     assert entry.unique_id == f"{DOMAIN}_{UUID_A}"
     kept = er.async_get(hass).async_get(existing.entity_id)
@@ -585,16 +586,16 @@ async def test_restarting_after_the_upgrade_is_a_no_op(
 async def test_an_already_migrated_entry_is_left_alone(
     hass: HomeAssistant, fridge_resources
 ) -> None:
-    """A v4 entry created by the current config flow has nothing to migrate
+    """A v5 entry created by the current config flow has nothing to migrate
     and nothing to re-key -- it was minted on its UUID."""
-    entry = _entry(hass, version=4, key=UUID_A, serial=MOCK_SERIAL, device_key=UUID_A)
+    entry = _entry(hass, version=5, key=UUID_A, serial=MOCK_SERIAL, device_key=UUID_A)
     device, existing = _seed_registry(hass, entry, UUID_A)
 
     with _reachable(fridge_resources, UUID_A):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.version == 4
+    assert entry.version == 5
     assert entry.data[CONF_DEVICE_KEY] == UUID_A
     assert _device_identifiers(hass, device.id) == {(DOMAIN, UUID_A)}
     assert _entity_unique_id(hass, existing.entity_id) == (f"{DOMAIN}_{UUID_A}_connection_mode")

--- a/tests/localthings/test_migration.py
+++ b/tests/localthings/test_migration.py
@@ -44,10 +44,11 @@ async def test_migration_recovers_serial_from_unique_id(
     await hass.async_block_till_done()
 
     # Straight through to the current version: v2 -> v3 is a statistics
-    # relabel that no-ops for a family without particulate sensors, and
-    # v3 -> v4 only records the legacy key for the coordinator to re-key
-    # from once a poll produces an OCF device id.
-    assert entry.version == 4
+    # relabel that no-ops for a family without particulate sensors, v3 -> v4
+    # only records the legacy key for the coordinator to re-key from once a
+    # poll produces an OCF device id, and v4 -> v5 no-ops for an entry with
+    # no dry_level sensor to drop.
+    assert entry.version == 5
     assert entry.data[CONF_SERIAL] == MOCK_SERIAL
 
 
@@ -262,7 +263,7 @@ async def test_migration_rejects_a_future_entry_version(hass: HomeAssistant) -> 
     written by a newer release."""
     from custom_components.localthings import async_migrate_entry
 
-    entry = MockConfigEntry(domain=DOMAIN, data=LEGACY_ENTRY_DATA, version=5)
+    entry = MockConfigEntry(domain=DOMAIN, data=LEGACY_ENTRY_DATA, version=6)
     entry.add_to_hass(hass)
 
     assert await async_migrate_entry(hass, entry) is False
@@ -280,3 +281,41 @@ async def test_migration_without_a_unique_id_falls_back_to_host(hass: HomeAssist
     assert await async_migrate_entry(hass, entry) is True
     assert entry.data[CONF_SERIAL] == entry.data[CONF_HOST]
     assert entry.unique_id == f"{DOMAIN}_{MOCK_HOST}"
+
+
+async def test_migration_drops_the_superseded_dry_level_sensor(hass: HomeAssistant) -> None:
+    """dryer.py's dry_level moved from a sensor to a select; unique_ids are
+    scoped by (integration, platform), so the old sensor row can only be
+    dropped, not carried across -- same tail-matching contract as the
+    particulate-statistics relabel: a plain match, a subdevice-instanced
+    match, a select-domain row with the same tail (untouched, wrong
+    domain), and an unrelated sensor (untouched, wrong tail)."""
+    from custom_components.localthings import async_migrate_entry
+
+    entry = MockConfigEntry(domain=DOMAIN, data=LEGACY_ENTRY_DATA, version=4)
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+
+    orphan = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, f"{DOMAIN}_{MOCK_SERIAL}_dry_level", config_entry=entry
+    )
+    orphan_instanced = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_{MOCK_SERIAL}_subdevice_uuid_dry_level_2",
+        config_entry=entry,
+    )
+    survivor_select = ent_reg.async_get_or_create(
+        "select", DOMAIN, f"{DOMAIN}_{MOCK_SERIAL}_dry_level", config_entry=entry
+    )
+    unrelated_sensor = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, f"{DOMAIN}_{MOCK_SERIAL}_dry_time", config_entry=entry
+    )
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 5
+    assert ent_reg.async_get(orphan.entity_id) is None
+    assert ent_reg.async_get(orphan_instanced.entity_id) is None
+    assert ent_reg.async_get(survivor_select.entity_id) is not None
+    assert ent_reg.async_get(unrelated_sensor.entity_id) is not None

--- a/tests/localthings/test_statistics_migration.py
+++ b/tests/localthings/test_statistics_migration.py
@@ -72,7 +72,7 @@ async def test_relabels_every_particulate_sensor(hass: HomeAssistant) -> None:
         # µg/m³ has a converter, so the class must be named, not None --
         # passing neither is deprecated and breaks in HA Core 2026.11.
         assert call.kwargs["new_unit_class"] == "concentration"
-    assert entry.version == 4
+    assert entry.version == 5
 
 
 async def test_leaves_other_sensors_on_the_same_device_alone(hass: HomeAssistant) -> None:
@@ -102,7 +102,7 @@ async def test_skips_families_that_did_not_gain_the_unit(hass: HomeAssistant) ->
             assert await async_migrate_entry(hass, entry) is True
 
         assert relabel.call_args_list == [], device_type
-        assert entry.version == 4
+        assert entry.version == 5
 
 
 async def test_defers_rather_than_consuming_the_migration_without_the_recorder(
@@ -127,7 +127,7 @@ async def test_defers_rather_than_consuming_the_migration_without_the_recorder(
         assert await async_migrate_entry(hass, entry) is True
 
     assert len(relabel.call_args_list) == 1
-    assert entry.version == 4
+    assert entry.version == 5
 
 
 async def test_omits_unit_class_on_an_older_home_assistant(hass: HomeAssistant) -> None:
@@ -151,7 +151,7 @@ async def test_omits_unit_class_on_an_older_home_assistant(hass: HomeAssistant) 
         assert await async_migrate_entry(hass, entry) is True
 
     assert seen == [{"new_unit_of_measurement": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER}]
-    assert entry.version == 4
+    assert entry.version == 5
 
 
 async def test_a_relabel_failure_never_fails_the_entry(hass: HomeAssistant) -> None:
@@ -165,7 +165,7 @@ async def test_a_relabel_failure_never_fails_the_entry(hass: HomeAssistant) -> N
     with patch(RELABEL, autospec=True, side_effect=TypeError("older HA signature")):
         assert await async_migrate_entry(hass, entry) is True
 
-    assert entry.version == 4
+    assert entry.version == 5
 
 
 async def test_follows_a_renamed_entity_rather_than_rebuilding_its_id(
@@ -226,4 +226,4 @@ async def test_a_fresh_entry_starts_at_the_migrated_version(hass: HomeAssistant)
     """
     from custom_components.localthings.config_flow import LocalThingsConfigFlow
 
-    assert LocalThingsConfigFlow.VERSION == 4
+    assert LocalThingsConfigFlow.VERSION == 5

--- a/tests/test_dryer_capabilities.py
+++ b/tests/test_dryer_capabilities.py
@@ -4,7 +4,7 @@ from custom_components.localthings.registry.adapter import flatten
 from custom_components.localthings.registry.by_type import for_device_by_model, resolve
 from custom_components.localthings.registry.capabilities import dryer, ignored
 from custom_components.localthings.registry.discovery import discover
-from custom_components.localthings.registry.entities import SelectDesc
+from custom_components.localthings.registry.entities import SelectDesc, SensorDesc
 from tests.conftest import _load_device
 
 
@@ -51,6 +51,68 @@ def test_expected_entities_present():
         "energy_kwh",
     ):
         assert key in state, key
+
+
+class TestDryLevel:
+    """dryLevel moved from a read-only sensor to a writable select,
+    mirroring washer.py's combo select -- same options_field/exists_fn/
+    write_fn shape, but its own translation_key: the field means a dryness
+    dial here, not the combo's duration-in-minutes dial."""
+
+    def test_is_a_select_not_a_sensor(self):
+        assert not any(
+            e.key == "dry_level" and isinstance(e, SensorDesc)
+            for e in dryer.DRYER_SETTINGS.entities
+        )
+        desc = next(e for e in dryer.DRYER_SETTINGS.entities if e.key == "dry_level")
+        assert isinstance(desc, SelectDesc)
+
+    def test_translation_key_is_dryer_specific(self):
+        desc = next(e for e in dryer.DRYER_SETTINGS.entities if e.key == "dry_level")
+        assert desc.translation_key == "dryer_dry_level"
+
+    def test_sits_in_controls_with_its_writable_siblings(self):
+        """A per-load choice, not device configuration: it belongs beside the
+        cycle select and wrinkle_prevent, which both carry no category -- and
+        that is where the sensor it replaces already sat, so an upgrading
+        user finds it where they left it."""
+        desc = next(e for e in dryer.DRYER_SETTINGS.entities if e.key == "dry_level")
+        assert desc.entity_category is None
+        wrinkle = next(e for e in dryer.DRYER_SETTINGS.entities if e.key == "wrinkle_prevent")
+        assert wrinkle.entity_category is None
+
+    def test_options_field(self):
+        desc = next(
+            e
+            for e in dryer.DRYER_SETTINGS.entities
+            if e.key == "dry_level" and isinstance(e, SelectDesc)
+        )
+        assert desc.options_field == "x.com.samsung.da.supportedDryLevel"
+
+    def test_presence_is_field_gated_not_narrowed_by_an_exists_fn(self):
+        """The select must appear exactly where the sensor it replaces did.
+        washer.py gates its combo dry_level on supportedDryLevel to tell a
+        combo from a plain washer; every dryer has a dry level, so the same
+        gate here would only suppress the entity -- including on a rep that
+        is a stub at discovery time, which entity._is_included admits so a
+        sub-poll can populate it. A missing entity would be permanent: the
+        v4->v5 migration removes the old sensor row unconditionally."""
+        desc = next(e for e in dryer.DRYER_SETTINGS.entities if e.key == "dry_level")
+        assert desc.exists_fn is None
+        assert desc.field == "x.com.samsung.da.dryLevel"
+
+    def test_write(self):
+        desc = next(
+            e
+            for e in dryer.DRYER_SETTINGS.entities
+            if e.key == "dry_level" and isinstance(e, SelectDesc)
+        )
+        assert desc.write_fn is not None
+        result = desc.write_fn("Normal", {})
+        assert result is not None
+        path, body = result
+        assert path == ["washer", "vs", "0"]
+        assert body == {"x.com.samsung.da.dryLevel": "Normal"}
 
 
 def test_job_beginning_status_reads_current_status():

--- a/tests/test_select_options.py
+++ b/tests/test_select_options.py
@@ -6,6 +6,7 @@ and callable forms of SelectDesc.options.
 from typing import ClassVar, cast
 
 from custom_components.localthings.coordinator import LocalThingsCoordinator
+from custom_components.localthings.registry.capabilities import dryer
 from custom_components.localthings.registry.capabilities.laundry import (
     BUZZER_SOUND,
     cycle_select,
@@ -65,6 +66,53 @@ def test_buzzer_volume_options_normalize_to_translation_keys():
         },
     )
     assert entity.options == ["volume_off", "volume_low", "volume_med", "volume_high"]
+
+
+def _dry_level_desc():
+    return next(e for e in dryer.DRYER_SETTINGS.entities if e.key == "dry_level")
+
+
+def test_dryer_dry_level_word_vocabulary_normalizes_to_translation_keys():
+    """Damp/Less/Normal/More/Very are catalogued under dryer_dry_level, so
+    they normalize to lowercase state keys the same way
+    test_buzzer_volume_options_normalize_to_translation_keys does -- Home
+    Assistant's frontend resolves the displayed text from there."""
+    entity = _make_select(
+        _dry_level_desc(),
+        "/washer/vs/0",
+        {
+            "/washer/vs/0": {
+                "x.com.samsung.da.dryLevel": "Normal",
+                "x.com.samsung.da.supportedDryLevel": [
+                    "None",
+                    "Damp",
+                    "Less",
+                    "Normal",
+                    "More",
+                    "Very",
+                ],
+            }
+        },
+    )
+    assert entity.options == ["none", "damp", "less", "normal", "more", "very"]
+
+
+def test_dryer_dry_level_numeric_vocabulary_renders_raw():
+    """DV6800N reports supportedDryLevel as None/1/2/3 rather than the
+    confirmed words. 'None' still normalizes (it is in the catalog); the
+    digits have no catalog entry, so they pass through unchanged instead of
+    being guessed at."""
+    entity = _make_select(
+        _dry_level_desc(),
+        "/washer/vs/0",
+        {
+            "/washer/vs/0": {
+                "x.com.samsung.da.dryLevel": "2",
+                "x.com.samsung.da.supportedDryLevel": ["None", "1", "2", "3"],
+            }
+        },
+    )
+    assert entity.options == ["none", "1", "2", "3"]
 
 
 def test_callable_options_receives_full_resource_snapshot():

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -376,6 +376,19 @@ def test_confirmed_dryer_table_03_dv19t8745bv_course_names():
         assert d_states["3d"] == w_states["66"], language  # Denim
 
 
+def test_confirmed_dryer_dry_level_labels():
+    """dryer_dry_level's word vocabulary (None/Damp/Less/Normal/More/Very),
+    confirmed across the TP1_21 dryer fixtures. The numeric vocabulary
+    (None/1/2/3) that DV6800N reports is deliberately NOT translated -- no
+    confirmed meaning for the digits exists, and select._display renders an
+    uncatalogued value raw rather than guessing a label for it."""
+    states = _load("en")["entity"]["select"]["dryer_dry_level"]["state"]
+    assert set(states) == {"none", "damp", "less", "normal", "more", "very"}
+    assert states["none"] == "Off"
+    for digit in ("1", "2", "3"):
+        assert digit not in states
+
+
 def test_reported_washer_standard_courses_all_have_table_02_labels():
     """Every non-personal code in the reported washer's live course list
     must resolve through the Table_02 catalog instead of appearing as raw


### PR DESCRIPTION
## Summary

- Move the dryer's `dry_level` from a read-only sensor to a writable select, matching what washer/dryer combos have had since #33
- Add an `entity.select.dryer_dry_level` catalog across all seven locales
- Add a v4 → v5 config-entry migration that drops the entity-registry row the platform move orphans

Every dryer board in the corpus reports `x.com.samsung.da.supportedDryLevel` right next to `dryLevel` on `/washer/vs/0` — the same live option list `washer.py`'s combo select already writes against — but the dryer registry bound the field read-only. Both capabilities bind the same href and only one ever binds per device, so the asymmetry was historical rather than anything device-side.

## Why a separate translation key

`washer_dry_level`'s state table is that field's *other* meaning on a combo: a duration in minutes (`"30"` → `"30 min"`, `"240"` → `"4 hr"`). Reusing it would label a dryer's dryness setting in minutes, so the dryer gets `dryer_dry_level`.

The catalog covers the `Damp/Less/Normal/More/Very` vocabulary the TP1_21 dryers report. The numeric `None/1/2/3` that DV5000T (TP2_20) and DV6800N (A51_20) report is deliberately left uncatalogued, so `select._display` renders the digits raw — nothing confirms what they mean, and that's the same treatment unidentified course codes already get.

## Two deliberate differences from `washer.py`'s descriptor

**Field-gated, no `exists_fn`.** In `washer.py` the gate on `supportedDryLevel` discriminates a combo from a plain washer. Every dryer has a dry level, so the same gate here would only ever suppress the entity — including on a rep that is merely a stub at discovery, which `entity._is_included` deliberately admits so a sub-poll can populate it. Since `_is_included` is evaluated once at discovery, that would have been permanent for the life of the entry, and the migration below would already have removed the sensor.

**No `entity_category`.** Dry level is a per-load choice made alongside the cycle, not device configuration. It belongs in Controls next to the cycle select and `wrinkle_prevent`, which is also where the sensor it replaces already sat.

## ⚠️ Breaking change

`unique_id`s are scoped by (integration, platform), so a platform move cannot rewrite the old registry row — it can only be dropped.

- The v4 → v5 migration removes `sensor.<dryer>_dry_level`. Dashboards, automations, and the entity's rename/area need repointing at `select.<dryer>_dry_level`. The removal is logged at INFO naming the replacement, since it is irreversible.
- The entry version bump means **downgrading fails the entry outright** rather than losing a single entity, because the older release's guard is `entry.version > 4`. That is the downgrade guard working as designed, but it is worth weighing given 0.24.0 just shipped.

## Validation

- `ruff check custom_components tests`, `ruff format --check custom_components tests`, `ty check custom_components tests` — all clean
- 1740 tests pass, including the corpus-wide golden/unique-id/translation checks
- No golden file changes: the state key stays `dry_level` and `flatten()` is platform-agnostic, so the four existing dryer goldens are untouched
- Confirmed on a Samsung DV5000T (`DA_WM_TP2_20_COMMON`) through Home Assistant: the select lists the board's own `None/1/2/3`, and setting a level takes on the appliance. That board reports `isModelSettingWithoutSC` true, so the write lands with Smart Control off (see `common.remote_control_required_for_write`).

## Not included

`dry_time` stays a sensor. Dryer boards do report `supportedDryTime`, so a writable dry-time select is viable, but it is a separate change and would need its own entry migration for the same platform-move reason.
