### PR TITLE
Centralize certificate-authenticated DTLS session construction

### DIFF
--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.selector import (
 )
 
 from . import cloudcourse
+from . import session as session_factory
 from .const import (
     CLIENTHELLO_PROBE_RETRIES,
     CLIENTHELLO_PROBE_TIMEOUT_S,
@@ -742,13 +743,16 @@ def _diagnose_failures(
 
 def _handshake_and_read(host: str, scan: _PortScan, cert_pem: str, key_pem: str) -> dict:
     """Handshake each candidate in turn, returning the first device that answers."""
-    from smartthings_local.protocol.dtls_session import DtlsCoapSession
-
     failures: list[tuple[int, Exception]] = []
     for port in scan.candidates:
         sess = None
         try:
-            sess = DtlsCoapSession(host, port, cert_pem=cert_pem, key_pem=key_pem)
+            sess = session_factory.create_certificate_session(
+                host,
+                port,
+                certificate_pem=cert_pem,
+                private_key_pem=key_pem,
+            )
             sess.connect()
             sess.start_reader()
             return _read_device(sess, host, port)

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -25,6 +25,7 @@ from smartthings_local.ocf.state_cache import StateCache
 from smartthings_local.protocol.dtls_session import DtlsCoapSession
 
 from . import cloudcourse
+from . import session as session_factory
 from .cloudcourse import CloudCourses
 from .cloudcourse import persist as cloud_persist
 from .const import (
@@ -800,11 +801,11 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         cert_pem = self._entry.data[CONF_LEAF_CERT_PEM]
         key_pem = self._entry.data[CONF_LEAF_KEY_PEM]
 
-        sess = DtlsCoapSession(
+        sess = session_factory.create_certificate_session(
             host,
             port,
-            cert_pem=cert_pem,
-            key_pem=key_pem,
+            certificate_pem=cert_pem,
+            private_key_pem=key_pem,
             on_notification=self._observe.on_notification,
             local_port=_local_source_port(host),
         )

--- a/custom_components/localthings/session.py
+++ b/custom_components/localthings/session.py
@@ -1,0 +1,55 @@
+"""Authentication providers and DTLS session construction."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from smartthings_local.protocol import auth as protocol_auth
+from smartthings_local.protocol import dtls_session
+
+NotificationCallback = Callable[[str, bytes], None]
+
+
+def create_certificate_auth(
+    certificate_pem: str,
+    private_key_pem: str,
+) -> protocol_auth.CertificateAuth:
+    """Create the existing in-memory certificate authentication provider."""
+    return protocol_auth.CertificateAuth.from_memory(certificate_pem, private_key_pem)
+
+
+def create_dtls_session(
+    host: str,
+    port: int,
+    *,
+    auth: protocol_auth.AuthenticationProvider,
+    on_notification: NotificationCallback | None = None,
+    local_port: int | None = None,
+) -> dtls_session.DtlsCoapSession:
+    """Construct a DTLS session without starting network I/O."""
+    return dtls_session.DtlsCoapSession(
+        host,
+        port,
+        auth=auth,
+        on_notification=on_notification,
+        local_port=local_port,
+    )
+
+
+def create_certificate_session(
+    host: str,
+    port: int,
+    *,
+    certificate_pem: str,
+    private_key_pem: str,
+    on_notification: NotificationCallback | None = None,
+    local_port: int | None = None,
+) -> dtls_session.DtlsCoapSession:
+    """Construct a session with the existing certificate authentication."""
+    return create_dtls_session(
+        host,
+        port,
+        auth=create_certificate_auth(certificate_pem, private_key_pem),
+        on_notification=on_notification,
+        local_port=local_port,
+    )

--- a/tests/localthings/test_config_flow.py
+++ b/tests/localthings/test_config_flow.py
@@ -233,6 +233,17 @@ WASHER_DEVICE0 = [
 ]
 
 
+class FakeCertificateAuth:
+    """Synthetic provider that keeps only the credential label tests need."""
+
+    def __init__(self, certificate_pem: str, private_key_pem: str) -> None:
+        self.certificate_pem = certificate_pem
+        self.private_key_pem = private_key_pem
+
+    def configure_context(self, _context) -> None:
+        """Satisfy the authentication-provider protocol."""
+
+
 class FakeSession:
     """Stand-in for DtlsCoapSession that answers /device/0 for any path.
 
@@ -242,6 +253,7 @@ class FakeSession:
     """
 
     instances: ClassVar[list[FakeSession]] = []
+    probe_instances: ClassVar[list[FakeSession]] = []
     reject_certs: ClassVar[set[str]] = set()
     # smartthings-local >= 0.1.3 ("redacted typed failures") no longer puts
     # the alert in connect()'s exception text -- set True to model that, so
@@ -249,8 +261,10 @@ class FakeSession:
     # instead of the legacy _alert_name text-parsing path.
     redact_rejection: ClassVar[bool] = False
 
-    def __init__(self, host, port, cert_pem=None, key_pem=None, **kwargs):
-        self.host, self.port, self.cert_pem = host, port, cert_pem
+    def __init__(self, host, port, cert_pem=None, key_pem=None, auth=None, **kwargs):
+        self.host, self.port = host, port
+        self.auth = auth
+        self.cert_pem = auth.certificate_pem if auth is not None else cert_pem
         FakeSession.instances.append(self)
 
     def connect(self):
@@ -275,12 +289,40 @@ class FakeSession:
         pass
 
 
+class FakeSessionFactory:
+    """Build config-flow sessions with inspectable synthetic providers."""
+
+    @staticmethod
+    def create_certificate_session(
+        host,
+        port,
+        *,
+        certificate_pem,
+        private_key_pem,
+        **kwargs,
+    ) -> FakeSession:
+        session = FakeSession(
+            host,
+            port,
+            auth=FakeCertificateAuth(certificate_pem, private_key_pem),
+            **kwargs,
+        )
+        FakeSession.probe_instances.append(session)
+        return session
+
+
+def _probe_sessions() -> list[FakeSession]:
+    """Sessions opened by the config flow, excluding the loaded coordinator."""
+    return list(FakeSession.probe_instances)
+
+
 @pytest.fixture
 def fake_dtls(monkeypatch):
     """Wire the probe path up to FakeSession with no real network anywhere."""
     from custom_components.localthings import config_flow
 
     FakeSession.instances = []
+    FakeSession.probe_instances = []
     FakeSession.reject_certs = set()
     FakeSession.redact_rejection = False
     monkeypatch.setattr(config_flow, "_fetch_samsung_uuid", lambda: "test-uuid")
@@ -293,6 +335,7 @@ def fake_dtls(monkeypatch):
         "smartthings_local.protocol.dtls_session.DtlsCoapSession",
         FakeSession,
     )
+    monkeypatch.setattr(config_flow, "session_factory", FakeSessionFactory())
     return FakeSession
 
 
@@ -349,7 +392,7 @@ async def test_clienthello_probe_picks_the_confirmed_port(
     # The whole range is probed (cheaply, in parallel) but only the confirmed
     # port is handed a handshake.
     assert set(probed) == set(config_flow.PROBE_PORT_RANGE)
-    assert [s.port for s in FakeSession.instances] == [49153]
+    assert [session.port for session in _probe_sessions()] == [49153]
 
 
 async def test_probe_uses_discovered_low_port(hass: HomeAssistant, monkeypatch, fake_dtls) -> None:
@@ -470,7 +513,7 @@ async def test_second_device_reuses_the_existing_leaf(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_LEAF_CERT_PEM] == MOCK_LEAF_CERT_PEM
-    assert FakeSession.instances[0].cert_pem == MOCK_LEAF_CERT_PEM
+    assert _probe_sessions()[0].cert_pem == MOCK_LEAF_CERT_PEM
 
 
 async def test_rejected_reused_leaf_is_reminted(
@@ -492,7 +535,10 @@ async def test_rejected_reused_leaf_is_reminted(
     assert result["type"] == FlowResultType.CREATE_ENTRY
     # Freshly minted, and it's the fresh one that got stored.
     assert result["data"][CONF_LEAF_CERT_PEM] == "FULLCHAIN"
-    assert [s.cert_pem for s in FakeSession.instances] == [MOCK_LEAF_CERT_PEM, "FULLCHAIN"]
+    assert [session.cert_pem for session in _probe_sessions()] == [
+        MOCK_LEAF_CERT_PEM,
+        "FULLCHAIN",
+    ]
 
 
 async def test_rejected_reused_leaf_is_reminted_against_a_redacted_library(
@@ -529,11 +575,14 @@ async def test_rejected_reused_leaf_is_reminted_against_a_redacted_library(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_LEAF_CERT_PEM] == "FULLCHAIN"
-    assert [s.cert_pem for s in FakeSession.instances] == [MOCK_LEAF_CERT_PEM, "FULLCHAIN"]
+    assert [session.cert_pem for session in _probe_sessions()] == [
+        MOCK_LEAF_CERT_PEM,
+        "FULLCHAIN",
+    ]
     assert diagnosed == [49154]
 
 
-def test_diagnostic_handshake_runs_once_not_once_per_failing_port(monkeypatch) -> None:
+def test_diagnostic_handshake_runs_once_not_once_per_failing_port(monkeypatch, fake_dtls) -> None:
     """_diagnostic_alert commits association state on the device (see its
     own docstring) -- running it once per failing candidate instead of once
     overall would both add latency (each is its own bounded handshake) and
@@ -543,10 +592,8 @@ def test_diagnostic_handshake_runs_once_not_once_per_failing_port(monkeypatch) -
     port, not three times against every candidate in scan order."""
     from custom_components.localthings import config_flow
 
-    FakeSession.instances = []
     FakeSession.reject_certs = {MOCK_LEAF_CERT_PEM}
     FakeSession.redact_rejection = True
-    monkeypatch.setattr("smartthings_local.protocol.dtls_session.DtlsCoapSession", FakeSession)
 
     diagnosed: list[int] = []
 
@@ -597,7 +644,7 @@ async def test_unconfirmed_port_failure_is_not_reminted(
     errors = result["errors"]
     assert errors is not None
     assert errors["base"] == "no_dtls_server"
-    assert len(FakeSession.instances) == 1
+    assert len(_probe_sessions()) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/localthings/test_coordinator.py
+++ b/tests/localthings/test_coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import time
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import cbor2
 import pytest
@@ -20,6 +20,9 @@ from smartthings_local.errors import SessionClosedError, SessionError, SessionTi
 from custom_components.localthings.const import (
     CONF_BYPASS_REMOTE_CONTROL,
     CONF_HOST,
+    CONF_LEAF_CERT_PEM,
+    CONF_LEAF_KEY_PEM,
+    CONF_PORT,
     DOMAIN,
     DTLS_LOCAL_PORT_BASE,
     SUMMARY_INTERVAL_S,
@@ -1898,6 +1901,65 @@ def test_local_source_port_non_ipv4_falls_back_to_hash() -> None:
     port = _local_source_port("some-hostname")
     assert port == _local_source_port("some-hostname")
     assert DTLS_LOCAL_PORT_BASE <= port <= DTLS_LOCAL_PORT_BASE + 0xFF
+
+
+def test_connect_session_preserves_the_certificate_session_contract(
+    hass: HomeAssistant,
+    mock_entry,
+) -> None:
+    """The coordinator owns lifecycle I/O after the factory constructs a session."""
+    coordinator = LocalThingsCoordinator(hass, mock_entry)
+    session = MagicMock()
+    identity = MagicMock()
+
+    with (
+        patch(
+            "custom_components.localthings.coordinator.session_factory.create_certificate_session",
+            return_value=session,
+        ) as session_factory,
+        patch(
+            "custom_components.localthings.coordinator.read_identity",
+            return_value=identity,
+        ) as read_identity,
+    ):
+        coordinator._connect_session()
+
+    session_factory.assert_called_once_with(
+        mock_entry.data[CONF_HOST],
+        mock_entry.data[CONF_PORT],
+        certificate_pem=mock_entry.data[CONF_LEAF_CERT_PEM],
+        private_key_pem=mock_entry.data[CONF_LEAF_KEY_PEM],
+        on_notification=coordinator._observe.on_notification,
+        local_port=_local_source_port(mock_entry.data[CONF_HOST]),
+    )
+    assert session.method_calls[:2] == [call.connect(), call.start_reader()]
+    read_identity.assert_called_once_with(session, None)
+    assert coordinator._session is session
+    assert coordinator._identity is identity
+
+
+def test_connect_session_does_not_publish_an_unstarted_session(
+    hass: HomeAssistant,
+    mock_entry,
+) -> None:
+    """A failed connect remains invisible to poll and command paths."""
+    coordinator = LocalThingsCoordinator(hass, mock_entry)
+    session = MagicMock()
+    session.start_reader.side_effect = RuntimeError("reader failed")
+
+    with (
+        patch(
+            "custom_components.localthings.coordinator.session_factory.create_certificate_session",
+            return_value=session,
+        ),
+        patch("custom_components.localthings.coordinator.read_identity") as read_identity,
+        pytest.raises(RuntimeError, match="reader failed"),
+    ):
+        coordinator._connect_session()
+
+    assert session.method_calls[:2] == [call.connect(), call.start_reader()]
+    read_identity.assert_not_called()
+    assert coordinator._session is None
 
 
 # ----------------------------------------------------------------------

--- a/tests/localthings/test_session.py
+++ b/tests/localthings/test_session.py
@@ -1,0 +1,110 @@
+"""Tests for DTLS authentication and session construction."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from smartthings_local.protocol import auth as protocol_auth
+from smartthings_local.protocol import dtls_session
+
+from custom_components.localthings import session as session_factory
+
+
+def test_create_certificate_auth_uses_in_memory_credentials() -> None:
+    """Stored certificate entries stay on the existing in-memory provider."""
+    auth = MagicMock(spec=protocol_auth.CertificateAuth)
+
+    with patch.object(
+        protocol_auth.CertificateAuth,
+        "from_memory",
+        return_value=auth,
+    ) as from_memory:
+        result = session_factory.create_certificate_auth("CERTIFICATE", "PRIVATE KEY")
+
+    assert result is auth
+    from_memory.assert_called_once_with("CERTIFICATE", "PRIVATE KEY")
+
+
+def test_create_dtls_session_passes_only_the_explicit_auth_provider() -> None:
+    """The session factory must not mix auth with legacy certificate arguments."""
+    auth = MagicMock(spec=protocol_auth.AuthenticationProvider)
+    callback = MagicMock()
+    session = MagicMock(spec=dtls_session.DtlsCoapSession)
+
+    with patch.object(
+        dtls_session,
+        "DtlsCoapSession",
+        return_value=session,
+    ) as session_class:
+        result = session_factory.create_dtls_session(
+            "192.0.2.10",
+            49154,
+            auth=auth,
+            on_notification=callback,
+            local_port=49742,
+        )
+
+    assert result is session
+    session_class.assert_called_once_with(
+        "192.0.2.10",
+        49154,
+        auth=auth,
+        on_notification=callback,
+        local_port=49742,
+    )
+    assert "cert_pem" not in session_class.call_args.kwargs
+    assert "key_pem" not in session_class.call_args.kwargs
+
+
+def test_create_certificate_session_composes_the_two_factories() -> None:
+    """Certificate callers use the shared session path without lifecycle I/O."""
+    auth = MagicMock(spec=protocol_auth.AuthenticationProvider)
+    callback = MagicMock()
+    session = MagicMock(spec=dtls_session.DtlsCoapSession)
+
+    with (
+        patch.object(
+            session_factory,
+            "create_certificate_auth",
+            return_value=auth,
+        ) as auth_factory,
+        patch.object(
+            session_factory,
+            "create_dtls_session",
+            return_value=session,
+        ) as session_builder,
+    ):
+        result = session_factory.create_certificate_session(
+            "192.0.2.10",
+            49154,
+            certificate_pem="CERTIFICATE",
+            private_key_pem="PRIVATE KEY",
+            on_notification=callback,
+            local_port=49742,
+        )
+
+    assert result is session
+    auth_factory.assert_called_once_with("CERTIFICATE", "PRIVATE KEY")
+    session_builder.assert_called_once_with(
+        "192.0.2.10",
+        49154,
+        auth=auth,
+        on_notification=callback,
+        local_port=49742,
+    )
+    session.connect.assert_not_called()
+    session.start_reader.assert_not_called()
+
+
+def test_real_certificate_provider_is_session_compatible_and_redacted() -> None:
+    """The published provider API accepts the existing in-memory credential shape."""
+    session = session_factory.create_certificate_session(
+        "192.0.2.10",
+        49154,
+        certificate_pem="SYNTHETIC CERTIFICATE",
+        private_key_pem="SYNTHETIC PRIVATE KEY",
+    )
+
+    assert isinstance(session.auth, protocol_auth.CertificateAuth)
+    assert repr(session.auth) == "CertificateAuth()"
+    assert "SYNTHETIC" not in repr(session.auth)


### PR DESCRIPTION
## Summary

- add a shared factory around `CertificateAuth.from_memory(...)` and `DtlsCoapSession(auth=...)`
- route setup handshakes and coordinator reconnects through that factory
- keep connection, reader startup, and session lifecycle ownership at the existing call sites

## Relationship to #405

This PR replaces the exploratory draft in #405 with a smaller, reviewable first step based on the discussion there and in #388.

Thank you to everyone who provided feedback, and especially to @vmonkey for helping me complete authenticated, read-only local communication with my WD86.

That result showed that the next useful upstream step is to separate LocalThings session construction first.

## Why this comes first

The immediate follow-up PR will add an explicit authentication and credential model, construct PSK sessions with `PskAuth`, and cover config-entry migration, reauthentication, and credential redaction while preserving existing certificate entries.

Today the setup flow and coordinator each construct certificate-specific sessions independently. Adding PSK selection directly at both call sites would duplicate the authentication branching and mix a compatibility refactor with credential-storage and migration behavior. This PR creates one provider-based session-construction seam first, so the follow-up can select `CertificateAuth` or `PskAuth` without changing session lifecycle ownership in two places.

After that generic PSK path is reviewed, a separate device-support PR can add sanitized WD86 resource coverage, capabilities, entities, translations, and real Home Assistant setup/reconnect/status/control validation.

## Scope

Existing certificate-backed config entries, stored field names, setup behavior, reconnect behavior, and user-visible configuration remain unchanged. This PR adds no config-entry migration, reauthentication flow, PSK credentials, discovery changes, endpoint rediscovery, or device capabilities.

## Validation

- 142 focused session/config-flow/coordinator tests passed
- 1,736 full tests passed with `smartthings-local` 0.1.11
- 1,736 full tests passed with `smartthings-local` 0.1.12
- Ruff format and lint passed
- `ty check` and `git diff --check` passed

Relates to #388. This PR does not close it.
