### PR TITLE
feat: add local Samsung TV (QN90B) control component

### DIFF
--- a/custom_components/samsung_tv_local/README.md
+++ b/custom_components/samsung_tv_local/README.md
@@ -1,0 +1,116 @@
+# Samsung TV Local (QN90B)
+
+A sibling component to LocalThings for the QN90B TVs, **100% local** — it
+talks to the TV directly over the remote-control WebSocket (port 8002, TLS)
+plus **Wake-on-LAN** — no SmartThings, no cloud, no fees.
+
+> LocalThings (mbillow) controls Samsung appliances over **CoAP/DTLS**
+> (fridges, washers, ...). The **QN90B does not speak CoAP/DTLS** (verified
+> against the TV), so this component uses the TV's own WebSocket transport
+> (the same protocol family as the stock HA `samsungtv` integration, but as
+> part of this fork).
+
+## Features
+
+- **Power**: on via WOL (MAC), off via `KEY_POWER`, on/off state
+- **Volume**: up/down/absolute set, mute + volume level state
+- **Source/input**: list (`ed.sourcesChanged`) + direct switch
+  (`ed.setSource` — best-effort; falls back to cycling `KEY_SOURCE`)
+- **Apps**: launch via `media_player.play_media(media_type="app",
+  media_id="<id or name>")` + shortcut buttons (Netflix, YouTube, Prime,
+  Disney+, Spotify)
+- **Media**: play/pause/stop/ff/rew (keys)
+- **Remote**: `remote.send_command` with friendly names or raw `KEY_*`
+  codes (e.g. `home`, `source`, `ok` — see `const.KEYS`)
+
+## Installation
+
+Copy `custom_components/samsung_tv_local/` into the `custom_components`
+directory of your Home Assistant and restart (or install via HACS as a local
+repository).
+
+## Configuration
+
+1. **Settings → Devices & Services → Add Integration → "Samsung TV Local
+   (QN90B)"**
+2. Enter the TV **IP**, the **MAC** (for WOL; Samsung TVs have separate MACs
+   for WiFi and Ethernet — use the one for the interface in use) and a name.
+3. Authentication (choose one):
+   - **Existing token**: paste the token from the stock `samsungtv` config
+     entry (in `.storage/core.config_entries`) — the pragmatic path, no
+     pairing needed.
+   - **Allow popup pairing**: an "Allow" popup appears on the TV; press Allow
+     and the token is granted automatically (no PIN — see below).
+
+## How pairing works (validated on the QN90B)
+
+The TV has **two independent pairing mechanisms**, and they behave very
+differently:
+
+### 1. Classic WebSocket pairing (the one this component uses — no PIN)
+
+```
+1. Client connects to wss://<tv>:8002 ... (TLS) WITHOUT a token
+2. The TV replies with the ms.channel.connect event whose data.token is a
+   freshly granted auth token
+3. The client stores the token and sends it as ?token=<token> on every
+   subsequent connection
+```
+
+- **No PIN, and usually no popup.** On the QN90B the token grant is
+  automatic while the TV is on — the `ms.channel.connect` event
+  arrives immediately with the token.
+- The TV may show an "Allow" popup **only the first time** a client name is
+  seen (or after the paired-client list is cleared). The popup renders the
+  client name; a "[Invalid UTF-8]" label is a cosmetic rendering bug of the
+  TV, not a real problem. If a popup appears, press Allow and the token
+  arrives right after.
+- The TV **remembers authorized clients by name**; later connections with an
+  already-authorized name rotate the token silently (no popup). A network
+  reset does **not** clear the authorized list. To force a fresh popup, use
+  a different client name.
+- The stored token keeps working across connections (it is only rotated when
+  connecting without a token).
+
+### 2. Encrypted SPC pairing (port 8080 — NOT used by this component)
+
+The TV also exposes the newer "encrypted" (SmartThings-style) pairing: an
+app opens the **CloudPINPage** (port 8080) and the TV shows an **8-digit
+PIN** (e.g. `1234-5678`). That flow performs a Diffie-Hellman/AES handshake
+(`/ws/pairing`) and yields a token + session id used by an encrypted
+socket.io session.
+
+- This is a **separate mechanism** from the WebSocket remote. On this
+  firmware the SPC endpoint (`/ws/pairing`) returns 404, so the encrypted
+  path is not available/needed for remote control here.
+- If you ever saw an 8-digit PIN on the TV while testing, it came from this
+  encrypted page (or from the stock SmartThings app), not from the classic
+  pairing.
+
+## Protocol notes (validated live on a QN90B)
+
+- The remote WebSocket is on port **8002 over TLS** (`wss://` with a
+  self-signed certificate; plain `ws://` is refused by this firmware).
+- The TV only accepts the socket while powered on; when off, WOL only.
+- No special TV setting is required — the socket is reachable whenever the
+  TV is on. The "**IP Remote**" setting is for remote *configuration* of the
+  TV (a different feature), and "**Remote Management**" is for Samsung
+  remote support; **neither gates the WebSocket**. The only authorization is
+  the one-time Allow popup (validated with both toggles on and off).
+- Power-on via WOL and key control (volume up/down, mute, home, power off)
+  are validated against real hardware.
+- Volume/source **state queries** (`ms.channel.emit` / `ed.volumeChanged`)
+  are not answered by every QN90B firmware revision — key-based control
+  still works, but state may be unavailable on some units.
+- `ed.setSource` (direct input switch) is a flagged guess — some firmware
+  ignores it; the component falls back to cycling `KEY_SOURCE`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Socket never answers (TLS handshake fails) | TV is off or unreachable — check the IP / power it on (WOL) |
+| `No Authorized` on commands | Token missing/expired — reconnect without a token to get a fresh one |
+| No popup appears during pairing | Normal — the token is granted silently; a popup only shows on first-time authorization |
+| TV shows "on" while the screen is off / WOL doesn't wake it | The TV's "**Instant On**" is ON (Settings → General & Privacy → Power and Energy Saving) — it keeps the network alive in standby. Turn it off for true deep-off, where WOL works and power state is accurate |
+| Volume level shows nothing | Firmware revision doesn't answer state queries — only key control available |

