### PR TITLE
Bump smartthings-local to 0.1.11 and unbreak CI on HA 2026.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ FROM ghcr.io/home-assistant/home-assistant:stable
 # repeats the install attempt on every container recreate. Baking
 # smartthings-local into the image keeps the dev container usable
 # offline and avoids relying on that runtime install path.
-RUN pip3 install --no-cache-dir "smartthings-local>=0.1.8"
+RUN pip3 install --no-cache-dir "smartthings-local>=0.1.11"

--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -21,7 +21,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
@@ -65,6 +64,7 @@ from .const import (
     PROBE_PORT_RANGE,
     SERVICE_WRITE_RESOURCE,
 )
+from .devices import find_entry_device
 from .learned import persist as learned_persist
 from .learned import stored as learned_stored
 from .registry.capabilities.laundry import cycle_options, personal_course_labels
@@ -1545,8 +1545,8 @@ class LocalThingsOptionsFlow(config_entries.OptionsFlow):
             # panel's href dropdown already lists actual hrefs off
             # coord.last_resources, and MAIN.to_actual is identity, so
             # this preserves the panel's existing behavior byte for byte.
-            dev = dr.async_get(self.hass).async_get_device(
-                identifiers=coord.device_info["identifiers"]
+            dev = find_entry_device(
+                self.hass, self.config_entry.entry_id, coord.device_info["identifiers"]
             )
             if dev is None:
                 return self.async_abort(reason="not_loaded")

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -49,6 +49,7 @@ from .const import (
     DTLS_LOCAL_PORT_BASE,
     SUMMARY_INTERVAL_S,
 )
+from .devices import set_via_device
 from .learned import LEARNABLE, LearnedModes, persist
 from .observe import GRACE_PERIOD_S, MODE_OBSERVE, MODE_POLL, ObserveManager
 from .registry import CAPABILITIES
@@ -786,13 +787,7 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             model=model or None,
             serial_number=serial,
         )
-        # Set through a plain mapping because HA 2026.9 dropped `via_device`
-        # from the DeviceInfo TypedDict for `via_device_id` (still accepted
-        # until 2027.8), while cores back to this integration's 2025.1 floor
-        # take only `via_device`. The identifier is also the safer half: HA
-        # drops an entity whose `via_device_id` names no registered device,
-        # where an unresolved `via_device` just leaves the row unlinked.
-        cast("dict[str, Any]", info)["via_device"] = (DOMAIN, self.device_key)
+        set_via_device(self.hass, self._entry.entry_id, info, (DOMAIN, self.device_key))
         return info
 
     @property

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -779,14 +779,21 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if subdevice.kind == "indexed"
                 else "Secondary Subdevice"
             )
