### PR TITLE
docs: design notes for reading the /file/transfer usage history

### DIFF
--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -63,6 +63,7 @@ from .registry.capabilities.common import (
 )
 from .registry.capabilities.laundry import cycle_options
 from .registry.discovery import BoundEntity
+from .registry.encode import from_json_safe, json_safe
 from .registry.entities import ClimateDesc
 from .registry.identity import (
     DeviceIdentity,
@@ -1271,7 +1272,11 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             await self._snapshot_store.async_save(
                 {
-                    "resources": dict(resources),
+                    # json_safe/from_json_safe on the way out and back in
+                    # (registry/encode.py): a rep the JSON encoder rejects
+                    # used to fail this write entirely, and the only
+                    # symptom was this entry losing its offline load.
+                    "resources": json_safe(dict(resources)),
                     "subdevice_candidates": [asdict(su) for su in candidates],
                     "identity": asdict(ident) if ident is not None else None,
                 }
@@ -1303,7 +1308,7 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not stored or not stored.get("resources"):
             return False
 
-        resources = stored["resources"]
+        resources = from_json_safe(stored["resources"])
         try:
             ident = stored.get("identity")
             if ident is not None:

--- a/custom_components/localthings/diagnostics.py
+++ b/custom_components/localthings/diagnostics.py
@@ -20,6 +20,7 @@ from . import cloudcourse
 from .const import DOMAIN
 from .coordinator import LocalThingsCoordinator
 from .registry.capabilities.laundry import cycle_options
+from .registry.encode import json_safe
 from .registry.redact import redact_resources
 from .registry.subdevices import MAIN
 
@@ -72,101 +73,108 @@ async def async_get_config_entry_diagnostics(
             "resources": res,
         }
 
-    return {
-        "device_type": coordinator.device_type_name or "unknown",
-        "one_ui_version": coordinator.one_ui_version,
-        "identity": {
-            "manufacturer": identity.manufacturer,
-            "model": identity.model,
-            "device_types": list(identity.device_types),
-            "resources": redact_resources(identity.raw),
-        }
-        if identity is not None
-        else None,
-        "unbound_hrefs": sorted(coordinator._unbound_hrefs),
-        # This subdevice's own resources, and only this subdevice's. On a
-        # composite device (issue #177) `last_resources` is the union
-        # across every live subdevice keyed by real hrefs, so reporting it
-        # raw here would mix a sibling's /mode/vs/1 with the master's
-        # /mode/vs/0 under no attribution. Each sibling reports its own
-        # resources in `subdevices` below instead. For a device with no
-        # subdevices, this is byte-identical to `last_resources`.
-        "resources": redact_resources(coordinator.device_resources(MAIN)),
-        # Sibling indoor subdevices discovered on this connection (issue
-        # #177). subdeviceIdList (the UUID a prefixed subdevice's key comes
-        # from) is deliberately NOT redacted here, unlike elsewhere in
-        # `resources` -- it's an appliance-internal pairing id, not account
-        # data, and reporting it is what makes this block actionable.
-        "subdevices": [_subdevice_diag(su) for su in coordinator.subdevices],
-        # Candidates that answered their seed but that discover_partitioned's
-        # liveness gate rejected -- an unused SmartThings slot, not a real
-        # second subdevice. Reported alongside subdevices above so a report
-        # shows what was found and why it didn't become an entity.
-        "subdevices_skipped": [
-            {
-                "kind": skip.subdevice.kind,
-                "key": skip.subdevice.key,
-                **_seed_diag(skip.subdevice),
-                "hrefs": list(skip.hrefs),
-                # The reps the liveness gate actually judged -- the one
-                # thing a reader needs to second-guess a skip, and they
-                # exist nowhere else in this dump: a rejected candidate is
-                # never polled again or entered into the state cache.
-                "resources": redact_resources(
-                    {
-                        canon: rep
-                        for href, rep in coordinator._skipped_subdevice_resources.items()
-                        if (canon := skip.subdevice.to_canonical(href)) is not None
-                    }
-                ),
+    # json_safe wraps the finished dump, after redaction rather than before:
+    # redact.py matches on key names and must see the real structure, and a
+    # value it blanks never reaches the encoder at all. See registry/encode.py
+    # for why a dump can contain something JSON has no form for.
+    return json_safe(
+        {
+            "device_type": coordinator.device_type_name or "unknown",
+            "one_ui_version": coordinator.one_ui_version,
+            "identity": {
+                "manufacturer": identity.manufacturer,
+                "model": identity.model,
+                "device_types": list(identity.device_types),
+                "resources": redact_resources(identity.raw),
             }
-            for skip in coordinator._skipped_subdevices
-        ],
-        # What each enumeration probe returned ({} vs a batch), keyed by the
-        # seed href attempted -- lets a report distinguish "checked, nothing
-        # there" from "never checked".
-        "subdevice_probes": dict(sorted(coordinator._subdevice_probes.items())),
-        # /multidevice/vs/0's rep ({} when the board doesn't answer it).
-        # Reported on its own, not inside `resources`, since it's metadata
-        # about the connection rather than one subdevice's state, and
-        # nothing polls it after discovery so it would go stale in there.
-        "multidevice": redact_resources(coordinator._multidevice),
-        # Modes this unit reported itself in but never advertised (issue
-        # #327). Reported separately from `resources` on purpose: the dump
-        # above stays exactly what the device said, so a triager can still
-        # see the gap these codes were inferred from. Keyed by actual href,
-        # like the store itself.
-        "learned_modes": {
-            "enabled": coordinator.learning_enabled,
-            "codes": coordinator.learned_snapshot(),
-        },
-        # Cloud "Download" programs discovered on this device (issue #342),
-        # reported separately from `resources` for the same reason as
-        # learned_modes above -- the dump there stays exactly what the device
-        # said, and this is what the integration made of it.
-        #
-        # Reported in full, names included. Half of what can go wrong with
-        # this feature is a configuration question -- which programs got
-        # named, which Download course was confirmed, whether a payload was
-        # ever captured for a slot the device advertises -- and none of that
-        # is answerable from the payloads alone. The names are the user's own
-        # words, so this is the one place they appear; they reach a dump only
-        # because its owner chose to download and share it.
-        "cloud_courses": {
-            "advertised_slots": cloudcourse.advertised_slots(coordinator.cloud_course_rep()),
-            "cloud_slots": cloudcourse.cloud_slots(
-                coordinator.cloud_course_rep(), cycle_options(coordinator.device_resources(MAIN))
-            ),
-            **cloud_courses,
-        },
-        "integration_version": integration.version,
-        "smartthings_local_version": stl_version,
-        "observe_mode": coordinator.observe_mode,
-        "observe_subscribed_hrefs": sorted(coordinator._observe.subscribed_hrefs),
-        "observe_fallback_hrefs": sorted(coordinator._observe.fallback_hrefs),
-        "observe_last_mode_change": coordinator._observe.last_mode_change_wall,
-        "observe_href_freshness_s": {
-            href: coordinator._cache.freshness_s(href)
-            for href in coordinator._observe.subscribed_hrefs
-        },
-    }
+            if identity is not None
+            else None,
+            "unbound_hrefs": sorted(coordinator._unbound_hrefs),
+            # This subdevice's own resources, and only this subdevice's. On a
+            # composite device (issue #177) `last_resources` is the union
+            # across every live subdevice keyed by real hrefs, so reporting it
+            # raw here would mix a sibling's /mode/vs/1 with the master's
+            # /mode/vs/0 under no attribution. Each sibling reports its own
+            # resources in `subdevices` below instead. For a device with no
+            # subdevices, this is byte-identical to `last_resources`.
+            "resources": redact_resources(coordinator.device_resources(MAIN)),
+            # Sibling indoor subdevices discovered on this connection (issue
+            # #177). subdeviceIdList (the UUID a prefixed subdevice's key comes
+            # from) is deliberately NOT redacted here, unlike elsewhere in
+            # `resources` -- it's an appliance-internal pairing id, not account
+            # data, and reporting it is what makes this block actionable.
+            "subdevices": [_subdevice_diag(su) for su in coordinator.subdevices],
+            # Candidates that answered their seed but that discover_partitioned's
+            # liveness gate rejected -- an unused SmartThings slot, not a real
+            # second subdevice. Reported alongside subdevices above so a report
+            # shows what was found and why it didn't become an entity.
+            "subdevices_skipped": [
+                {
+                    "kind": skip.subdevice.kind,
+                    "key": skip.subdevice.key,
+                    **_seed_diag(skip.subdevice),
+                    "hrefs": list(skip.hrefs),
+                    # The reps the liveness gate actually judged -- the one
+                    # thing a reader needs to second-guess a skip, and they
+                    # exist nowhere else in this dump: a rejected candidate is
+                    # never polled again or entered into the state cache.
+                    "resources": redact_resources(
+                        {
+                            canon: rep
+                            for href, rep in coordinator._skipped_subdevice_resources.items()
+                            if (canon := skip.subdevice.to_canonical(href)) is not None
+                        }
+                    ),
+                }
+                for skip in coordinator._skipped_subdevices
+            ],
+            # What each enumeration probe returned ({} vs a batch), keyed by the
+            # seed href attempted -- lets a report distinguish "checked, nothing
+            # there" from "never checked".
+            "subdevice_probes": dict(sorted(coordinator._subdevice_probes.items())),
+            # /multidevice/vs/0's rep ({} when the board doesn't answer it).
+            # Reported on its own, not inside `resources`, since it's metadata
+            # about the connection rather than one subdevice's state, and
+            # nothing polls it after discovery so it would go stale in there.
+            "multidevice": redact_resources(coordinator._multidevice),
+            # Modes this unit reported itself in but never advertised (issue
+            # #327). Reported separately from `resources` on purpose: the dump
+            # above stays exactly what the device said, so a triager can still
+            # see the gap these codes were inferred from. Keyed by actual href,
+            # like the store itself.
+            "learned_modes": {
+                "enabled": coordinator.learning_enabled,
+                "codes": coordinator.learned_snapshot(),
+            },
+            # Cloud "Download" programs discovered on this device (issue #342),
+            # reported separately from `resources` for the same reason as
+            # learned_modes above -- the dump there stays exactly what the device
+            # said, and this is what the integration made of it.
+            #
+            # Reported in full, names included. Half of what can go wrong with
+            # this feature is a configuration question -- which programs got
+            # named, which Download course was confirmed, whether a payload was
+            # ever captured for a slot the device advertises -- and none of that
+            # is answerable from the payloads alone. The names are the user's own
+            # words, so this is the one place they appear; they reach a dump only
+            # because its owner chose to download and share it.
+            "cloud_courses": {
+                "advertised_slots": cloudcourse.advertised_slots(coordinator.cloud_course_rep()),
+                "cloud_slots": cloudcourse.cloud_slots(
+                    coordinator.cloud_course_rep(),
+                    cycle_options(coordinator.device_resources(MAIN)),
+                ),
+                **cloud_courses,
+            },
+            "integration_version": integration.version,
+            "smartthings_local_version": stl_version,
+            "observe_mode": coordinator.observe_mode,
+            "observe_subscribed_hrefs": sorted(coordinator._observe.subscribed_hrefs),
+            "observe_fallback_hrefs": sorted(coordinator._observe.fallback_hrefs),
+            "observe_last_mode_change": coordinator._observe.last_mode_change_wall,
+            "observe_href_freshness_s": {
+                href: coordinator._cache.freshness_s(href)
+                for href in coordinator._observe.subscribed_hrefs
+            },
+        }
+    )

--- a/custom_components/localthings/registry/encode.py
+++ b/custom_components/localthings/registry/encode.py
@@ -1,0 +1,131 @@
+"""Make decoded CBOR safe to hand to a JSON serializer, and read it back.
+
+The sibling of `redact.py`: that one makes device data safe to *share*,
+this one makes it safe to *represent*. Every path that carries a device's
+own data out of this integration -- the `read_resource`/`write_resource`
+service responses, diagnostics downloads, the discovery snapshot store --
+ends at a JSON encoder, and CBOR can decode to values JSON has no form
+for. A byte string is the one that shows up in practice: the appliance's
+usage history at `/file/transfer/vs/0` (issue #301) is 2-3 KB of binary,
+and without this it cannot leave the device at all.
+
+This is the second time an export path has silently lost a payload for
+being the wrong shape. The first was a Collection's list body reading as
+an empty `2.05 {}` (issue #335), fixed by carrying `body` alongside `rep`.
+That fix was correct and stays; this module is the general form of the
+lesson, so the third case is representable before anyone hits it.
+
+Unrepresentable values become a self-describing marker dict rather than
+being dropped or stringified, and `from_json_safe` turns the markers back
+into the values they stand for. That round trip is the point: a
+contributor can paste a blob straight out of a service response into a
+test fixture's `probes` map and the parser under test sees real `bytes`.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+from decimal import Decimal
+from typing import Any
+
+TYPE_KEY = "__localthings_type__"
+
+# Inlined base64 stops here; `len` and `sha256` stay honest about the whole
+# value. Generous for the few-KB histories this exists for, small enough
+# that a board offering a firmware image can't turn a diagnostics download
+# into a multi-megabyte file.
+MAX_INLINE_BYTES = 64 * 1024
+
+
+def _bytes_marker(raw: bytes, max_inline: int) -> dict[str, Any]:
+    head = raw[:max_inline]
+    marker: dict[str, Any] = {
+        TYPE_KEY: "bytes",
+        "len": len(raw),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+        "base64": base64.b64encode(head).decode("ascii"),
+    }
+    if len(head) != len(raw):
+        marker["truncated"] = True
+    return marker
+
+
+def json_safe(value: Any, *, max_inline_bytes: int = MAX_INLINE_BYTES) -> Any:
+    """Return `value` with everything a JSON encoder would reject replaced
+    by a marker dict, recursively.
+
+    Cycles are possible in principle (CBOR value sharing, tags 28/29) and
+    would otherwise recurse forever, so already-visited containers become a
+    marker too.
+    """
+    return _walk(value, max_inline_bytes, set())
+
+
+def _walk(value: Any, max_inline: int, seen: set[int]) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+
+    if isinstance(value, float):
+        # orjson renders these as `null`, which reads as "the device sent
+        # nothing" rather than "the device sent something JSON can't hold".
+        if value != value or value in (float("inf"), float("-inf")):
+            return {TYPE_KEY: "float", "value": repr(value)}
+        return value
+
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return _bytes_marker(bytes(value), max_inline)
+
+    if isinstance(value, (dict, list, tuple, set, frozenset)):
+        if id(value) in seen:
+            return {TYPE_KEY: "cycle"}
+        seen = seen | {id(value)}
+
+    if isinstance(value, dict):
+        # CBOR map keys need not be strings; JSON object keys must be. A
+        # coerced key is marked so it can't be mistaken for one the device
+        # actually sent as text.
+        out = {}
+        for key, item in value.items():
+            safe_key = key if isinstance(key, str) else f"{TYPE_KEY}:{key!r}"
+            out[safe_key] = _walk(item, max_inline, seen)
+        return out
+
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_walk(item, max_inline, seen) for item in value]
+
+    if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
+        return {TYPE_KEY: "datetime", "value": value.isoformat()}
+
+    if isinstance(value, Decimal):
+        return {TYPE_KEY: "decimal", "value": str(value)}
+
+    tag = getattr(value, "tag", None)
+    if tag is not None and hasattr(value, "value"):  # cbor2.CBORTag
+        return {TYPE_KEY: "tag", "tag": tag, "value": _walk(value.value, max_inline, seen)}
+
+    # Deliberately last, and deliberately not a raise: an export path
+    # losing one field is recoverable, an export path raising loses the
+    # whole report -- which is the failure this module exists to end.
+    return {TYPE_KEY: "unrepresentable", "repr": repr(value)[:200]}
+
+
+def from_json_safe(value: Any) -> Any:
+    """Inverse of `json_safe` for the markers that round-trip losslessly.
+
+    Only `bytes` does, and only when it wasn't truncated; every other
+    marker describes a value JSON could not hold and is left as the marker
+    dict it is. Written for test fixtures: a `probes` entry can carry a
+    real blob as JSON and reach a parser as `bytes`.
+    """
+    if isinstance(value, list):
+        return [from_json_safe(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    if value.get(TYPE_KEY) == "bytes" and not value.get("truncated"):
+        try:
+            return base64.b64decode(value["base64"], validate=True)
+        except (KeyError, ValueError, TypeError):
+            return value
+    return {key: from_json_safe(item) for key, item in value.items()}

--- a/custom_components/localthings/services.py
+++ b/custom_components/localthings/services.py
@@ -24,6 +24,7 @@ from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN, SERVICE_READ_RESOURCE, SERVICE_WRITE_RESOURCE
 from .coordinator import LocalThingsCoordinator, normalize_href
+from .registry.encode import json_safe
 from .registry.subdevices import MAIN, Subdevice
 
 ATTR_HREF = "href"
@@ -159,7 +160,10 @@ async def _async_write_resource(hass: HomeAssistant, call: ServiceCall) -> Servi
             canonical_by_actual.get(actual_href, actual_href): verified
             for actual_href, verified in sequence["verified"].items()
         }
-    return response
+    # One json_safe at the boundary rather than per field: `before`/`after`
+    # and every verified rep are whatever the appliance sent, and a service
+    # response ends at a JSON encoder (see registry/encode.py).
+    return cast(ServiceResponse, json_safe(response))
 
 
 async def _async_read_resource(hass: HomeAssistant, call: ServiceCall) -> ServiceResponse:
@@ -174,7 +178,7 @@ async def _async_read_resource(hass: HomeAssistant, call: ServiceCall) -> Servic
         # the appliance reported, without the fields this integration merges
         # on for its own use (see coordinator.entity_resources).
         snapshot: dict[str, Any] = {"resources": coordinator.device_resources(subdevice)}
-        return cast(ServiceResponse, snapshot)
+        return cast(ServiceResponse, json_safe(snapshot))
 
     # Same normalize-before-translate order as the write path above.
     canonical = normalize_href(href)
@@ -194,7 +198,7 @@ async def _async_read_resource(hass: HomeAssistant, call: ServiceCall) -> Servic
     # duplicating every rep in every response.
     if body is not None and not isinstance(body, dict):
         read_result["body"] = body
-    return cast(ServiceResponse, read_result)
+    return cast(ServiceResponse, json_safe(read_result))
 
 
 def async_setup_services(hass: HomeAssistant) -> None:

--- a/docs/investigations/file-transfer-usage-db.md
+++ b/docs/investigations/file-transfer-usage-db.md
@@ -1,0 +1,227 @@
+# Reading `/file/transfer/vs/0`: the on-appliance usage history
+
+Design notes for issues #301 (`ARTIK051_KRAC_18K`, runtime hours), #329
+(`ARTIK051_PRAC_20K` multi-split, energy + per-head runtime) and #285
+(`DA_WM_TP1_21_COMMON` washer, energy that outlives `cumulativePower`).
+
+Every appliance in those three reports keeps a rolling usage history in a
+file at `/file/transfer/vs/0`, and none of them can reach it through this
+integration. This file records why, what the design has to solve, and which
+questions have to be answered before any of it can be written.
+
+Nothing here is implemented. The reporters' parsers exist on their own
+branches; this is the shape they would have to land in.
+
+## What the reporters established
+
+| board | payload | series it carries |
+| --- | --- | --- |
+| `ARTIK051_KRAC_18K` (#301) | 181 × 12 B flat records | cumulative runtime, tenths of an hour |
+| `ARTIK051_PRAC_20K` (#329) | 181 × 12 B flat records, three `uint32` fields | shared outdoor-unit Wh **and** per-head runtime |
+| `DA_WM_TP1_21_COMMON` (#285/#301) | 281 × 12 B flat records | cumulative Wh, third field always zero |
+| some washers (#301) | genuine SQLite | a `power_usage` table |
+
+Common to all of them: the file is named `/mnt/usage.db` regardless of what
+it actually contains, values are cumulative rather than per-day, one record
+per day the appliance actually ran (so the window is ~181 *operating* days,
+not 181 calendar days), and the series does not start at zero.
+
+Two corroborations worth keeping. On the washer, the file's last record
+equals `/energy/consumption/vs/0`'s `cumulativePower` and `cumulativeDate`
+exactly — the file is the same meter, persisted. On the multi-split, the
+shared field equals `cumulativePower` on all three heads while the runtime
+field differs per head — the file carries both the thing that is
+legitimately shared and the thing that is legitimately per-unit, side by
+side.
+
+## The blocker is real and it is not board-specific
+
+`discovery.discover()` walks whatever `parse_device0_batch` found, i.e. the
+`/device/0` batch. `/file/transfer/vs/0` is not in it.
+
+That is not a quirk of the reporters' boards. Across the 83 `*_device.json`
+fixtures in this repository that carry a `/device/0` batch:
+
+- `/file/information/vs/0` appears in the batch on **63** of them.
+- `/file/transfer/vs/0` appears in the batch on **none** of them.
+- Of the six fixtures that captured an `/oic/res`, three list
+  `/file/transfer/vs/0`, `/file/list/vs/0` and `/file/transfer/chunk/vs/0`
+  as links: `ARTIK051_DONGLE_FAC_18K` and both `FAC_BORA` captures, the
+  latter two also carrying UUID-prefixed per-subdevice copies. Of the other
+  three, one captured no links at all and two list no `/file/*` href — and
+  per `composite-subdevice-hrefs.md`, an href's absence from `/oic/res`
+  proves nothing about whether it answers.
+
+So the file surface is a firmware-wide convention: advertised in `/oic/res`,
+withheld from the batch, and therefore invisible to every capability this
+registry can currently declare. A `Capability(href="/file/transfer/vs/0")`
+silently binds nothing — #301 deployed exactly that on live hardware and got
+no entity, which is the registry working as designed.
+
+There is already one precedent for the same gap. `/multidevice/vs/0` is
+listed in `/oic/res` on the Pattern A board and absent from its batch, and
+`enumerate_subdevices` gives it its own RETRIEVE and folds the result into
+the merged resources dict before discovery runs. That is the seam this
+design widens.
+
+## Design
+
+### 1. Reachability: a probe tier, not a general cold-tier rewrite
+
+`poll_tier` today has three values and only two behaviours: `hot`/`warm`
+hrefs get individual sub-poll GETs, `cold` means "refreshed by the batch and
+nothing else". What #301 asks for is a fourth behaviour — *read this href
+individually because the batch will never carry it*.
+
+Proposal: a `probe` tier. A capability declares `poll_tier="probe"`; the
+registry exposes the set of probe hrefs as a module-level constant derived
+from `CAPABILITIES` at import, because discovery cannot tier an href it
+never sees. The coordinator then:
+
+- probes those hrefs once inside the first-discovery block, folding the
+  results into `resources` **before** `_run_discovery` — same position and
+  same posture as `_enumerate_subdevices_blocking`, so a probe that fails
+  costs the entities on that href and nothing else;
+- re-reads them on a slow cadence afterwards, driven by a cycle counter in
+  `_async_update_data` rather than a new timer. A counter that ticks in
+  half hours and gains one record a day does not need the 30 s summary
+  interval; once every 30–60 minutes is generous.
+- maps each href through `subdevice.to_actual()` like every other read, so
+  the UUID-prefixed per-head copies the `FAC_BORA` fixtures advertise are
+  reachable by the same code.
+
+Cost when nothing is there: one GET per probe href per probe interval, which
+404s. That is why the probe list must stay short and maintainer-curated.
+
+### 2. Decode in the registry, never cache the blob
+
+The rep is not a Property map of scalars. It is a wrapper —
+`x.com.samsung.items` → `[{x.com.samsung.name, x.com.samsung.blob}]` — whose
+payload is 2–3 KB of binary.
+
+That blob must not reach `StateCache`. `_async_save_snapshot` writes the
+first cycle's resources to a JSON `Store` (bytes would fail the encode and
+cost the entry its offline rehydration), diagnostics dumps `last_resources`
+into every issue report, and `_on_cache_changed` fires a full entity push on
+any change. None of those want a kilobyte of binary.
+
+So the probe applies a *projected* rep: parse the blob, cache the scalars.
+
+`Capability.project(rep, resources) -> dict` is already declared on the
+dataclass and is currently dead code — nothing reads it. This is what it was
+for. Wiring it into the probe path (and only the probe path) keeps the
+parser in the registry next to the capability that consumes it, keeps the
+coordinator ignorant of record layouts, and leaves `SensorDesc(field=...)`
+working unchanged against the projected keys. Synthetic keys follow the
+existing convention, `x.localthings.*`, as `cloudcourse.FIELD` already does.
+
+### 3. Discriminate on record shape, not on a model token
+
+#329 is right that the parser should key on the payload. It is also what
+this registry does everywhere else — `is_legacy_board` gates on which href
+is present, not on a model string.
+
+- `SQLite format 3\0` in the first 16 bytes → the SQLite variant.
+- length divisible by 12 with no remainder → a flat record array; pick the
+  layout by *validating* candidates across the whole file (a plausible,
+  monotonic Unix timestamp in the leading `uint32`, versus the `uint64`
+  leading field of the KRAC shape) rather than guessing from one record.
+- anything else → parse nothing, log once, bind nothing. An unrecognized
+  format is a coverage gap for a human, not a reason to publish a number.
+
+The validator is the load-bearing part: three 12-byte layouts are already
+known and a fourth is likely, so "does this decode into a monotonic series"
+has to be a test the parser runs, not an assumption it makes.
+
+### 4. What to expose
+
+**Runtime hours — yes, and this is the part worth doing first.**
+`total_increasing`, `device_class: duration`, unit `h`. It is the honest
+primitive, HA's own long-term statistics give the monthly view for free
+without this integration touching the statistics API, and #329 proved it is
+genuinely per-unit even on a multi-split where the energy figure can never
+be. On a `KRAC` board it is also the *only* usage number the appliance has —
+#302 established that its permanent `0.0` kWh is correct, because the
+hardware has no meter and its own app draws an hours graph instead.
+
+**Energy — yes, but not as a second `total_increasing` energy sensor.**
+Where the file carries energy it is the same counter
+`/energy/consumption/vs/0` already publishes. Creating a second
+`state_class: total_increasing` energy entity for one physical meter is the
+double-count trap #329 warns about, one layer down. Two shapes are
+defensible:
+
+- default: `entity_category: diagnostic`, `enabled_default=False`, no
+  `state_class` — a corroborating figure, not an energy-dashboard source;
+- fallback: full `total_increasing` energy **only** where
+  `/energy/consumption/vs/0` has no `cumulativePower` at all, which is
+  exactly #285's washer and exactly the case where this file is the only
+  copy of the number.
+
+The second needs no new machinery: two descriptors with complementary
+`exists_fn`, the pattern `ai_energy_level`'s switch/select pair and
+`ENERGY_METER_LEGACY`/`GENERIC` already use.
+
+**`UsagesDB_reset` — no.** #301 is right. It destroys the only copy of the
+history, and there is nothing for a user to weigh that against.
+
+### 5. Backfilling the ~181-day window — out of scope
+
+Agreed with #301, with one correction to the premise: the mechanism is not
+as unreachable as the issue assumes. `recorder` is already in
+`after_dependencies` and `__init__.py` already calls into
+`recorder.statistics` for the v2→v3 particulate relabel.
+
+It should still not happen here. External statistic ids do not attach to the
+entity, so the imported history lives beside the sensor rather than in it;
+the AC formats carry no per-day energy to import in the first place; and it
+buys a one-time cosmetic win against permanent complexity. Publish the
+current cumulative value, let HA accumulate from today, leave the past in
+the appliance.
+
+## What has to be answered before any of this is written
+
+In rough order of how much they can invalidate:
+
+1. **The interface query.** Both reporters read the resource as
+   `GET /file/transfer/vs/0?if=oic.if.baseline`. `DtlsCoapSession.get()`
+   takes path segments and no query string, and nothing in this component
+   has ever sent one. Either the default RETRIEVE returns the same payload —
+   in which case this is a non-issue — or the design needs a
+   `smartthings-local` change before its first line. Nothing else matters
+   until this is settled.
+2. **The exact record layouts.** The byte-level specs in #301 and its washer
+   comment are written in angle brackets and are stripped from the GitHub
+   API's rendering of both. They need to be re-read from the issue as
+   displayed, or restated by the reporters, before a parser is written
+   against them. The *semantics* above are not in doubt; the field widths
+   and order are, and the discriminator in §3 depends on them.
+3. **Whether the GET is safe to repeat.** `/oic/res` advertises
+   `/file/transfer/vs/0` as `oic.if.a` with `bm: 3` — an actuator, and
+   observable. Both reporters' one-shot GETs worked with no prior write, so
+   it very probably has no side effect and needs no session setup, but a
+   resource we intend to poll on a schedule deserves better than "probably".
+   The `bm: 3` is a curiosity only: a 2 KB blob is not something to OBSERVE.
+4. **`/file/list/vs/0`.** Sits in the same `/oic/res` block on every board
+   that carries one, is declared `oic.if.s`, and has never been read by
+   anyone. It is the natural "what files are there, and how big" resource —
+   `/file/information/vs/0` demonstrably is not, carrying only a timezone
+   offset and a misspelled `supprtedtype`. One probe answers whether the
+   guessing in §3 is necessary at all.
+5. **`/file/transfer/chunk/vs/0`.** Implies a chunked download protocol for
+   files too large for a single blockwise GET — most likely relevant to the
+   SQLite washers, whose file has no reason to stay at 3 KB.
+6. **Fixtures.** Every fixture in this repository is `/device/0` JSON. A
+   blob needs a new fixture shape (base64 beside the batch), one per format,
+   before the parser can have a golden test.
+
+## Suggested sequencing
+
+1. Answer (1) and (4) with the existing `read_resource` debug service — no
+   code changes, and between them they decide the shape of everything else.
+2. Land the probe tier alone, with `/file/transfer/vs/0` and
+   `/file/list/vs/0` as coverage-only capabilities that bind no entities.
+   Diagnostics then start carrying both payloads from every board a user
+   owns, which is what turns four reported formats into a real census.
+3. Land the parser and the runtime-hours sensor against the two AC formats.
+4. Decide the energy question in §4 on the evidence step 2 produces.

--- a/docs/investigations/file-transfer-usage-db.md
+++ b/docs/investigations/file-transfer-usage-db.md
@@ -297,20 +297,26 @@ In rough order of how much they can invalidate:
    against them. The *semantics* above are not in doubt; the field widths
    and order are, and the discriminator in §3 depends on them.
 
-4. **Getting bytes out of the device at all.** `read_resource` returns the
-   decoded rep verbatim as a `ServiceResponse`, which HA serializes as JSON
-   for the websocket API. A CBOR byte string has no JSON form, so a blob
-   either fails the response encode or renders as something unusable — and
-   `composite-subdevice-hrefs.md` already warns contributors not to ask for
-   one to be pasted into a comment. Every fixture in this repository is
-   `/device/0` JSON, so a blob also needs a new fixture shape (base64
-   beside the batch), one per format, before any parser can have a golden.
+4. ~~**Getting bytes out of the device at all.**~~ **Done.**
+   `read_resource` returned the decoded rep verbatim as a `ServiceResponse`,
+   which HA serializes as JSON, and a CBOR byte string has no JSON form — so
+   a blob could not leave the appliance through this integration at all. The
+   snapshot store had the same problem with a worse symptom: the write fails
+   and the entry silently loses its offline load.
 
-   Both problems have the same small fix: have `read_resource` render a
-   `bytes` value as its length, SHA-256 and base64 rather than passing it
-   through. That is a self-contained change, it is useful to anyone
-   reverse-engineering any binary rep on any board, and nothing else in this
-   design can be collected or tested until it exists.
+   `registry/encode.py` now renders any value a JSON encoder would reject as
+   a self-describing marker (`bytes` as length, SHA-256 and base64), and
+   `from_json_safe` turns the markers back. It is applied once at each
+   boundary that carries device data out — both service responses,
+   diagnostics, and the snapshot store, which round-trips through it — so
+   the next unrepresentable type is representable before anyone hits it.
+
+   The fixture corpus needed less than this file first claimed: a fixture's
+   optional `probes` map already exists for exactly this, holding hand-read
+   resources that belong to no batch (`/multidevice/vs/0` on the
+   `ARTIK051_DONGLE_FAC_18K` fixture). `tests/conftest.py` now decodes it
+   through `from_json_safe`, so a `probes` entry can carry a blob as JSON
+   and the parser under test is handed real `bytes`.
 
 5. **`/file/transfer/chunk/vs/0`.** Implies a chunked download protocol for
    files too large for a single blockwise GET — most likely relevant to the
@@ -318,18 +324,18 @@ In rough order of how much they can invalidate:
 
 ## Suggested sequencing
 
-1. Land the `bytes` rendering in `read_resource` (question 4). It is the
-   smallest useful change here, it stands on its own merits, and nothing
-   downstream can be measured without it.
-2. With that in hand, read `/file/transfer/vs/0` on a board whose
-   `/file/list/vs/0` is already known — the dishwasher above is the obvious
-   candidate, since its primary file is named `energy.db` outright. One read
-   settles questions 1 and 2 together: whether a plain GET answers, and
-   which file it hands back when the appliance has two.
+1. ~~Land the `bytes` rendering in `read_resource`.~~ Done, and generalized —
+   see question 4.
+2. Read `/file/transfer/vs/0` on a board whose `/file/list/vs/0` is already
+   known — the dishwasher above is the obvious candidate, since its primary
+   file is named `energy.db` outright. One read settles questions 1 and 2
+   together: whether a plain GET answers, and which file it hands back when
+   the appliance has two. The blob now survives the trip, so the answer
+   arrives in a form that can go straight into a fixture.
 3. Land the probe tier alone, with `/file/list/vs/0` and
    `/file/transfer/vs/0` as coverage-only capabilities that bind no
-   entities. Diagnostics then start carrying the file list — and, once
-   question 4 is done, the blob — from every board a user owns, which is
-   what turns four reported formats into a real census.
+   entities. Diagnostics then start carrying the file list and the blob from
+   every board a user owns, which is what turns four reported formats into a
+   real census.
 4. Land the parser and the runtime-hours sensor against the two AC formats.
 5. Decide the energy question in §4 on the evidence step 3 produces.

--- a/docs/investigations/file-transfer-usage-db.md
+++ b/docs/investigations/file-transfer-usage-db.md
@@ -34,6 +34,56 @@ field differs per head — the file carries both the thing that is
 legitimately shared and the thing that is legitimately per-unit, side by
 side.
 
+## `/file/list/vs/0` answers, and it changes what the probe has to do
+
+Read live off a dishwasher (2.05, `oic.if.s`, no write and no selection
+first):
+
+```yaml
+rep:
+  x.com.samsung.items:
+    - x.com.samsung.id: '0'
+      x.com.samsung.name: /opt/data/energy.db
+    - x.com.samsung.id: '1'
+      x.com.samsung.name: /opt/data/hass.db
+```
+
+Three things follow.
+
+**The filename is family-dependent, so nothing may hardcode it.** The ACs in
+#301/#329 and the washer in #285 all serve `/mnt/usage.db`. This dishwasher
+has no such path: its history is `/opt/data/energy.db`. A design that keys
+on the name `usage.db` — or that assumes one file — is already wrong on the
+third family anyone points it at.
+
+**There is a selection step, and it has already been exercised.** The items
+carry an `x.com.samsung.id`, and `/file/transfer/vs/0` is declared
+`oic.if.a` in `/oic/res` while `/file/list/vs/0` is `oic.if.s`. That reads
+as list-then-select-then-read, and `ac-filter-reset.md` confirms the second
+half from a live `ARTIK051_KRAC_18K`: *"`/file/transfer/vs/0` serves only
+`/mnt/usage.db`; selecting another path returns 4.05/4.00."* So a selection
+write exists, the firmware validates what it is handed, and on that board it
+refused everything but the primary file. What is still unknown is whether a
+bare GET returns the primary file without any selection — which is what both
+reporters appear to have done, on appliances whose primary file was the one
+they wanted anyway.
+
+**`hass.db` is Samsung's, not ours.** It sits beside `energy.db` here and
+beside `/mnt/usage.db` on the KRAC, and it pairs with the `/hass/state/vs/0`
+and `/hass/command/vs/0` hrefs that three fixtures advertise in `/oic/res`.
+Those return 4.04 on every interface (`ac-filter-reset.md`), so this is
+unimplemented vendor scaffolding that happens to collide with Home
+Assistant's own shorthand. Worth stating once so nobody spends an afternoon
+on it.
+
+One correction to #301 while here: it writes off `/file/information/vs/0` as
+carrying "no file list, no size", which is true and is no longer the point —
+`/file/list/vs/0` is the enumeration resource. But that href's
+`x.com.samsung.timeoffset` is the device's own UTC offset, and every format
+on record stamps records at day or hour granularity in device-local terms.
+It is not a dead resource; it is the thing that makes a record's date mean
+something.
+
 ## The blocker is real and it is not board-specific
 
 `discovery.discover()` walks whatever `parse_device0_batch` found, i.e. the
@@ -93,6 +143,19 @@ never sees. The coordinator then:
 Cost when nothing is there: one GET per probe href per probe interval, which
 404s. That is why the probe list must stay short and maintainer-curated.
 
+`/file/list/vs/0` belongs on that list ahead of `/file/transfer/vs/0`, and
+not only for diagnostics. Since the filename varies by family — `usage.db`
+on the ACs and the washer, `energy.db` on the dishwasher — the list is how
+the probe knows *which* file it is about to read, and by extension which
+parser to reach for and whether a history exists on this board at all. It is
+`oic.if.s`, it answers a plain GET, and its reply is a handful of short
+strings, so it is cheap enough to read on every probe cycle rather than
+cached from first discovery.
+
+Whether reading the file itself is one GET or a select-then-GET is open —
+see question 2 below, which is the single fact this section's cadence
+depends on.
+
 ### 2. Decode in the registry, never cache the blob
 
 The rep is not a Property map of scalars. It is a wrapper —
@@ -132,6 +195,17 @@ is present, not on a model string.
 The validator is the load-bearing part: three 12-byte layouts are already
 known and a fourth is likely, so "does this decode into a monotonic series"
 has to be a test the parser runs, not an assumption it makes.
+
+The filename is a prior, never the test. `energy.db` on a dishwasher and a
+`power_usage` table on the SQLite washers both point at SQLite, and #301's
+`/mnt/usage.db` that is not SQLite is the standing proof that the name
+decides nothing. Read the magic bytes.
+
+If the SQLite branch is ever taken, note that the file arrives as bytes in
+memory and `sqlite3` cannot open a buffer. `sqlite3.Connection.deserialize`
+(3.11+, so available on every Python HA now runs) reads one without a
+temporary file; the alternative is writing the blob to disk from inside an
+executor job, which is worse in every respect.
 
 ### 4. What to expose
 
@@ -190,38 +264,72 @@ In rough order of how much they can invalidate:
    in which case this is a non-issue — or the design needs a
    `smartthings-local` change before its first line. Nothing else matters
    until this is settled.
-2. **The exact record layouts.** The byte-level specs in #301 and its washer
+
+   Note that `/file/list/vs/0` answered a plain segment-path GET from this
+   integration's own `read_resource`, with no query, so the query is not
+   required to reach the file surface as such. That is encouraging, not
+   conclusive: `oic.if.s` is that resource's only non-baseline interface,
+   while `/file/transfer/vs/0` is `oic.if.a`, and an actuator's default
+   interface is the more likely one to answer differently.
+
+2. **Whether a bare GET reads the primary file, or a selection write is
+   required first.** `/file/list/vs/0` hands out an `x.com.samsung.id` per
+   file, and `ac-filter-reset.md` records a live board *rejecting* a
+   selection of a non-primary path (4.05/4.00) — so a write path exists and
+   the firmware validates it. Both reporters' one-shot GETs returned the
+   file they wanted, but on appliances whose primary file was the one they
+   wanted, which does not distinguish "GET returns the primary file" from
+   "GET returns whatever was last selected, and nothing had selected
+   anything".
+
+   This is the question that decides whether the probe in §1 is a read or a
+   read-modify-read, and a scheduled probe that has to *write* to an
+   actuator on every cycle is a materially different proposition — it can
+   race a user's own debug write, and it needs the settle guard
+   `ObserveManager.mark_write_pending` exists for. If selection turns out to
+   be required, that is an argument for probing far less often than §1
+   proposes, or only once per session.
+
+3. **The exact record layouts.** The byte-level specs in #301 and its washer
    comment are written in angle brackets and are stripped from the GitHub
    API's rendering of both. They need to be re-read from the issue as
    displayed, or restated by the reporters, before a parser is written
    against them. The *semantics* above are not in doubt; the field widths
    and order are, and the discriminator in §3 depends on them.
-3. **Whether the GET is safe to repeat.** `/oic/res` advertises
-   `/file/transfer/vs/0` as `oic.if.a` with `bm: 3` — an actuator, and
-   observable. Both reporters' one-shot GETs worked with no prior write, so
-   it very probably has no side effect and needs no session setup, but a
-   resource we intend to poll on a schedule deserves better than "probably".
-   The `bm: 3` is a curiosity only: a 2 KB blob is not something to OBSERVE.
-4. **`/file/list/vs/0`.** Sits in the same `/oic/res` block on every board
-   that carries one, is declared `oic.if.s`, and has never been read by
-   anyone. It is the natural "what files are there, and how big" resource —
-   `/file/information/vs/0` demonstrably is not, carrying only a timezone
-   offset and a misspelled `supprtedtype`. One probe answers whether the
-   guessing in §3 is necessary at all.
+
+4. **Getting bytes out of the device at all.** `read_resource` returns the
+   decoded rep verbatim as a `ServiceResponse`, which HA serializes as JSON
+   for the websocket API. A CBOR byte string has no JSON form, so a blob
+   either fails the response encode or renders as something unusable — and
+   `composite-subdevice-hrefs.md` already warns contributors not to ask for
+   one to be pasted into a comment. Every fixture in this repository is
+   `/device/0` JSON, so a blob also needs a new fixture shape (base64
+   beside the batch), one per format, before any parser can have a golden.
+
+   Both problems have the same small fix: have `read_resource` render a
+   `bytes` value as its length, SHA-256 and base64 rather than passing it
+   through. That is a self-contained change, it is useful to anyone
+   reverse-engineering any binary rep on any board, and nothing else in this
+   design can be collected or tested until it exists.
+
 5. **`/file/transfer/chunk/vs/0`.** Implies a chunked download protocol for
    files too large for a single blockwise GET — most likely relevant to the
    SQLite washers, whose file has no reason to stay at 3 KB.
-6. **Fixtures.** Every fixture in this repository is `/device/0` JSON. A
-   blob needs a new fixture shape (base64 beside the batch), one per format,
-   before the parser can have a golden test.
 
 ## Suggested sequencing
 
-1. Answer (1) and (4) with the existing `read_resource` debug service — no
-   code changes, and between them they decide the shape of everything else.
-2. Land the probe tier alone, with `/file/transfer/vs/0` and
-   `/file/list/vs/0` as coverage-only capabilities that bind no entities.
-   Diagnostics then start carrying both payloads from every board a user
-   owns, which is what turns four reported formats into a real census.
-3. Land the parser and the runtime-hours sensor against the two AC formats.
-4. Decide the energy question in §4 on the evidence step 2 produces.
+1. Land the `bytes` rendering in `read_resource` (question 4). It is the
+   smallest useful change here, it stands on its own merits, and nothing
+   downstream can be measured without it.
+2. With that in hand, read `/file/transfer/vs/0` on a board whose
+   `/file/list/vs/0` is already known — the dishwasher above is the obvious
+   candidate, since its primary file is named `energy.db` outright. One read
+   settles questions 1 and 2 together: whether a plain GET answers, and
+   which file it hands back when the appliance has two.
+3. Land the probe tier alone, with `/file/list/vs/0` and
+   `/file/transfer/vs/0` as coverage-only capabilities that bind no
+   entities. Diagnostics then start carrying the file list — and, once
+   question 4 is done, the blob — from every board a user owns, which is
+   what turns four reported formats into a real census.
+4. Land the parser and the runtime-hours sensor against the two AC formats.
+5. Decide the energy question in §4 on the evidence step 3 produces.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,10 +33,17 @@ def _load_device_full(name: str):
     belong to no batch, e.g. the hand-read /multidevice/vs/0 in the
     ARTIK051_DONGLE_FAC_18K fixture) is folded into `seeds` here, since
     FakeCoapSession answers both shapes off the same href key.
+
+    `probes` runs through `from_json_safe`, so an entry may carry a binary
+    rep as the marker `read_resource`/diagnostics emit for one (see
+    registry/encode.py) and the fake session hands the caller real `bytes`,
+    exactly as a device would.
     """
+    from custom_components.localthings.registry.encode import from_json_safe
+
     data = json.loads((FIXTURES / f"{name}_device.json").read_text())
     resources = _resources_from_dump(data)
-    seeds = {**data.get("seeds", {}), **data.get("probes", {})}
+    seeds = {**data.get("seeds", {}), **from_json_safe(data.get("probes", {}))}
     return resources, data.get("oic_res", []), seeds
 
 

--- a/tests/localthings/test_offline_setup.py
+++ b/tests/localthings/test_offline_setup.py
@@ -123,6 +123,36 @@ async def test_snapshot_written_after_first_discovery(
     assert "subdevice_candidates" in stored
 
 
+async def test_snapshot_survives_a_binary_rep(
+    hass: HomeAssistant, mock_entry, hass_storage
+) -> None:
+    """A rep carrying bytes used to fail the whole snapshot write -- the
+    JSON store can't encode one -- and the only symptom was this entry
+    silently losing its offline load. registry/encode.py stores a marker
+    and rebuilds the bytes on replay."""
+    resources = _load_fridge()
+    resources["/file/transfer/vs/0"] = {
+        "x.com.samsung.name": "/mnt/usage.db",
+        "x.com.samsung.blob": b"\x00\x01\x02usage",
+    }
+
+    online_ids = await _setup_online_then_unload(hass, mock_entry, resources)
+    assert online_ids
+
+    stored = hass_storage[_store_key(mock_entry)]["data"]
+    assert stored["resources"]["/file/transfer/vs/0"]["x.com.samsung.blob"]["len"] == 8
+
+    with _unreachable():
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_entry.state is ConfigEntryState.LOADED
+    assert {s.entity_id for s in hass.states.async_all()} == online_ids
+    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
+    replayed = coordinator.discovery_resources["/file/transfer/vs/0"]
+    assert replayed["x.com.samsung.blob"] == b"\x00\x01\x02usage"
+
+
 async def test_snapshot_not_written_when_device_never_answers(
     hass: HomeAssistant, mock_entry, hass_storage
 ) -> None:

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -1,0 +1,139 @@
+"""json_safe / from_json_safe: representing what CBOR decodes to and JSON
+cannot hold.
+
+The case that matters is `bytes` -- the usage history at
+/file/transfer/vs/0 (issue #301) is a few KB of binary, and every path
+that carries device data out of this integration ends at a JSON encoder.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+
+import pytest
+
+from custom_components.localthings.registry.encode import (
+    TYPE_KEY,
+    from_json_safe,
+    json_safe,
+)
+
+
+def _json_round_trip(value):
+    """What HA's serializer would do with it. Any survivor of json_safe has
+    to make it through this without raising."""
+    return json.loads(json.dumps(value, allow_nan=False))
+
+
+def test_plain_reps_pass_through_untouched():
+    rep = {
+        "x.com.samsung.da.cumulativePower": "5118585",
+        "rt": ["x.com.samsung.file.list"],
+        "n": 12,
+        "ok": True,
+        "missing": None,
+        "ratio": 2.5,
+    }
+    assert json_safe(rep) == rep
+
+
+def test_bytes_become_a_marker_that_json_accepts():
+    blob = bytes(range(256)) * 4
+    safe = json_safe({"x.com.samsung.blob": blob})
+    marker = safe["x.com.samsung.blob"]
+
+    assert marker[TYPE_KEY] == "bytes"
+    assert marker["len"] == len(blob)
+    assert marker["sha256"] == hashlib.sha256(blob).hexdigest()
+    assert base64.b64decode(marker["base64"]) == blob
+    assert "truncated" not in marker
+    _json_round_trip(safe)
+
+
+def test_bytes_round_trip_back_to_bytes():
+    original = {"x.com.samsung.items": [{"x.com.samsung.blob": b"\x00\x01\x02usage"}]}
+    # Through an actual JSON encode/decode, which is the trip a fixture makes.
+    restored = from_json_safe(_json_round_trip(json_safe(original)))
+    assert restored == original
+
+
+def test_a_truncated_blob_keeps_honest_metadata_and_does_not_round_trip():
+    blob = b"x" * 500
+    marker = json_safe(blob, max_inline_bytes=10)
+
+    assert marker["len"] == 500
+    assert marker["sha256"] == hashlib.sha256(blob).hexdigest()
+    assert marker["truncated"] is True
+    assert base64.b64decode(marker["base64"]) == b"x" * 10
+    # Refusing to rebuild a partial value is the point: a parser must never
+    # be handed 10 bytes that claim to be 500.
+    assert from_json_safe(marker) == marker
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"raw",
+        bytearray(b"raw"),
+        memoryview(b"raw"),
+    ],
+)
+def test_every_bytes_like_type_is_handled(value):
+    assert from_json_safe(json_safe(value)) == b"raw"
+
+
+def test_non_string_map_keys_are_coerced_and_marked():
+    safe = json_safe({1: "a", "b": 2})
+    assert safe["b"] == 2
+    coerced = [k for k in safe if k != "b"]
+    assert len(coerced) == 1
+    assert coerced[0].startswith(TYPE_KEY)
+    _json_round_trip(safe)
+
+
+def test_sets_and_tuples_become_lists():
+    assert json_safe(("a", "b")) == ["a", "b"]
+    assert sorted(json_safe({"a", "b"})) == ["a", "b"]
+
+
+def test_non_finite_floats_survive_as_markers():
+    safe = json_safe({"a": float("nan"), "b": float("inf")})
+    assert safe["a"][TYPE_KEY] == "float"
+    assert safe["b"][TYPE_KEY] == "float"
+    # allow_nan=False is what orjson does; a bare NaN would fail here.
+    _json_round_trip(safe)
+
+
+def test_a_cycle_terminates():
+    rep: dict = {"href": "/x/vs/0"}
+    rep["self"] = rep
+    safe = json_safe(rep)
+    assert safe["href"] == "/x/vs/0"
+    assert safe["self"][TYPE_KEY] == "cycle"
+    _json_round_trip(safe)
+
+
+def test_an_unknown_type_is_described_rather_than_raising():
+    class Opaque:
+        def __repr__(self):
+            return "<opaque>"
+
+    safe = json_safe({"weird": Opaque()})
+    assert safe["weird"] == {TYPE_KEY: "unrepresentable", "repr": "<opaque>"}
+    _json_round_trip(safe)
+
+
+def test_cbor_tags_keep_their_tag_number_and_payload():
+    cbor2 = pytest.importorskip("cbor2")
+    safe = json_safe(cbor2.CBORTag(42, b"inner"))
+    assert safe[TYPE_KEY] == "tag"
+    assert safe["tag"] == 42
+    assert from_json_safe(safe["value"]) == b"inner"
+    _json_round_trip(safe)
+
+
+def test_from_json_safe_leaves_ordinary_data_alone():
+    rep = {"a": [1, "two", {"three": None}]}
+    assert from_json_safe(rep) == rep

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,6 +9,8 @@ multi-write sequencing, settle/verify_after, and the options-flow rewiring.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from unittest.mock import AsyncMock, patch
 
 import cbor2
@@ -29,6 +31,7 @@ from custom_components.localthings.const import (
     SERVICE_WRITE_RESOURCE,
 )
 from custom_components.localthings.coordinator import LocalThingsCoordinator
+from custom_components.localthings.registry.encode import TYPE_KEY, from_json_safe
 from custom_components.localthings.registry.subdevices import Subdevice
 from custom_components.localthings.services import async_setup_services
 
@@ -640,6 +643,31 @@ async def test_read_resource_surfaces_a_collections_list_body(hass, coordinator,
     assert response["code"] == "2.05"
     assert response["rep"] == {}
     assert response["body"] == batch
+
+
+async def test_read_resource_renders_a_binary_rep_as_a_marker(hass, coordinator, device_id):
+    """A CBOR byte string has no JSON form, and a service response is
+    JSON-serialized -- so without registry/encode.py the appliance's usage
+    history at /file/transfer/vs/0 (issue #301) could not leave the device
+    through this service at all."""
+    blob = bytes(range(256)) * 8
+    fake = _FakeSession()
+    fake.queue_get(
+        "file/transfer/vs/0",
+        {"x.com.samsung.name": "/mnt/usage.db", "x.com.samsung.blob": blob},
+    )
+    coordinator._session = fake
+
+    response = await _call_read(hass, device_id, href="/file/transfer/vs/0")
+
+    assert response["rep"]["x.com.samsung.name"] == "/mnt/usage.db"
+    marker = response["rep"]["x.com.samsung.blob"]
+    assert marker[TYPE_KEY] == "bytes"
+    assert marker["len"] == len(blob)
+    assert marker["sha256"] == hashlib.sha256(blob).hexdigest()
+    # The response is what a contributor pastes into a fixture, so the trip
+    # back to real bytes has to survive an actual JSON encode.
+    assert from_json_safe(json.loads(json.dumps(response)))["rep"]["x.com.samsung.blob"] == blob
 
 
 async def test_read_resource_failure_is_surfaced_as_a_home_assistant_error(


### PR DESCRIPTION
Issues #301, #329 and #285 all describe a rolling usage history the
appliance keeps at /file/transfer/vs/0 -- runtime hours on ARTIK051 ACs,
energy on the TP1_21 washer, both on the PRAC multi-split -- that no
capability can bind, because the href is advertised in /oic/res and never
appears in the /device/0 batch (none of this repository's 83 batch
fixtures carry it).

Records what the design has to solve: a probe tier for hrefs the batch
will never carry, decoding the blob in the registry via the currently
unused Capability.project so the binary never reaches the state cache or
the offline snapshot, discriminating the payload formats on record shape,
and why the file's energy series should not become a second
total_increasing sensor. Also lists the questions that gate the work --
chiefly whether the resource can be read without the ?if=oic.if.baseline
query DtlsCoapSession cannot currently send.