--- a/custom_components/samsung_tv_local/__init__.py
+++ b/custom_components/samsung_tv_local/__init__.py
@@ -1,0 +1,37 @@
+"""Samsung TV Local (QN90B): local WebSocket control without SmartThings."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_TOKEN, DOMAIN, PLATFORMS
+from .coordinator import SamsungTvHub
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    async def _save_token(token: str) -> None:
+        hass.config_entries.async_update_entry(entry, data={**entry.data, CONF_TOKEN: token})
+
+    hub = SamsungTvHub(
+        hass,
+        host=entry.data[CONF_HOST],
+        mac=entry.data[CONF_MAC],
+        token=entry.data[CONF_TOKEN],
+        name=entry.data.get(CONF_NAME, "Samsung TV"),
+        token_saver=_save_token,
+    )
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/samsung_tv_local/button.py
+++ b/custom_components/samsung_tv_local/button.py
@@ -1,0 +1,49 @@
+"""Button entities: one-tap launch of common apps."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+_LAUNCH_BUTTONS = [
+    ("org.tizen.netflix", "Netflix"),
+    ("11101200001", "YouTube"),
+    ("3201512006785", "Prime Video"),
+    ("3201901017640", "Disney+"),
+    ("9Ur5IzDK1D", "Spotify"),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    hub = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([SamsungAppButton(hub, app_id, label) for app_id, label in _LAUNCH_BUTTONS])
+
+
+class SamsungAppButton(ButtonEntity):
+    """Launch a specific app by id."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, hub, app_id: str, label: str) -> None:
+        self._hub = hub
+        self._app_id = app_id
+        self._attr_unique_id = f"{hub.mac}-app-{app_id}"
+        self._attr_translation_key = "launch_app"
+        self._attr_translation_placeholders = {"app": label}
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, hub.mac)},
+            "name": hub.name,
+            "manufacturer": "Samsung",
+            "model": "QN90B",
+        }
+
+    async def async_press(self) -> None:
+        await self._hub.launch_app(self._app_id)

--- a/custom_components/samsung_tv_local/config_flow.py
+++ b/custom_components/samsung_tv_local/config_flow.py
@@ -1,0 +1,86 @@
+"""Config flow for Samsung TV Local (QN90B).
+
+Two ways to authenticate:
+  * provide an existing token directly (e.g. the one from the stock HA
+    `samsungtv` integration entry - the pragmatic path), or
+  * pair by allowing the TV's on-screen popup (QN90B firmware grants the
+    token in the channel-connect event, no PIN required).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from .const import CONF_HOST, CONF_MAC, CONF_TOKEN, DOMAIN
+from .protocol import pair
+
+_LOGGER = logging.getLogger(__name__)
+
+_TEXT = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT))
+
+STEP_USER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): _TEXT,
+        vol.Required(CONF_MAC): _TEXT,
+        vol.Optional(CONF_NAME, default="Samsung TV"): _TEXT,
+        vol.Optional(CONF_TOKEN, default=""): _TEXT,
+    }
+)
+
+
+class SamsungTvLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a Samsung TV Local config flow."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_MAC].lower())
+            self._abort_if_unique_id_configured()
+            self._host = user_input[CONF_HOST]
+            self._mac = user_input[CONF_MAC]
+            self._name = user_input.get(CONF_NAME, "Samsung TV")
+            token = user_input.get(CONF_TOKEN) or ""
+            if token:
+                return self.async_create_entry(
+                    title=self._name,
+                    data={
+                        CONF_HOST: self._host,
+                        CONF_MAC: self._mac,
+                        CONF_TOKEN: token,
+                        CONF_NAME: self._name,
+                    },
+                )
+            return await self.async_step_pairing()
+        return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors)
+
+    async def async_step_pairing(self, user_input=None) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                token = await pair(self._host, name="LocalThings")
+            except Exception as exc:
+                _LOGGER.warning("pairing failed: %s", exc)
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=self._name,
+                    data={
+                        CONF_HOST: self._host,
+                        CONF_MAC: self._mac,
+                        CONF_TOKEN: token,
+                        CONF_NAME: self._name,
+                    },
+                )
+        return self.async_show_form(step_id="pairing", data_schema=vol.Schema({}), errors=errors)