-        return DeviceInfo(
+        info = DeviceInfo(
             identifiers={(DOMAIN, f"{self.device_key}_{subdevice.key}")},
-            via_device=(DOMAIN, self.device_key),
             name=f"{base_name} {label}",
             manufacturer=self.device_info.get("manufacturer") or "Samsung",
             model=model or None,
             serial_number=serial,
         )
+        # Set through a plain mapping because HA 2026.9 dropped `via_device`
+        # from the DeviceInfo TypedDict for `via_device_id` (still accepted
+        # until 2027.8), while cores back to this integration's 2025.1 floor
+        # take only `via_device`. The identifier is also the safer half: HA
+        # drops an entity whose `via_device_id` names no registered device,
+        # where an unresolved `via_device` just leaves the row unlinked.
+        cast("dict[str, Any]", info)["via_device"] = (DOMAIN, self.device_key)
+        return info
 
     @property
     def observe_mode(self) -> str:

--- a/custom_components/localthings/devices.py
+++ b/custom_components/localthings/devices.py
@@ -1,0 +1,64 @@
+"""Device-registry lookups and parent links, across the HA releases this
+integration supports.
+
+HA 2026.9 deprecated `DeviceInfo`'s `via_device` for `via_device_id` and
+`device_registry.async_get_device` for `async_get_device_by_identifier`, both
+breaking in 2027.8; neither replacement exists on hacs.json's 2025.1 floor.
+The lookups here are written to need no replacement at all, and the one call
+that does feature-detects at runtime -- same pattern as `__init__.py`'s
+PARTICULATE_UNIT and `new_unit_class`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, cast
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo
+
+# Set through a plain mapping either way: whichever key this core wants, the
+# other one is absent from its DeviceInfo TypedDict, so a static assignment
+# could only ever type-check against one HA generation.
+_HAS_VIA_DEVICE_ID = "via_device_id" in DeviceInfo.__annotations__
+
+
+def find_entry_device(
+    hass: HomeAssistant, entry_id: str, identifiers: Iterable[tuple[str, str]]
+) -> dr.DeviceEntry | None:
+    """The `entry_id` device row carrying any of `identifiers`.
+
+    Scans the entry's own rows rather than calling `async_get_device`, which
+    searches every entry and is deprecated for exactly that reason -- an
+    identifier is only unique within one config entry. Every caller here means
+    its own entry's row, so this is both the compatible spelling and the
+    correct one; entries hold a handful of rows, so the scan is free.
+    """
+    wanted = set(identifiers)
+    return next(
+        (
+            row
+            for row in dr.async_entries_for_config_entry(dr.async_get(hass), entry_id)
+            if row.identifiers & wanted
+        ),
+        None,
+    )
+
+
+def set_via_device(
+    hass: HomeAssistant, entry_id: str, info: DeviceInfo, parent: tuple[str, str]
+) -> None:
+    """Link `info` under the `parent` identifier's device row, in place.
+
+    A core new enough to want `via_device_id` needs the parent's registry id,
+    and drops the entity outright if that id names no registered device -- so
+    an unregistered parent leaves the link unset here, exactly as an
+    unresolvable `via_device` does on an older core. Either way the next
+    entity added under this device picks the link up once the parent exists.
+    """
+    if not _HAS_VIA_DEVICE_ID:
+        cast("dict[str, Any]", info)["via_device"] = parent
+        return
+    if (device := find_entry_device(hass, entry_id, (parent,))) is not None:
+        cast("dict[str, Any]", info)["via_device_id"] = device.id

--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -11,7 +11,7 @@
   "requirements": [
     "cbor2>=5.4.6",
     "pyOpenSSL>=23.0",
-    "smartthings-local>=0.1.8"
+    "smartthings-local>=0.1.11"
   ],
   "version": "0.24.0"
 }

--- a/custom_components/localthings/observe.py
+++ b/custom_components/localthings/observe.py
@@ -240,10 +240,13 @@ class ObserveManager:
         Blocking — run in an executor.
 
         Split from the grace wait below (issue #294) so the coordinator can
-        hold its session lock for just these sends -- each is a fire-and-
-        forget UDP datagram (DtlsCoapSession.subscribe doesn't wait for the
-        device's ack), unlike the wait, which can block for the whole grace
-        period and must not hold a lock a command write is also waiting on.
+        hold its session lock for just these sends -- each is fire-and-forget
+        (DtlsCoapSession.subscribe doesn't wait for the device's ack), but
+        since smartthings-local 0.1.9 it goes through the session's rate
+        limiter, so the hold is now about one limiter interval per href
+        (~200ms at the 5 req/s default). Still bounded, unlike the wait,
+        which can block for the whole grace period and must not hold a lock
+        a command write is also waiting on.
         """
         with self._notify_cond:
             self._notified.clear()

--- a/custom_components/localthings/rekey.py
+++ b/custom_components/localthings/rekey.py
@@ -20,6 +20,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from .const import DOMAIN
+from .devices import find_entry_device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,7 +72,7 @@ def rekey_entry(hass: HomeAssistant, entry: ConfigEntry, old_key: str, new_key: 
         if not stale:
             continue
         fresh = {(DOMAIN, f"{new_key}{ident[1][len(old_key) :]}") for ident in stale}
-        existing = dev_reg.async_get_device(identifiers=fresh)
+        existing = find_entry_device(hass, entry.entry_id, fresh)
         if existing is not None and existing.id != device.id:
             # Removing a device takes its entities with it. Anything still
             # attached here was re-keyed rather than removed above -- the

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest-homeassistant-custom-component>=0.13.316
 
 # Integration runtime deps, needed to import the component under test
 # (also declared in custom_components/localthings/manifest.json).
-smartthings-local>=0.1.8
+smartthings-local>=0.1.11
 cbor2>=5.4.6
 pyOpenSSL>=23.0
 cryptography>=41.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -38,6 +39,25 @@ def _load_device_full(name: str):
     resources = _resources_from_dump(data)
     seeds = {**data.get("seeds", {}), **data.get("probes", {})}
     return resources, data.get("oic_res", []), seeds
+
+
+def linked_parent(hass, info) -> tuple[str, str] | None:
+    """The identifier of the device `info` links under, or None if unlinked.
+
+    device_info_for names the parent by identifier or by registry id
+    depending on the core (see custom_components/localthings/devices.py);
+    reading it back through the registry keeps a test asserting the link
+    itself rather than which spelling the installed HA wanted.
+    """
+    from homeassistant.helpers import device_registry as dr
+
+    raw = cast("dict[str, Any]", info)
+    if (parent := raw.get("via_device")) is not None:
+        return parent
+    if (device_id := raw.get("via_device_id")) is None:
+        return None
+    row = dr.async_get(hass).async_get(device_id)
+    return next(iter(row.identifiers)) if row is not None else None
 
 
 class FakeCoapSession:

--- a/tests/localthings/conftest.py
+++ b/tests/localthings/conftest.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+from inspect import signature
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import cbor2
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.localthings.const import (
@@ -120,6 +123,33 @@ LEGACY_ENTRY_DATA = {
     CONF_LEAF_CERT_PEM: MOCK_LEAF_CERT_PEM,
     CONF_LEAF_KEY_PEM: MOCK_LEAF_KEY_PEM,
 }
+
+
+def entry_has_identifier(
+    hass: HomeAssistant, entry: MockConfigEntry, identifier: tuple[str, str]
+) -> bool:
+    """True if any device row belonging to `entry` carries `identifier`.
+
+    Not `dev_reg.async_get_device`, which HA 2026.9 deprecates (removed in
+    2027.8) because identifiers are no longer unique across config entries --
+    and one entry's own rows are what these assertions mean anyway.
+    """
+    return any(
+        identifier in row.identifiers
+        for row in dr.async_entries_for_config_entry(dr.async_get(hass), entry.entry_id)
+    )
+
+
+def link_to_parent(parent: dr.DeviceEntry) -> dict[str, Any]:
+    """`async_get_or_create` kwargs linking a new row under `parent`.
+
+    HA 2026.9 replaced `via_device` (an identifier) with `via_device_id` (a
+    device id) and errors on the old one; cores back to this integration's
+    2025.1 floor accept only `via_device`. Both store the same link.
+    """
+    if "via_device_id" in signature(dr.DeviceRegistry.async_get_or_create).parameters:
+        return {"via_device_id": parent.id}
+    return {"via_device": next(iter(parent.identifiers))}
 
 
 def _load_fridge_resources() -> dict:

--- a/tests/localthings/test_identity_migration.py
+++ b/tests/localthings/test_identity_migration.py
@@ -31,7 +31,13 @@ from custom_components.localthings.const import (
 )
 from custom_components.localthings.registry.identity import DeviceIdentity
 
-from .conftest import LEGACY_ENTRY_DATA, MOCK_HOST, MOCK_SERIAL
+from .conftest import (
+    LEGACY_ENTRY_DATA,
+    MOCK_HOST,
+    MOCK_SERIAL,
+    entry_has_identifier,
+    link_to_parent,
+)
 
 _COORD = "custom_components.localthings.coordinator.LocalThingsCoordinator"
 
@@ -187,7 +193,7 @@ async def test_v3_entry_moves_onto_the_device_uuid_keeping_its_entity_ids(
     assert kept.entity_id == "sensor.kitchen_purifier_connection"
     assert kept.unique_id == f"{DOMAIN}_{UUID_A}_connection_mode"
     # Nothing left behind on the old key.
-    assert dr.async_get(hass).async_get_device(identifiers={(DOMAIN, MOCK_SERIAL)}) is None
+    assert not entry_has_identifier(hass, entry, (DOMAIN, MOCK_SERIAL))
 
 
 async def test_the_oldest_install_walks_all_the_way_from_v1(
@@ -338,7 +344,7 @@ async def test_a_composite_appliance_keeps_its_subdevice_links(
     sub = dev_reg.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, f"{MOCK_SERIAL}_subdevice_1")},
-        via_device=(DOMAIN, MOCK_SERIAL),
+        **link_to_parent(master),
     )
     assert sub.via_device_id == master.id
 
@@ -348,7 +354,9 @@ async def test_a_composite_appliance_keeps_its_subdevice_links(
 
     assert _device_identifiers(hass, master.id) == {(DOMAIN, UUID_A)}
     rekeyed_sub = dev_reg.async_get(sub.id)
-    assert rekeyed_sub is not None
+    # isinstance, not `is not None`: HA 2026.9's async_get can also return a
+    # ChildDeviceEntry, which carries no via_device_id.
+    assert isinstance(rekeyed_sub, dr.DeviceEntry)
     assert rekeyed_sub.identifiers == {(DOMAIN, f"{UUID_A}_subdevice_1")}
     # Still the same parent row, so the device tree the user sees is intact.
     assert rekeyed_sub.via_device_id == master.id

--- a/tests/localthings/test_migration.py
+++ b/tests/localthings/test_migration.py
@@ -18,7 +18,13 @@ from custom_components.localthings.const import (
     DOMAIN,
 )
 
-from .conftest import LEGACY_ENTRY_DATA, MOCK_HOST, MOCK_PORT, MOCK_SERIAL
+from .conftest import (
+    LEGACY_ENTRY_DATA,
+    MOCK_HOST,
+    MOCK_PORT,
+    MOCK_SERIAL,
+    entry_has_identifier,
+)
 
 
 def _legacy_entry(hass: HomeAssistant, unique_id: str) -> MockConfigEntry:
@@ -187,7 +193,7 @@ async def test_migration_rekeys_an_ip_keyed_device_and_entity(
     assert rekeyed is not None
     assert rekeyed.unique_id == f"{DOMAIN}_{MOCK_SERIAL}_connection_mode"
     # And nothing is left keyed on the IP.
-    assert dev_reg.async_get_device(identifiers={(DOMAIN, MOCK_HOST)}) is None
+    assert not entry_has_identifier(hass, entry, (DOMAIN, MOCK_HOST))
 
 
 async def test_migration_removes_an_orphan_that_is_already_duplicated(

--- a/tests/test_subdevice_discovery.py
+++ b/tests/test_subdevice_discovery.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from smartthings_local.protocol.dtls_session import DtlsCoapSession
 
@@ -24,7 +25,7 @@ from custom_components.localthings.const import (
 from custom_components.localthings.coordinator import LocalThingsCoordinator
 from custom_components.localthings.registry.entities import ClimateDesc
 from custom_components.localthings.registry.identity import DeviceIdentity
-from tests.conftest import FakeCoapSession, _load_device_full
+from tests.conftest import FakeCoapSession, _load_device_full, linked_parent
 
 ENTRY_DATA = {
     CONF_HOST: "10.0.0.177",
@@ -42,6 +43,17 @@ def _coordinator(hass: HomeAssistant) -> LocalThingsCoordinator:
     )
     entry.add_to_hass(hass)
     return LocalThingsCoordinator(hass, entry)
+
+
+def _register_master(hass: HomeAssistant, coordinator: LocalThingsCoordinator) -> None:
+    """The master's own device row, which a running install always has by the
+    time a subdevice entity is added -- its own entities create it. Needed
+    explicitly here because these tests drive the coordinator directly,
+    without the entity platform that would otherwise register it."""
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=coordinator._entry.entry_id,
+        identifiers={(DOMAIN, coordinator.device_key)},
+    )
 
 
 async def _discover_with(
@@ -145,11 +157,12 @@ async def test_pattern_a_sub1_device_info_links_via_device_to_master(hass: HomeA
     await _discover(coordinator, "airconditioner_artik051_dongle_fac_18k")
 
     sub1 = next(su for su in coordinator.subdevices if su.key == "1")
+    master_serial = coordinator.device_key
+    _register_master(hass, coordinator)
     info = coordinator.device_info_for(sub1)
 
-    master_serial = coordinator.device_key
     assert info["identifiers"] == {(DOMAIN, f"{master_serial}_1")}
-    assert cast("dict[str, Any]", info)["via_device"] == (DOMAIN, master_serial)
+    assert linked_parent(hass, info) == (DOMAIN, master_serial)
     # The subdevice's own /information/vs/1 (real, ARTIK051_DONGLE_FAC_RAC_18K)
     # is what names/models this device, not the master's.
     assert info["model"] == "ARTIK051_DONGLE_FAC_RAC_18K"
@@ -243,11 +256,12 @@ async def test_fac_bora_2in1_subdevice_device_info(hass: HomeAssistant):
     await _discover(coordinator, "airconditioner_fac_bora_2in1")
 
     subdevice = coordinator.subdevices[0]
+    master_serial = coordinator.device_key
+    _register_master(hass, coordinator)
     info = coordinator.device_info_for(subdevice)
 
-    master_serial = coordinator.device_key
     assert info["identifiers"] == {(DOMAIN, f"{master_serial}_{_SUB_UUID}")}
-    assert cast("dict[str, Any]", info)["via_device"] == (DOMAIN, master_serial)
+    assert linked_parent(hass, info) == (DOMAIN, master_serial)
     # Confirmed live by the reporter (DESIGN-177.md section 1): the wall
     # subdevice's own identity, distinct from the master's TP2X_FAC_BORA_21K.
     assert info["model"] == "TP2X_FAC_BORA_RAC_21K"

--- a/tests/test_subdevice_discovery.py
+++ b/tests/test_subdevice_discovery.py
@@ -149,7 +149,7 @@ async def test_pattern_a_sub1_device_info_links_via_device_to_master(hass: HomeA
 
     master_serial = coordinator.device_key
     assert info["identifiers"] == {(DOMAIN, f"{master_serial}_1")}
-    assert info["via_device"] == (DOMAIN, master_serial)
+    assert cast("dict[str, Any]", info)["via_device"] == (DOMAIN, master_serial)
     # The subdevice's own /information/vs/1 (real, ARTIK051_DONGLE_FAC_RAC_18K)
     # is what names/models this device, not the master's.
     assert info["model"] == "ARTIK051_DONGLE_FAC_RAC_18K"
@@ -247,7 +247,7 @@ async def test_fac_bora_2in1_subdevice_device_info(hass: HomeAssistant):
 
     master_serial = coordinator.device_key
     assert info["identifiers"] == {(DOMAIN, f"{master_serial}_{_SUB_UUID}")}
-    assert info["via_device"] == (DOMAIN, master_serial)
+    assert cast("dict[str, Any]", info)["via_device"] == (DOMAIN, master_serial)
     # Confirmed live by the reporter (DESIGN-177.md section 1): the wall
     # subdevice's own identity, distinct from the master's TP2X_FAC_BORA_21K.
     assert info["model"] == "TP2X_FAC_BORA_RAC_21K"


### PR DESCRIPTION
Three commits: the `smartthings-local` floor moves `0.1.8 → 0.1.11`, the suite stops failing on Home Assistant 2026.9's device-registry deprecations, and the integration stops making the deprecated calls at all. The second and third are not caused by the first — `main` went red on its own overnight — but they have to land for this branch to be green, so they ride along here.

## 1. smartthings-local 0.1.11

Raises the floor in `manifest.json`, `requirements-dev.txt` and the `Dockerfile`, picking up 0.1.9, 0.1.10 and 0.1.11.

- **0.1.9** — CoAP request sends now go through the session rate limiter. `subscribe()` previously bypassed it entirely, so an eleven-href OBSERVE registration burst went out as fast as the loop ran and could wedge an appliance until a watchdog forced a new session (upstream #53, and #396 here). `post()` and the first block of a blockwise GET are paced now too.
- **0.1.10** — a MID-indexed exchange registry so token-less control messages (empty ACK, bare RST) correlate, and retransmissions reuse one Message ID per RFC 7252 §4.2. Adds `SessionResetError` and `SessionIdentifierError`. Also adds `discover_ocf_responder_ports()`, which we do not call.
- **0.1.11** — DELETE, Block1 POST uploads, request-option validation, `discover_ocf_secure_ports()` and `read_plaintext_ocf_resource()`. `post()` gained opt-in write retransmission.

**Why no integration changes.** I diffed the 0.1.8 wheel against the 0.1.11 sdist rather than reading the release notes: only `errors.py`, `coap.py`, `dtls_handshake.py` and `dtls_session.py` changed, and the three new modules are unused here. Every call site keeps its signature — `connect`/`get`/`post`/`subscribe`/`ping`/`refresh_observes`, plus `dtls_probe.probe` and `diagnose_dtls_handshake`; the additions are keyword-only with defaults. `write_max_attempts` defaults to `1`, so write retransmission stays off and `_connect_session` passes no override. `SessionResetError` and `SessionIdentifierError` both subclass `SessionError` → `ConnectionError`, so existing handling covers them.

**Two behaviors worth a reviewer's attention.** Paced OBSERVE registration runs under the coordinator's session lock — the hold issue #294 deliberately kept short — so that hold is now about one limiter interval per href (~2.2s for eleven at 5 req/s) rather than eleven back-to-back datagrams, and a command write can queue behind a resubscribe burst for a couple of seconds. Still bounded, still far shorter than the grace wait it was split from, so the design is unchanged and the cost is recorded in the `subscribe_hrefs` docstring, whose old claim ("each is a fire-and-forget UDP datagram") understated it. Expect connect-to-seeded to take a couple of seconds longer per device; upstream considers that the fix. Separately, option validation now raises `ValueError`/`TypeError` on an empty path segment instead of sending a zero-length Uri-Path — `_href_to_path_segs` filters those, and the two poll loops that don't already sit inside a per-href `except Exception`.

## 2. Home Assistant 2026.9 device-registry deprecations

The nightly `Validate` run on `main` went red on 2026-08-28 with no commit behind it ([run 33156264353](https://github.com/mbillow/localthings/actions/runs/33156264353), same head as this branch's base). `pytest-homeassistant-custom-component>=0.13.316` is a floor, so CI on Python 3.14 resolved 0.13.359 / `homeassistant 2026.9.0b1`, which deprecates `DeviceInfo`'s `via_device` (for `via_device_id`) and `device_registry.async_get_device` (for `async_get_device_by_identifier`), both breaking in 2027.8.

**The three CI failures were all in test code.** `report_usage` only errors when it cannot find an integration frame — exactly a test calling the registry directly; the integration's own calls are attributed to it and merely log. Fixed version-neutrally, since the two interpreters resolve different cores:

- Two assertions used `async_get_device(identifiers=...)` to say nothing is left keyed on an old identifier. They now scan the entry's own rows via `async_entries_for_config_entry`.
- One fixture linked a subdevice row with `via_device=`; it goes through a `link_to_parent` helper that passes whichever kwarg `async_get_or_create` accepts.
- One assertion narrows `async_get`'s result past 2026.9's new `ChildDeviceEntry`.

## 3. Dropping the deprecated calls (runtime feature detection)

That left the integration still calling both deprecated APIs — harmless (a WARNING naming 2027.8) but noisy: a user with a composite appliance would see one report per platform on every setup, and anyone re-keying would see another. A new `devices.py` removes them without touching `hacs.json`'s 2025.1 floor, following the same feature-detection pattern as `__init__.py`'s `UnitOfDensity` and `new_unit_class`:

- **`find_entry_device` needs no detection.** `async_get_device` searched every config entry — which is precisely why identifiers stopped being unique across them and why it is deprecated. Both callers (the re-key collision check, and the debug-write panel finding its own device) mean their own entry's row, so scanning `async_entries_for_config_entry` is both the compatible spelling and the more correct one. It also closes a real edge in `rekey_entry`, which could previously match another entry's device and move this entry's entities onto it before deleting the row they came from.
- **`set_via_device` does detect**, because there is no common spelling: a core with `via_device_id` in `DeviceInfo` needs the master's registry id, an older one takes only the identifier. Where the id is wanted but the master row does not exist yet, the link is left unset rather than guessed — HA *drops* an entity whose `via_device_id` names no registered device, while an unresolvable `via_device` on an older core silently leaves the row unlinked, so this matches the old behavior in the one case the two can differ, and the next entity added under that device picks the link up.

## Testing

Both interpreters resolve different cores, so everything was run twice.

| | full suite | ruff format | ruff lint | ty |
|---|---|---|---|---|
| Python 3.14.7, homeassistant 2026.9.0b1 (what CI runs) | 1730 passed | pass | pass | pass |
| Python 3.13, homeassistant 2026.2.3 | 1730 passed | pass | pass | pass |

Beyond the suite, I drove a composite appliance through a full config-entry setup on both cores and read the device rows and log records back. On each, the subdevice row comes out linked to the master (`via_device_id` set), with **0 deprecation reports and 0 errors**; the re-key path reports nothing on either. That probe is how the "all three failures were test-only" claim above was established too — before this change it printed four `via_device` reports attributed to our own `async_add_entities` frames, and no errors.

## Follow-ups, deliberately not here

- Whether to pin `pytest-homeassistant-custom-component` rather than floor it. Pinning would have kept `main` green through this, at the cost of not hearing about core deprecations until someone bumps it — worth a decision either way, but not one this PR should make quietly.
- `discover_ocf_secure_ports()` / `discover_ocf_responder_ports()` for the config flow's port probing, and `write_max_attempts`, which needs per-device numbers to justify enabling.