### PR TITLE
Bump smartthings-local to 0.1.12 (issue #417) and prep v0.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ FROM ghcr.io/home-assistant/home-assistant:stable
 # repeats the install attempt on every container recreate. Baking
 # smartthings-local into the image keeps the dev container usable
 # offline and avoids relying on that runtime install path.
-RUN pip3 install --no-cache-dir "smartthings-local>=0.1.11"
+RUN pip3 install --no-cache-dir "smartthings-local>=0.1.12"

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -820,6 +820,11 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._identity = None
 
     def _close_session(self) -> None:
+        # Blocking, run in an executor. As of smartthings-local 0.1.12,
+        # close() actually puts the DTLS close_notify on the wire instead of
+        # just building it (issue #417), and paces the OBSERVE deregisters
+        # it now sends through the session rate limiter -- a few seconds for
+        # an appliance with a dozen relations at the 5 req/s default.
         sess = self._session
         self._session = None
         if sess is not None:

--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -11,7 +11,7 @@
   "requirements": [
     "cbor2>=5.4.6",
     "pyOpenSSL>=23.0",
-    "smartthings-local>=0.1.11"
+    "smartthings-local>=0.1.12"
   ],
   "version": "0.24.0"
 }

--- a/custom_components/localthings/manifest.json
+++ b/custom_components/localthings/manifest.json
@@ -13,5 +13,5 @@
     "pyOpenSSL>=23.0",
     "smartthings-local>=0.1.12"
   ],
-  "version": "0.24.0"
+  "version": "0.25.0"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest-homeassistant-custom-component>=0.13.316
 
 # Integration runtime deps, needed to import the component under test
 # (also declared in custom_components/localthings/manifest.json).
-smartthings-local>=0.1.11
+smartthings-local>=0.1.12
 cbor2>=5.4.6
 pyOpenSSL>=23.0
 cryptography>=41.0


### PR DESCRIPTION
## smartthings-local 0.1.12 (issue #417)

Upstream (QuiteYellow, issue #417): `close()` previously built the DTLS close_notify alert and left it sitting in the BIO — nothing reached the appliance, so the device kept the old association across a clean shutdown. 0.1.12 actually puts it on the wire, which lands directly on the HA-restart case #254 was split from (a fixed source port covers the unclean-exit half; this covers the clean one).

No call-site changes: `subscribe()` and `refresh_observes()` both gain keyword-only parameters that default to today's behavior, and the new `DtlsCoapSession` callbacks (`on_legacy_notification`, `on_observe_pending`, `on_observe_error`) and methods (`quiesce_for_close`, `abort`, `unsubscribe`) are additive and unused here. The new `coap_tcp` module has no carrier behind it — nothing to adopt.

One behavior worth recording: `close()` now paces the OBSERVE deregisters it sends through the session rate limiter rather than firing them as fast as the loop runs — a few seconds for an appliance with a dozen relations at the 5 req/s default. Noted in `_close_session`; it runs in an executor job already awaited from Core-stop, so the added latency costs nothing beyond what issue #254's fix already accepted.

Floor raised in `manifest.json`, `requirements-dev.txt`, and `Dockerfile`.

## Version bump

Bumps `manifest.json` to `0.25.0` to prep the next release, which also picks up (already on `main`, not yet shipped):
- #401 — AddWash controls/sensors for washers
- #415 — smartthings-local 0.1.11 (fixes appliance-wedge-at-connect, issue #396) and Home Assistant 2026.9 device-registry deprecation cleanup

## Testing

Verified against smartthings-local 0.1.12 from PyPI on Python 3.13: full suite (1746 tests), ruff format, ruff lint, and ty all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XWDxdmZoZjV4jPGT3xxy7N)_