--- a/custom_components/samsung_tv_local/const.py
+++ b/custom_components/samsung_tv_local/const.py
@@ -1,0 +1,72 @@
+"""Constants for the Samsung TV Local (QN90B) component."""
+
+DOMAIN = "samsung_tv_local"
+
+CONF_HOST = "host"
+CONF_MAC = "mac"
+CONF_TOKEN = "token"
+CONF_NAME = "name"
+
+DEFAULT_NAME = "Samsung TV"
+WS_PORT = 8002
+WOL_PORT = 9
+WOL_BCAST = "255.255.255.255"
+
+# Friendly key name -> raw key code sent to the TV.
+KEYS = {
+    "power": "KEY_POWER",
+    "volup": "KEY_VOLUP",
+    "voldown": "KEY_VOLDOWN",
+    "mute": "KEY_MUTE",
+    "chup": "KEY_CHUP",
+    "chdown": "KEY_CHDOWN",
+    "up": "KEY_UP",
+    "down": "KEY_DOWN",
+    "left": "KEY_LEFT",
+    "right": "KEY_RIGHT",
+    "ok": "KEY_ENTER",
+    "back": "KEY_RETURN",
+    "exit": "KEY_EXIT",
+    "home": "KEY_HOME",
+    "source": "KEY_SOURCE",
+    "guide": "KEY_GUIDE",
+    "info": "KEY_INFO",
+    "play": "KEY_PLAY",
+    "pause": "KEY_PAUSE",
+    "stop": "KEY_STOP",
+    "ff": "KEY_FF",
+    "rew": "KEY_REW",
+    "rec": "KEY_REC",
+    "red": "KEY_RED",
+    "green": "KEY_GREEN",
+    "yellow": "KEY_YELLOW",
+    "blue": "KEY_BLUE",
+    "menu": "KEY_MENU",
+    "tools": "KEY_TOOLS",
+    "list": "KEY_CH_LIST",
+    "0": "KEY_0",
+    "1": "KEY_1",
+    "2": "KEY_2",
+    "3": "KEY_3",
+    "4": "KEY_4",
+    "5": "KEY_5",
+    "6": "KEY_6",
+    "7": "KEY_7",
+    "8": "KEY_8",
+    "9": "KEY_9",
+}
+
+# Friendly app id -> label (the runtime installed list is authoritative).
+KNOWN_APPS = {
+    "org.tizen.netflix": "Netflix",
+    "11101200001": "YouTube",
+    "320160100764": "YouTube",
+    "3201512006785": "Prime Video",
+    "3201901017640": "Disney+",
+    "9Ur5IzDK1D": "Spotify",
+    "org.tizen.browser": "Internet",
+    "3201801011689": "Apple TV",
+    "xTxLOQN1a6": "Twitch",
+}
+
+PLATFORMS = ["media_player", "remote", "button"]

--- a/custom_components/samsung_tv_local/coordinator.py
+++ b/custom_components/samsung_tv_local/coordinator.py
@@ -1,0 +1,141 @@
+"""Coordinator: owns the local TV session and exposes control helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+from homeassistant.core import HomeAssistant
+
+from .protocol import AuthError, SamsungRemote, pair, wake_on_lan
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SamsungTvHub:
+    """Controller for one TV over the local WebSocket protocol.
+
+    The auth token is refreshed automatically (re-paired) whenever the TV
+    rejects it, so a token expiry never leaves the TV stuck.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        host: str,
+        mac: str,
+        token: str,
+        name: str = "Samsung TV",
+        token_saver: Callable[[str], Awaitable[None]] | None = None,
+    ) -> None:
+        self.hass = hass
+        self.host = host
+        self.mac = mac
+        self.token = token
+        self.name = name
+        self.max_volume = 0
+        self._token_saver = token_saver
+        self._token_lock = asyncio.Lock()
+
+    async def _refresh_token(self) -> None:
+        """Re-pair with the TV and persist the fresh token."""
+        old_token = self.token
+        async with self._token_lock:
+            # Another task may have refreshed while we waited for the lock.
+            if self.token != old_token:
+                return
+            token = await pair(self.host, name="LocalThings")
+            self.token = token
+            if self._token_saver is not None:
+                await self._token_saver(token)
+            _LOGGER.info("refreshed TV auth token")
+
+    async def _session(self) -> SamsungRemote:
+        """Open a session, refreshing the token once if it was rejected."""
+        tv = SamsungRemote(self.host, name="LocalThings", token=self.token)
+        try:
+            await tv.connect()
+        except AuthError:
+            await self._refresh_token()
+            tv = SamsungRemote(self.host, name="LocalThings", token=self.token)
+            await tv.connect()
+        return tv
+
+    async def is_on(self) -> bool:
+        try:
+            tv = await self._session()
+            await tv.close()
+            return True
+        except Exception:
+            return False
+
+    async def turn_on(self) -> None:
+        if not await self.is_on():
+            await wake_on_lan(self.mac, self.host)
+
+    async def _send_key_authed(self, key: str) -> None:
+        """Send a key, refreshing the token and retrying on auth rejection."""
+        for attempt in (1, 2):
+            tv = await self._session()  # refreshes on connect-time rejection
+            try:
+                await tv.send_key_checked(key)  # detects command-time rejection
+                return
+            except AuthError:
+                await tv.close()
+                if attempt == 1:
+                    await self._refresh_token()
+                    continue
+                raise
+            finally:
+                await tv.close()
+
+    async def turn_off(self) -> None:
+        await self._send_key_authed("KEY_POWER")
+
+    async def send_key(self, key: str) -> None:
+        await self._send_key_authed(key)
+
+    async def volume_step(self, delta: int) -> None:
+        """Move the volume by `delta` steps on a single session."""
+        if delta == 0:
+            return
+        key = "KEY_VOLUP" if delta > 0 else "KEY_VOLDOWN"
+        async with await self._session() as tv:
+            for _ in range(abs(delta)):
+                await tv.send_key(key)
+
+    async def volume(self) -> dict:
+        try:
+            async with await self._session() as tv:
+                return await tv.get_volume()
+        except Exception as exc:
+            _LOGGER.debug("volume query failed: %s", exc)
+            return {}
+
+    async def sources(self) -> list:
+        try:
+            async with await self._session() as tv:
+                return await tv.get_sources()
+        except Exception as exc:
+            _LOGGER.debug("sources query failed: %s", exc)
+            return []
+
+    async def launch_app(self, app_id: str) -> None:
+        async with await self._session() as tv:
+            await tv.launch_app(app_id)
+
+    async def set_source(self, source_id: str) -> None:
+        """Best-effort direct source switch.
+
+        Not every Tizen firmware answers `ed.setSource`; fall back to cycling
+        with KEY_SOURCE when it is ignored.
+        """
+        tv = await self._session()
+        try:
+            await tv.set_source(source_id)
+        except Exception as exc:
+            _LOGGER.warning("ed.setSource failed (%s); cycling KEY_SOURCE", exc)
+            await tv.send_key("KEY_SOURCE")
+        finally:
+            await tv.close()

--- a/custom_components/samsung_tv_local/manifest.json
+++ b/custom_components/samsung_tv_local/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "samsung_tv_local",
+  "name": "Samsung TV Local (QN90B)",
+  "codeowners": ["@danalec"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/danalec/localthings",
+  "issue_tracker": "https://github.com/danalec/localthings/issues",
+  "iot_class": "local_polling",
+  "requirements": ["websockets>=13.0"],
+  "version": "0.1.0"
+}

--- a/custom_components/samsung_tv_local/media_player.py
+++ b/custom_components/samsung_tv_local/media_player.py
@@ -1,0 +1,155 @@
+"""Media player entity for a locally controlled Samsung QN90B TV."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+
+from homeassistant.components.media_player import MediaPlayerEntity
+from homeassistant.components.media_player.const import (
+    MediaPlayerEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, KNOWN_APPS
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = datetime.timedelta(seconds=30)
+
+# Reverse map so play_media accepts either an app id or a friendly name.
+_APP_ID_BY_NAME = {name: app_id for app_id, name in KNOWN_APPS.items()}
+
+SUPPORT_SAMSUNGTV = (
+    MediaPlayerEntityFeature.TURN_ON
+    | MediaPlayerEntityFeature.TURN_OFF
+    | MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.VOLUME_STEP
+    | MediaPlayerEntityFeature.VOLUME_MUTE
+    | MediaPlayerEntityFeature.SELECT_SOURCE
+    | MediaPlayerEntityFeature.PLAY_MEDIA
+    | MediaPlayerEntityFeature.PLAY
+    | MediaPlayerEntityFeature.PAUSE
+    | MediaPlayerEntityFeature.STOP
+    | MediaPlayerEntityFeature.NEXT_TRACK
+    | MediaPlayerEntityFeature.PREVIOUS_TRACK
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    hub = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([SamsungTvMediaPlayer(hub)], update_before_add=False)
+
+
+class SamsungTvMediaPlayer(MediaPlayerEntity):
+    """A QN90B controlled over the local WebSocket remote."""
+
+    _attr_has_entity_name = True
+    _attr_supported_features = SUPPORT_SAMSUNGTV
+
+    def __init__(self, hub) -> None:
+        self._hub = hub
+        self._attr_unique_id = f"{hub.mac}-media_player"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, hub.mac)},
+            "name": hub.name,
+            "manufacturer": "Samsung",
+            "model": "QN90B",
+        }
+        self._sources: list[str] = []
+        self._volume = 0
+        self._muted = False
+        self._state = STATE_OFF
+
+    async def async_update(self) -> None:
+        """Refresh on/off, volume and sources from the TV."""
+        try:
+            if not await self._hub.is_on():
+                self._state = STATE_OFF
+                return
+            self._state = STATE_ON
+            vol = await self._hub.volume()
+            if vol:
+                self._volume = int(vol.get("volume") or 0)
+                self._hub.max_volume = int(vol.get("max") or 0)
+                self._muted = bool(vol.get("mute"))
+            sources = await self._hub.sources()
+            if sources:
+                self._sources = [s.get("name") or s.get("id") for s in sources]
+        except Exception as exc:
+            _LOGGER.debug("update failed: %s", exc)
+            self._state = STATE_OFF
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def volume_level(self) -> float | None:
+        if self._hub.max_volume:
+            return self._volume / self._hub.max_volume
+        return None
+
+    @property
+    def is_volume_muted(self) -> bool:
+        return self._muted
+
+    @property
+    def source_list(self) -> list[str]:
+        return self._sources
+
+    async def async_turn_on(self) -> None:
+        await self._hub.turn_on()
+
+    async def async_turn_off(self) -> None:
+        await self._hub.turn_off()
+
+    async def async_volume_up(self) -> None:
+        await self._hub.send_key("KEY_VOLUP")
+
+    async def async_volume_down(self) -> None:
+        await self._hub.send_key("KEY_VOLDOWN")
+
+    async def async_volume_set(self, volume: float) -> None:
+        if not self._hub.max_volume:
+            return
+        target = round(volume * self._hub.max_volume)
+        await self._hub.volume_step(target - self._volume)
+        self._volume = target
+
+    async def async_mute_volume(self, mute: bool) -> None:
+        if self._muted != mute:
+            await self._hub.send_key("KEY_MUTE")
+            self._muted = mute
+
+    async def async_select_source(self, source: str) -> None:
+        await self._hub.set_source(source)
+
+    async def async_play_media(self, media_type: str, media_id: str, **kwargs) -> None:
+        if media_type != "app":
+            _LOGGER.warning("only media_type 'app' is supported (got %s)", media_type)
+            return
+        app_id = KNOWN_APPS.get(media_id) or _APP_ID_BY_NAME.get(media_id) or media_id
+        await self._hub.launch_app(app_id)
+
+    async def async_media_play(self) -> None:
+        await self._hub.send_key("KEY_PLAY")
+
+    async def async_media_pause(self) -> None:
+        await self._hub.send_key("KEY_PAUSE")
+
+    async def async_media_stop(self) -> None:
+        await self._hub.send_key("KEY_STOP")
+
+    async def async_media_next_track(self) -> None:
+        await self._hub.send_key("KEY_FF")
+
+    async def async_media_previous_track(self) -> None:
+        await self._hub.send_key("KEY_REW")

--- a/custom_components/samsung_tv_local/protocol.py
+++ b/custom_components/samsung_tv_local/protocol.py
@@ -1,0 +1,268 @@
+"""Local transport for Samsung QN90B TVs.
+
+The QN90B exposes the remote-control WebSocket on port 8002 over TLS
+(wss:// with a self-signed certificate). A TV only accepts commands while it
+is powered on; power-on is done via a Wake-on-LAN magic packet.
+
+Commands require an auth token. Two ways to obtain one:
+  * the classic Pin4 pairing flow over the same WebSocket (works on many
+    models, see `pair`), or
+  * reuse the token already granted by another client (e.g. the stock HA
+    `samsungtv` integration config entry) - the pragmatic path.
+
+No cloud, no SmartThings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import socket
+import ssl
+import urllib.parse
+
+import websockets
+from websockets.exceptions import ConnectionClosedError
+
+_LOGGER = logging.getLogger(__name__)
+
+REMOTE_CHANNEL = "/api/v2/channels/samsung.remote.control"
+
+
+def _serialize_name(name: str) -> str:
+    """Base64-encode the client name for the URL query.
+
+    Samsung TVs decode this value and render it in the Allow popup; a raw
+    (non-Base64) name decodes to garbage and shows as "[Invalid UTF-8]".
+    """
+    return base64.b64encode(name.encode("utf-8")).decode("ascii")
+
+
+def _ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+class RemoteError(Exception):
+    """The TV did not answer as expected."""
+
+
+class AuthError(RemoteError):
+    """The stored token was rejected (expired/revoked)."""
+
+
+class SamsungRemote:
+    """One remote-control WebSocket session to a TV."""
+
+    def __init__(self, host, name="LocalThings", token=None, port=8002):
+        self.host = host
+        self.name = name
+        self.token = token
+        self.port = port
+        self._ws = None
+
+    def _uri(self, include_token):
+        query = {"name": _serialize_name(self.name)}
+        if include_token and self.token:
+            query["token"] = self.token
+        return f"wss://{self.host}:{self.port}{REMOTE_CHANNEL}?" + urllib.parse.urlencode(query)
+
+    async def connect(self):
+        self._ws = await websockets.connect(
+            self._uri(include_token=True), ssl=_ssl_context(), open_timeout=8
+        )
+        # Drain startup events until the channel-connect confirmation.
+        for _ in range(5):
+            try:
+                msg = json.loads(await asyncio.wait_for(self._ws.recv(), timeout=4))
+            except TimeoutError:
+                break
+            except ConnectionClosedError as exc:
+                raise RemoteError(f"connection closed during handshake ({exc.code})") from exc
+            event = msg.get("event")
+            if event == "ms.channel.connect":
+                break
+            if event in ("ms.channel.unauthorized", "ms.channel.timeOut"):
+                raise AuthError(f"token rejected ({event})")
+
+    async def close(self):
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+
+    async def __aenter__(self):
+        if self._ws is None:
+            await self.connect()
+        return self
+
+    async def __aexit__(self, *exc):
+        await self.close()
+
+    async def _send(self, payload):
+        if self._ws is None:
+            raise RemoteError("not connected")
+        await self._ws.send(json.dumps(payload))
+
+    async def _recv(self, recv_timeout: float = 4.0):
+        if self._ws is None:
+            raise RemoteError("not connected")
+        return json.loads(await asyncio.wait_for(self._ws.recv(), timeout=recv_timeout))
+
+    async def send_key(self, key):
+        await self._send(
+            {
+                "method": "ms.remote.control",
+                "params": {
+                    "Cmd": "Click",
+                    "DataOfCmd": key,
+                    "Option": "false",
+                    "TypeOfRemote": "SendRemoteKey",
+                },
+            }
+        )
+
+    async def send_key_checked(self, key):
+        """Send a key and detect an auth rejection.
+
+        The QN90B replies `ms.error {message: "No Authorized"}` to rejected
+        commands (and stays silent on accepted ones), so a short read is
+        enough to tell an expired token apart.
+        """
+        await self.send_key(key)
+        try:
+            msg = await self._recv(recv_timeout=1.0)
+        except TimeoutError:
+            return  # accepted: no reply on success
+        data = msg.get("data") or {}
+        if msg.get("event") == "ms.error" and data.get("message") == "No Authorized":
+            raise AuthError("No Authorized")
+
+    async def _emit(self, event):
+        """Query state and wait for the matching reply (bounded by timeout)."""
+        await self._send({"method": "ms.channel.emit", "params": {"event": event, "to": "host"}})
+        for _ in range(20):
+            try:
+                msg = await self._recv(recv_timeout=4)
+            except TimeoutError:
+                raise RemoteError(f"no reply for {event}") from None
+            data = msg.get("data")
+            if (
+                msg.get("event") == "ms.error"
+                and isinstance(data, dict)
+                and data.get("message") == "No Authorized"
+            ):
+                raise AuthError("No Authorized")
+            if isinstance(data, dict) and data.get("event") == event:
+                return data.get("data", {})
+            if msg.get("event") == event:
+                return msg.get("data", {})
+        raise RemoteError(f"no reply for {event}")
+
+    async def get_volume(self):
+        data = await self._emit("ed.volumeChanged")
+        return {
+            "volume": data.get("volume"),
+            "mute": bool(data.get("mute", False)),
+            "max": data.get("maxVolume"),
+        }
+
+    async def get_sources(self):
+        data = await self._emit("ed.sourcesChanged")
+        return data.get("sources", [])
+
+    async def launch_app(self, app_id):
+        await self._send(
+            {
+                "method": "ms.channel.emit",
+                "params": {
+                    "event": "ed.apps.launch",
+                    "to": "host",
+                    "data": {
+                        "action_type": "DEEP_LINK",
+                        "appId": app_id,
+                        "metaTag": "",
+                    },
+                },
+            }
+        )
+
+    async def set_source(self, source_id):
+        """Best-effort direct source switch (see README)."""
+        await self._send(
+            {
+                "method": "ms.channel.emit",
+                "params": {
+                    "event": "ed.setSource",
+                    "to": "host",
+                    "data": {"id": source_id},
+                },
+            }
+        )
+
+
+async def pair(host, name="LocalThings", port=8002):
+    """Pair by triggering the TV's allow popup and reading the granted token.
+
+    On QN90B firmware the TV shows an "Allow" popup (no PIN). After the user
+    allows it, the channel-connect event carries the auth token.
+    """
+    uri = f"wss://{host}:{port}{REMOTE_CHANNEL}?" + urllib.parse.urlencode(
+        {"name": _serialize_name(name)}
+    )
+    last_exc: Exception | None = None
+    # Retry the connection: the TV occasionally closes a fresh socket with a
+    # protocol error while its remote service is settling.
+    for _attempt in range(3):
+        try:
+            async with websockets.connect(uri, ssl=_ssl_context(), open_timeout=8) as ws:
+                # Up to ~2 minutes for the user to press Allow on the TV.
+                for _ in range(15):
+                    try:
+                        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=8))
+                    except TimeoutError:
+                        continue
+                    if msg.get("event") == "ms.channel.connect":
+                        token = (msg.get("data") or {}).get("token")
+                        if token:
+                            return token
+        except (ConnectionClosedError, OSError, TimeoutError) as exc:
+            last_exc = exc
+            await asyncio.sleep(1)
+    raise RemoteError(f"no token granted (was the popup allowed?): {last_exc}")
+
+
+async def is_on(host, token=None, port=8002):
+    """A TV only accepts the remote WebSocket while powered on.
+
+    Pass the auth token when available so the probe does not re-trigger the
+    TV's Allow popup.
+    """
+    try:
+        tv = SamsungRemote(host, token=token, port=port)
+        await tv.connect()
+        await tv.close()
+        return True
+    except Exception:
+        return False
+
+
+async def wake_on_lan(mac, host=None):
+    """Send a WOL magic packet for `mac` (00:11:22:33:44:55)."""
+    mac_bytes = bytes.fromhex(mac.replace(":", "").replace("-", ""))
+    if len(mac_bytes) != 6:
+        raise ValueError(f"bad MAC: {mac}")
+    packet = b"\xff" * 6 + mac_bytes * 16
+    loop = asyncio.get_running_loop()
+
+    def _send():
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            sock.sendto(packet, ("255.255.255.255", 9))
+            if host:
+                sock.sendto(packet, (host, 9))
+
+    await loop.run_in_executor(None, _send)

--- a/custom_components/samsung_tv_local/remote.py
+++ b/custom_components/samsung_tv_local/remote.py
@@ -1,0 +1,40 @@
+"""Remote entity: send arbitrary keys to the TV."""
+
+from __future__ import annotations
+
+from homeassistant.components.remote import RemoteEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, KEYS
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    hub = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([SamsungTvRemote(hub)])
+
+
+class SamsungTvRemote(RemoteEntity):
+    """Send any remote key (friendly name or raw KEY_* code)."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, hub) -> None:
+        self._hub = hub
+        self._attr_unique_id = f"{hub.mac}-remote"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, hub.mac)},
+            "name": hub.name,
+            "manufacturer": "Samsung",
+            "model": "QN90B",
+        }
+
+    async def async_send_command(self, command: list[str], **kwargs) -> None:
+        for cmd in command:
+            code = KEYS.get(cmd, cmd)
+            await self._hub.send_key(code)

--- a/custom_components/samsung_tv_local/translations/en.json
+++ b/custom_components/samsung_tv_local/translations/en.json
@@ -1,0 +1,31 @@
+{
+  "title": "Samsung TV Local (QN90B)",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Samsung TV (QN90B)",
+        "description": "Local WebSocket control (no SmartThings). Enter the TV's IP, its MAC address (for Wake-on-LAN), a name, and optionally an existing auth token. Leave the token empty to pair via the TV's on-screen Allow popup.",
+        "data": {
+          "host": "IP address",
+          "mac": "MAC address",
+          "name": "Name",
+          "token": "Auth token (optional)"
+        }
+      },
+      "pairing": {
+        "title": "Pairing",
+        "description": "Click Continue: the token is granted automatically (no PIN). If the TV has never authorized this client, an Allow popup may appear — press Allow if it does."
+      }
+    },
+    "error": {
+      "cannot_connect": "Could not reach the TV or no token was granted. Is it powered on?"
+    }
+  },
+  "entity": {
+    "button": {
+      "launch_app": {
+        "name": "Launch {app}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a small companion component, `samsung_tv_local`, to control Samsung
QN90B TVs entirely over the local network — no SmartThings, no cloud.

The QN90B doesn't speak the CoAP/DTLS protocol localthings uses for
appliances (no response on 3010/3011/5683/5684), so it talks the TV's own
remote WebSocket (wss://:8002) plus Wake-on-LAN instead.

It provides:
- media_player: power (WOL on, KEY_POWER off), volume/mute, source, app launch, media keys
- remote entity: any KEY_* command
- buttons: one-tap launch of Netflix/YouTube/Prime/Disney+/Spotify

Pairing is the TV's Allow popup (token granted automatically, no PIN); the
client name is Base64-encoded so the popup renders correctly, and the token
refreshes itself if the TV ever rejects it.

Tested live against two QN90B units (on/off, volume, mute, WOL wake-up).

It's a sibling component rather than a device type inside localthings, since
the transport is different — happy to reconsider the layout.