### PR TITLE
Add OwnerPSK credential-backed sessions

### DIFF
--- a/custom_components/localthings/__init__.py
+++ b/custom_components/localthings/__init__.py
@@ -16,7 +16,16 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_DEVICE_TYPE, CONF_HOST, CONF_PORT, CONF_SERIAL, DOMAIN, PLATFORMS
+from .const import (
+    AUTH_CERTIFICATE,
+    CONF_AUTH_TYPE,
+    CONF_DEVICE_TYPE,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_SERIAL,
+    DOMAIN,
+    PLATFORMS,
+)
 from .coordinator import LocalThingsCoordinator, snapshot_store
 from .registry.identity import resolve_serial
 from .rekey import rekey_entry
@@ -213,12 +222,16 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     what the coordinator rewrites *from* once a live poll finally hands it
     a UUID to rewrite *to*.
 
-    The version is still bumped now rather than at that point, because the
-    bump's real job is the `entry.version > 4` downgrade guard below: an
+    v4 -> v5 makes the authentication mode explicit. Every entry written by
+    an older release is certificate-backed, so this adds only the discriminator
+    and leaves all endpoint, credential, identity, and registry data untouched.
+
+    The v4 version is still bumped before a live UUID re-key completes because
+    that bump's real job is the downgrade guard below: an
     entry re-keyed onto a UUID and then loaded by a release that reads
     CONF_SERIAL as the key would silently orphan every entity it has.
     """
-    if entry.version > 4:
+    if entry.version > 5:
         return False  # downgrade: this release doesn't know the newer shape
 
     if entry.version == 1:
@@ -257,6 +270,14 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.entry_id,
             legacy_key,
         )
+
+    if entry.version == 4:
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_AUTH_TYPE: AUTH_CERTIFICATE},
+            version=5,
+        )
+        _LOGGER.debug("migrated entry %s to version 5 (certificate auth)", entry.entry_id)
 
     return True
 

--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.selector import (
 )
 
 from . import cloudcourse
+from . import session as session_factory
 from .const import (
     CLIENTHELLO_PROBE_RETRIES,
     CLIENTHELLO_PROBE_TIMEOUT_S,
@@ -742,13 +743,16 @@ def _diagnose_failures(
 
 def _handshake_and_read(host: str, scan: _PortScan, cert_pem: str, key_pem: str) -> dict:
     """Handshake each candidate in turn, returning the first device that answers."""
-    from smartthings_local.protocol.dtls_session import DtlsCoapSession
-
     failures: list[tuple[int, Exception]] = []
     for port in scan.candidates:
         sess = None
         try:
-            sess = DtlsCoapSession(host, port, cert_pem=cert_pem, key_pem=key_pem)
+            sess = session_factory.create_certificate_session(
+                host,
+                port,
+                certificate_pem=cert_pem,
+                private_key_pem=key_pem,
+            )
             sess.connect()
             sess.start_reader()
             return _read_device(sess, host, port)

--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -13,6 +13,7 @@ import selectors
 import socket
 import ssl
 import time
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any
@@ -33,12 +34,16 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+from smartthings_local.errors import AuthenticationError, SessionError
 
 from . import cloudcourse
 from . import session as session_factory
 from .const import (
+    AUTH_CERTIFICATE,
+    AUTH_OWNER_PSK,
     CLIENTHELLO_PROBE_RETRIES,
     CLIENTHELLO_PROBE_TIMEOUT_S,
+    CONF_AUTH_TYPE,
     CONF_BYPASS_REMOTE_CONTROL,
     CONF_CA_CERT_PEM,
     CONF_CA_KEY_PEM,
@@ -52,6 +57,8 @@ from .const import (
     CONF_LEARN_MODES,
     CONF_MANUFACTURER,
     CONF_MODEL,
+    CONF_OWNER_PSK,
+    CONF_OWNER_UUID,
     CONF_PORT,
     CONF_SERIAL,
     DEFAULT_CLOUD_COURSES_ENABLED,
@@ -65,14 +72,23 @@ from .const import (
     PROBE_PORT_RANGE,
     SERVICE_WRITE_RESOURCE,
 )
+from .credentials import (
+    InvalidCredentialConfig,
+    OwnerPskDeviceMismatch,
+    normalize_owner_psk,
+    normalize_owner_uuid,
+    require_matching_ocf_uuid,
+)
 from .devices import find_entry_device
 from .learned import persist as learned_persist
 from .learned import stored as learned_stored
 from .registry.capabilities.laundry import cycle_options, personal_course_labels
+from .registry.identity import read_ocf_device_id
 from .registry.subdevices import MAIN
 
 _TEXT = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT))
 _MULTILINE = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT, multiline=True))
+_PASSWORD = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
 _HYSTERESIS_MINUTES = NumberSelector(
     NumberSelectorConfig(
         min=0,
@@ -93,6 +109,7 @@ _CLOUD_PROBE_INTERVAL_S = 3.0
 _LOGGER = logging.getLogger(__name__)
 
 _SAMSUNG_CLOUD_HOST = "connect-v2.samsungiotcloud.com"
+_REAUTH_TIMEOUT_S = 10.0
 
 
 class CannotConnect(Exception):
@@ -811,6 +828,43 @@ def _probe_and_validate(
     return {**info, "leaf_cert_pem": cert_pem, "leaf_key_pem": key_pem}
 
 
+def _verify_owner_psk(
+    host: str,
+    port: int,
+    device_key: str,
+    owner_uuid: str,
+    owner_psk: str,
+) -> tuple[str, str]:
+    """Validate replacement credentials against the exact peer under one deadline."""
+    normalized_uuid = normalize_owner_uuid(owner_uuid)
+    normalized_psk = normalize_owner_psk(owner_psk)
+    deadline = time.monotonic() + _REAUTH_TIMEOUT_S
+
+    def remaining() -> float:
+        value = deadline - time.monotonic()
+        if value <= 0:
+            raise TimeoutError("OwnerPSK validation timed out")
+        return value
+
+    sess = session_factory.create_owner_psk_session(
+        host,
+        port,
+        owner_uuid=normalized_uuid,
+        owner_psk=normalized_psk,
+    )
+    try:
+        sess.connect(timeout=remaining())
+        sess.start_reader()
+        require_matching_ocf_uuid(
+            device_key,
+            read_ocf_device_id(sess, timeout=remaining()),
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            sess.close()
+    return normalized_uuid, normalized_psk
+
+
 class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # v3 relabels the particulate sensors' recorded statistics; a freshly
     # created entry has none to relabel, so it starts at the migrated
@@ -818,7 +872,9 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # v4 keys the entry on the OCF device UUID (issue #381), which the probe
     # below resolves up front -- so a new entry is already on the v4 shape
     # and has nothing to re-key either.
-    VERSION = 4
+    # v5 adds an explicit auth discriminator. Existing entries migrate to
+    # certificate mode without changing any credential or identity value.
+    VERSION = 5
 
     def __init__(self) -> None:
         self._host: str = ""
@@ -848,6 +904,7 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data={
                 CONF_HOST: self._host,
                 CONF_PORT: info["port"],
+                CONF_AUTH_TYPE: AUTH_CERTIFICATE,
                 CONF_CA_CERT_PEM: self._ca_cert_pem,
                 CONF_CA_KEY_PEM: self._ca_key_pem,
                 CONF_LEAF_CERT_PEM: info["leaf_cert_pem"],
@@ -862,7 +919,12 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         existing = self.hass.config_entries.async_entries(DOMAIN)
-        has_creds = bool(existing)
+        certificate_entries = [
+            entry
+            for entry in existing
+            if entry.data.get(CONF_AUTH_TYPE, AUTH_CERTIFICATE) == AUTH_CERTIFICATE
+        ]
+        has_creds = bool(certificate_entries)
 
         errors: dict[str, str] = {}
 
@@ -870,10 +932,11 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._host = user_input[CONF_HOST].strip()
             existing_leaf = None
             if has_creds:
-                self._ca_cert_pem = existing[0].data[CONF_CA_CERT_PEM]
-                self._ca_key_pem = existing[0].data[CONF_CA_KEY_PEM]
-                leaf_cert = existing[0].data.get(CONF_LEAF_CERT_PEM)
-                leaf_key = existing[0].data.get(CONF_LEAF_KEY_PEM)
+                reusable_entry = certificate_entries[0]
+                self._ca_cert_pem = reusable_entry.data[CONF_CA_CERT_PEM]
+                self._ca_key_pem = reusable_entry.data[CONF_CA_KEY_PEM]
+                leaf_cert = reusable_entry.data.get(CONF_LEAF_CERT_PEM)
+                leaf_key = reusable_entry.data.get(CONF_LEAF_KEY_PEM)
                 if leaf_cert and leaf_key:
                     existing_leaf = (leaf_cert, leaf_key)
             else:
@@ -972,6 +1035,80 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # showing it here means a user filing the device-support issue
             # this step asks for can quote it without digging through logs.
             description_placeholders={"model": info.get("model") or "unknown"},
+        )
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> ConfigFlowResult:
+        """Start Home Assistant's standard reauthentication flow for OwnerPSK."""
+        if entry_data.get(CONF_AUTH_TYPE, AUTH_CERTIFICATE) != AUTH_OWNER_PSK:
+            return self.async_abort(reason="reauth_not_supported")
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle user-initiated OwnerPSK replacement."""
+        entry = self._get_reconfigure_entry()
+        if entry.data.get(CONF_AUTH_TYPE, AUTH_CERTIFICATE) != AUTH_OWNER_PSK:
+            return self.async_abort(reason="reauth_not_supported")
+        return await self.async_step_reauth_confirm(user_input)
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Validate replacement OwnerPSK credentials before storing them."""
+        entry = (
+            self._get_reconfigure_entry()
+            if self.source == config_entries.SOURCE_RECONFIGURE
+            else self._get_reauth_entry()
+        )
+        if entry.data.get(CONF_AUTH_TYPE, AUTH_CERTIFICATE) != AUTH_OWNER_PSK:
+            return self.async_abort(reason="reauth_not_supported")
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                owner_uuid, owner_psk = await self.hass.async_add_executor_job(
+                    _verify_owner_psk,
+                    entry.data[CONF_HOST],
+                    entry.data[CONF_PORT],
+                    entry.data[CONF_DEVICE_KEY],
+                    user_input[CONF_OWNER_UUID],
+                    user_input[CONF_OWNER_PSK],
+                )
+            except (AuthenticationError, InvalidCredentialConfig, OwnerPskDeviceMismatch):
+                errors["base"] = "invalid_auth"
+            except (SessionError, TimeoutError, OSError) as exc:
+                _LOGGER.warning(
+                    "OwnerPSK reauthentication of %s could not connect [%s]",
+                    entry.data[CONF_HOST],
+                    type(exc).__name__,
+                )
+                errors["base"] = "psk_cannot_connect"
+            except Exception as exc:
+                _LOGGER.error(
+                    "Unexpected OwnerPSK reauthentication failure [%s]",
+                    type(exc).__name__,
+                )
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={
+                        CONF_OWNER_UUID: owner_uuid,
+                        CONF_OWNER_PSK: owner_psk,
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_OWNER_UUID): _TEXT,
+                    vol.Required(CONF_OWNER_PSK): _PASSWORD,
+                }
+            ),
+            description_placeholders={"device": entry.title},
+            errors=errors,
         )
 
 

--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -1099,11 +1099,19 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
+        suggested_owner_uuid = (
+            user_input.get(CONF_OWNER_UUID, entry.data[CONF_OWNER_UUID])
+            if user_input is not None
+            else entry.data[CONF_OWNER_UUID]
+        )
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_OWNER_UUID): _TEXT,
+                    vol.Required(
+                        CONF_OWNER_UUID,
+                        description={"suggested_value": suggested_owner_uuid},
+                    ): _TEXT,
                     vol.Required(CONF_OWNER_PSK): _PASSWORD,
                 }
             ),

--- a/custom_components/localthings/const.py
+++ b/custom_components/localthings/const.py
@@ -15,10 +15,15 @@ PLATFORMS = [
 
 CONF_HOST = "host"
 CONF_PORT = "port"
+CONF_AUTH_TYPE = "auth_type"
+AUTH_CERTIFICATE = "certificate"
+AUTH_OWNER_PSK = "owner_psk"
 CONF_CA_CERT_PEM = "ca_cert_pem"
 CONF_CA_KEY_PEM = "ca_key_pem"
 CONF_LEAF_CERT_PEM = "leaf_cert_pem"
 CONF_LEAF_KEY_PEM = "leaf_key_pem"
+CONF_OWNER_UUID = "owner_uuid"
+CONF_OWNER_PSK = "owner_psk"
 
 # Device identity, resolved once by the config flow's probe and persisted
 # on the entry (issue #236) -- what the coordinator mints registry keys

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -16,11 +16,16 @@ from typing import Any, cast
 import cbor2
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    HomeAssistantError,
+    ServiceValidationError,
+)
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from smartthings_local.errors import AuthenticationError
 from smartthings_local.ocf.state_cache import StateCache
 from smartthings_local.protocol.dtls_session import DtlsCoapSession
 
@@ -29,14 +34,14 @@ from . import session as session_factory
 from .cloudcourse import CloudCourses
 from .cloudcourse import persist as cloud_persist
 from .const import (
+    AUTH_OWNER_PSK,
+    CONF_AUTH_TYPE,
     CONF_BYPASS_REMOTE_CONTROL,
     CONF_CLOUD_COURSES,
     CONF_CLOUD_COURSES_ENABLED,
     CONF_DEVICE_KEY,
     CONF_DEVICE_TYPE,
     CONF_HOST,
-    CONF_LEAF_CERT_PEM,
-    CONF_LEAF_KEY_PEM,
     CONF_LEARN_MODES,
     CONF_LEARNED_MODES,
     CONF_MANUFACTURER,
@@ -49,6 +54,11 @@ from .const import (
     DOMAIN,
     DTLS_LOCAL_PORT_BASE,
     SUMMARY_INTERVAL_S,
+)
+from .credentials import (
+    InvalidCredentialConfig,
+    OwnerPskDeviceMismatch,
+    require_matching_ocf_uuid,
 )
 from .devices import set_via_device
 from .learned import LEARNABLE, LearnedModes, persist
@@ -72,6 +82,7 @@ from .registry.identity import (
     device_display_name,
     ocf_device_key,
     read_identity,
+    read_ocf_device_id,
     resolve_model,
     resolve_serial,
 )
@@ -799,19 +810,26 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _connect_session(self) -> None:
         host = self._entry.data[CONF_HOST]
         port = self._entry.data[CONF_PORT]
-        cert_pem = self._entry.data[CONF_LEAF_CERT_PEM]
-        key_pem = self._entry.data[CONF_LEAF_KEY_PEM]
+        auth_type = self._entry.data.get(CONF_AUTH_TYPE)
 
-        sess = session_factory.create_certificate_session(
-            host,
-            port,
-            certificate_pem=cert_pem,
-            private_key_pem=key_pem,
+        sess = session_factory.create_entry_session(
+            self._entry.data,
             on_notification=self._observe.on_notification,
             local_port=_local_source_port(host),
         )
-        sess.connect()
-        sess.start_reader()
+        try:
+            sess.connect()
+            sess.start_reader()
+            if auth_type == AUTH_OWNER_PSK:
+                reported_device_id = read_ocf_device_id(sess)
+                require_matching_ocf_uuid(
+                    self._entry.data[CONF_DEVICE_KEY],
+                    reported_device_id,
+                )
+        except Exception:
+            with contextlib.suppress(Exception):
+                sess.close()
+            raise
         self._session = sess
         self._log.debug("DTLS connected to %s:%d", host, port)
         try:
@@ -1739,6 +1757,23 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return flatten(self.bound, self.entity_resources())
         raise UpdateFailed(f"{what}: {e}") from e
 
+    def _raise_if_owner_psk_auth_failed(self, error: Exception) -> None:
+        """Translate only definitive OwnerPSK failures into HA reauthentication.
+
+        A generic ``SessionError`` is deliberately not sufficient: current
+        smartthings-local releases use it for both a rejected handshake and
+        endpoint/backend failures. Treating every one as bad credentials would
+        turn an ordinary network outage into a reauthentication prompt.
+        """
+        if self._entry.data.get(CONF_AUTH_TYPE) != AUTH_OWNER_PSK:
+            return
+        if isinstance(error, InvalidCredentialConfig):
+            raise ConfigEntryAuthFailed("stored OwnerPSK credentials are invalid") from error
+        if isinstance(error, OwnerPskDeviceMismatch):
+            raise ConfigEntryAuthFailed("OwnerPSK device identity did not match") from error
+        if isinstance(error, AuthenticationError):
+            raise ConfigEntryAuthFailed("OwnerPSK authentication failed") from error
+
     # ------------------------------------------------------------------
     # DataUpdateCoordinator hook
     # ------------------------------------------------------------------
@@ -1754,6 +1789,7 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 resources = await self.hass.async_add_executor_job(self._poll_once)
                 self._mark_device_answered()
             except Exception as e:
+                self._raise_if_owner_psk_auth_failed(e)
                 if self._defer_reconnect_for(e):
                     self._log.debug(
                         "poll failed (%s), not yet treated as session "
@@ -1785,6 +1821,7 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 try:
                     resources = await self.hass.async_add_executor_job(self._poll_once)
                 except Exception as e2:
+                    self._raise_if_owner_psk_auth_failed(e2)
                     return self._device_unreachable("poll failed after reconnect", e2)
                 else:
                     self._mark_device_answered()

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -25,6 +25,7 @@ from smartthings_local.ocf.state_cache import StateCache
 from smartthings_local.protocol.dtls_session import DtlsCoapSession
 
 from . import cloudcourse
+from . import session as session_factory
 from .cloudcourse import CloudCourses
 from .cloudcourse import persist as cloud_persist
 from .const import (
@@ -801,11 +802,11 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         cert_pem = self._entry.data[CONF_LEAF_CERT_PEM]
         key_pem = self._entry.data[CONF_LEAF_KEY_PEM]
 
-        sess = DtlsCoapSession(
+        sess = session_factory.create_certificate_session(
             host,
             port,
-            cert_pem=cert_pem,
-            key_pem=key_pem,
+            certificate_pem=cert_pem,
+            private_key_pem=key_pem,
             on_notification=self._observe.on_notification,
             local_port=_local_source_port(host),
         )

--- a/custom_components/localthings/credentials.py
+++ b/custom_components/localthings/credentials.py
@@ -1,0 +1,150 @@
+"""Config-entry authentication models that keep credential values opaque."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+from smartthings_local.protocol import auth as protocol_auth
+
+from .const import (
+    AUTH_CERTIFICATE,
+    AUTH_OWNER_PSK,
+    CONF_AUTH_TYPE,
+    CONF_CA_CERT_PEM,
+    CONF_CA_KEY_PEM,
+    CONF_LEAF_CERT_PEM,
+    CONF_LEAF_KEY_PEM,
+    CONF_OWNER_PSK,
+    CONF_OWNER_UUID,
+)
+
+_OWNER_PSK_HEX_RE = re.compile(r"(?:[0-9a-fA-F]{32}|[0-9a-fA-F]{64})\Z")
+_CERTIFICATE_FIELDS = (
+    CONF_CA_CERT_PEM,
+    CONF_CA_KEY_PEM,
+    CONF_LEAF_CERT_PEM,
+    CONF_LEAF_KEY_PEM,
+)
+_OWNER_PSK_FIELDS = (CONF_OWNER_UUID, CONF_OWNER_PSK)
+
+
+class InvalidCredentialConfig(ValueError):
+    """A fixed, credential-safe config-entry validation error."""
+
+
+class OwnerPskDeviceMismatch(Exception):
+    """An authenticated OwnerPSK session reported a different OCF device."""
+
+
+def authentication_type(data: Mapping[str, Any]) -> str:
+    """Return the explicit mode, treating all pre-migration entries as certificates."""
+    value = data.get(CONF_AUTH_TYPE, AUTH_CERTIFICATE)
+    if value not in (AUTH_CERTIFICATE, AUTH_OWNER_PSK):
+        raise InvalidCredentialConfig("unsupported authentication type")
+    return value
+
+
+def is_owner_psk(data: Mapping[str, Any]) -> bool:
+    """Return whether one entry uses an existing OCF OwnerPSK."""
+    return authentication_type(data) == AUTH_OWNER_PSK
+
+
+def normalize_ocf_uuid(value: str) -> str:
+    """Return one canonical, non-zero OCF UUID without echoing invalid input."""
+    try:
+        parsed = UUID(str(value).strip())
+    except (AttributeError, TypeError, ValueError):
+        raise InvalidCredentialConfig("invalid OCF UUID") from None
+    if parsed.int == 0:
+        raise InvalidCredentialConfig("invalid OCF UUID")
+    return str(parsed)
+
+
+def normalize_owner_uuid(value: str) -> str:
+    """Normalize the UUID used as the DTLS PSK client identity."""
+    canonical = normalize_ocf_uuid(value)
+    if b"\x00" in UUID(canonical).bytes:
+        # OpenSSL exposes the identity as a NUL-terminated byte string.
+        raise InvalidCredentialConfig("invalid owner UUID")
+    return canonical
+
+
+def normalize_owner_psk(value: str) -> str:
+    """Normalize a strict 128- or 256-bit OwnerPSK hex string."""
+    normalized = str(value).strip()
+    if _OWNER_PSK_HEX_RE.fullmatch(normalized) is None:
+        raise InvalidCredentialConfig("invalid OwnerPSK")
+    return normalized.lower()
+
+
+def require_matching_ocf_uuid(expected: str, reported: str | None) -> str:
+    """Return the expected UUID only when the authenticated peer matches it."""
+    expected_uuid = normalize_ocf_uuid(expected)
+    try:
+        reported_uuid = normalize_ocf_uuid(reported or "")
+    except InvalidCredentialConfig:
+        raise OwnerPskDeviceMismatch("authenticated OCF device did not match") from None
+    if reported_uuid != expected_uuid:
+        raise OwnerPskDeviceMismatch("authenticated OCF device did not match")
+    return expected_uuid
+
+
+class OwnerPskCredentials:
+    """Immutable OwnerPSK credentials with no value-bearing representation."""
+
+    __slots__ = ("_provider",)
+    _provider: protocol_auth.PskAuth
+
+    def __init__(self, provider: protocol_auth.PskAuth) -> None:
+        object.__setattr__(self, "_provider", provider)
+
+    def __setattr__(self, _name: str, _value: object) -> None:
+        raise AttributeError("OwnerPskCredentials is immutable")
+
+    def __delattr__(self, _name: str) -> None:
+        raise AttributeError("OwnerPskCredentials is immutable")
+
+    @classmethod
+    def from_text(cls, *, owner_uuid: str, owner_psk: str) -> OwnerPskCredentials:
+        """Parse config-entry strings into the narrow protocol provider."""
+        identity = UUID(normalize_owner_uuid(owner_uuid)).bytes
+        key = bytes.fromhex(normalize_owner_psk(owner_psk))
+        return cls(protocol_auth.PskAuth(identity=identity, key=key))
+
+    def authentication_provider(self) -> protocol_auth.PskAuth:
+        """Return the immutable provider without exposing its credential bytes."""
+        return self._provider
+
+    def __repr__(self) -> str:
+        return "OwnerPskCredentials()"
+
+
+def certificate_credentials_from_entry(data: Mapping[str, Any]) -> tuple[str, str]:
+    """Return the one complete, unmixed certificate credential pair."""
+    if authentication_type(data) != AUTH_CERTIFICATE:
+        raise InvalidCredentialConfig("unexpected authentication credentials")
+    if any(field in data for field in _OWNER_PSK_FIELDS):
+        raise InvalidCredentialConfig("mixed authentication credentials")
+    certificate = data.get(CONF_LEAF_CERT_PEM)
+    private_key = data.get(CONF_LEAF_KEY_PEM)
+    if not isinstance(certificate, str) or not certificate:
+        raise InvalidCredentialConfig("missing certificate credentials")
+    if not isinstance(private_key, str) or not private_key:
+        raise InvalidCredentialConfig("missing certificate credentials")
+    return certificate, private_key
+
+
+def owner_psk_credentials_from_entry(data: Mapping[str, Any]) -> tuple[str, str]:
+    """Return the one complete, unmixed OwnerPSK credential pair."""
+    if authentication_type(data) != AUTH_OWNER_PSK:
+        raise InvalidCredentialConfig("unexpected authentication credentials")
+    if any(field in data for field in _CERTIFICATE_FIELDS):
+        raise InvalidCredentialConfig("mixed authentication credentials")
+    owner_uuid = data.get(CONF_OWNER_UUID)
+    owner_psk = data.get(CONF_OWNER_PSK)
+    if not isinstance(owner_uuid, str) or not isinstance(owner_psk, str):
+        raise InvalidCredentialConfig("missing OwnerPSK credentials")
+    return owner_uuid, owner_psk

--- a/custom_components/localthings/diagnostics.py
+++ b/custom_components/localthings/diagnostics.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.loader import async_get_integration
 
 from . import cloudcourse
-from .const import DOMAIN
+from .const import AUTH_CERTIFICATE, CONF_AUTH_TYPE, DOMAIN
 from .coordinator import LocalThingsCoordinator
 from .registry.capabilities.laundry import cycle_options
 from .registry.encode import json_safe
@@ -79,6 +79,7 @@ async def async_get_config_entry_diagnostics(
     # for why a dump can contain something JSON has no form for.
     return json_safe(
         {
+            "auth_type": entry.data.get(CONF_AUTH_TYPE, AUTH_CERTIFICATE),
             "device_type": coordinator.device_type_name or "unknown",
             "one_ui_version": coordinator.one_ui_version,
             "identity": {

--- a/custom_components/localthings/registry/identity.py
+++ b/custom_components/localthings/registry/identity.py
@@ -156,6 +156,26 @@ def _get(sess, path) -> dict:
     return {}
 
 
+def read_ocf_device_id(sess, *, timeout: float = 10.0) -> str | None:
+    """Read only ``/oic/d`` and return its device UUID.
+
+    Unlike the best-effort identity diagnostics below, transport failures
+    propagate so callers can distinguish an unreachable peer from a peer
+    that authenticated but claimed the wrong identity.
+    """
+    code, payload = sess.get(["oic", "d"], timeout=timeout)
+    if code != 0x45 or not payload:
+        return None
+    try:
+        body = cbor2.loads(payload)
+    except (TypeError, ValueError, cbor2.CBORDecodeError):
+        return None
+    if not isinstance(body, dict):
+        return None
+    device_id = body.get("di")
+    return device_id if isinstance(device_id, str) else None
+
+
 def _get_links(sess, path) -> list:
     """Like _get, but for /oic/res: a baseline-Interface RETRIEVE on it
     returns a CBOR array of Link objects (href/rt/if/di/...), not a single

--- a/custom_components/localthings/registry/redact.py
+++ b/custom_components/localthings/registry/redact.py
@@ -28,6 +28,8 @@ _SENSITIVE_SUBSTRINGS = (
     "duid",
     "password",
     "secret",
+    "psk",
+    "credential",
 )
 
 # Matched whole, not as substrings: these are bare one/two-letter keys too

--- a/custom_components/localthings/session.py
+++ b/custom_components/localthings/session.py
@@ -1,0 +1,55 @@
+"""Authentication providers and DTLS session construction."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from smartthings_local.protocol import auth as protocol_auth
+from smartthings_local.protocol import dtls_session
+
+NotificationCallback = Callable[[str, bytes], None]
+
+
+def create_certificate_auth(
+    certificate_pem: str,
+    private_key_pem: str,
+) -> protocol_auth.CertificateAuth:
+    """Create the existing in-memory certificate authentication provider."""
+    return protocol_auth.CertificateAuth.from_memory(certificate_pem, private_key_pem)
+
+
+def create_dtls_session(
+    host: str,
+    port: int,
+    *,
+    auth: protocol_auth.AuthenticationProvider,
+    on_notification: NotificationCallback | None = None,
+    local_port: int | None = None,
+) -> dtls_session.DtlsCoapSession:
+    """Construct a DTLS session without starting network I/O."""
+    return dtls_session.DtlsCoapSession(
+        host,
+        port,
+        auth=auth,
+        on_notification=on_notification,
+        local_port=local_port,
+    )
+
+
+def create_certificate_session(
+    host: str,
+    port: int,
+    *,
+    certificate_pem: str,
+    private_key_pem: str,
+    on_notification: NotificationCallback | None = None,
+    local_port: int | None = None,
+) -> dtls_session.DtlsCoapSession:
+    """Construct a session with the existing certificate authentication."""
+    return create_dtls_session(
+        host,
+        port,
+        auth=create_certificate_auth(certificate_pem, private_key_pem),
+        on_notification=on_notification,
+        local_port=local_port,
+    )

--- a/custom_components/localthings/session.py
+++ b/custom_components/localthings/session.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from typing import Any
 
 from smartthings_local.protocol import auth as protocol_auth
 from smartthings_local.protocol import dtls_session
+
+from .const import (
+    AUTH_CERTIFICATE,
+    CONF_HOST,
+    CONF_PORT,
+)
+from .credentials import (
+    OwnerPskCredentials,
+    authentication_type,
+    certificate_credentials_from_entry,
+    owner_psk_credentials_from_entry,
+)
 
 NotificationCallback = Callable[[str, bytes], None]
 
@@ -50,6 +63,69 @@ def create_certificate_session(
         host,
         port,
         auth=create_certificate_auth(certificate_pem, private_key_pem),
+        on_notification=on_notification,
+        local_port=local_port,
+    )
+
+
+def create_owner_psk_auth(
+    owner_uuid: str,
+    owner_psk: str,
+) -> protocol_auth.PskAuth:
+    """Create a PSK provider from an existing OCF owner credential."""
+    return OwnerPskCredentials.from_text(
+        owner_uuid=owner_uuid,
+        owner_psk=owner_psk,
+    ).authentication_provider()
+
+
+def create_owner_psk_session(
+    host: str,
+    port: int,
+    *,
+    owner_uuid: str,
+    owner_psk: str,
+    on_notification: NotificationCallback | None = None,
+    local_port: int | None = None,
+) -> dtls_session.DtlsCoapSession:
+    """Construct a session from an existing OCF OwnerPSK."""
+    return create_dtls_session(
+        host,
+        port,
+        auth=create_owner_psk_auth(owner_uuid, owner_psk),
+        on_notification=on_notification,
+        local_port=local_port,
+    )
+
+
+def authentication_provider_from_entry(
+    data: Mapping[str, Any],
+) -> protocol_auth.AuthenticationProvider:
+    """Build exactly one provider through the shared authentication factories."""
+    if authentication_type(data) == AUTH_CERTIFICATE:
+        certificate, private_key = certificate_credentials_from_entry(data)
+        return create_certificate_auth(certificate, private_key)
+    owner_uuid, owner_psk = owner_psk_credentials_from_entry(data)
+    return create_owner_psk_auth(owner_uuid, owner_psk)
+
+
+def create_entry_session(
+    data: Mapping[str, Any],
+    *,
+    on_notification: NotificationCallback | None = None,
+    local_port: int | None = None,
+) -> dtls_session.DtlsCoapSession:
+    """Construct the session selected by one complete config entry."""
+    host = data.get(CONF_HOST)
+    port = data.get(CONF_PORT)
+    if not isinstance(host, str) or not host:
+        raise ValueError("missing session endpoint")
+    if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
+        raise ValueError("invalid session endpoint")
+    return create_dtls_session(
+        host,
+        port,
+        auth=authentication_provider_from_entry(data),
         on_notification=on_notification,
         local_port=local_port,
     )

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -1522,6 +1522,18 @@
       "confirm_unknown_type": {
         "title": "Typ spotřebiče nebyl rozpoznán",
         "description": "Tento spotřebič hlásí model „{model}“, což je typ, který LocalThings zatím nerozpoznává. Přesto bude přidán, ale pouze se společnými funkcemi (napájení, alarmy atd., pokud jsou k dispozici), nikoli s plnou sadou funkcí pro danou rodinu spotřebičů. Podporu můžete později pomoci rozšířit stažením diagnostiky pro toto zařízení (Nastavení > Zařízení a služby > toto zařízení > nabídka > Stáhnout diagnostiku) a jejím vložením do nového issue. Odesláním zařízení přidáte i tak."
+      },
+      "reauth_confirm": {
+        "title": "Opětovné ověření OwnerPSK",
+        "description": "Zadejte existující přihlašovací údaje vlastníka OCF pro zařízení {device}. LocalThings pouze ověří a uloží údaje, které již máte; nezískává je, neodvozuje, nezavádí, neobnovuje ani nepřevádí vlastnictví.",
+        "data": {
+          "owner_uuid": "UUID vlastníka",
+          "owner_psk": "OwnerPSK"
+        },
+        "data_description": {
+          "owner_uuid": "UUID vlastníka OCF používané jako 16bajtová identita klienta PSK.",
+          "owner_psk": "Existující 128bitový nebo 256bitový OwnerPSK zapsaný šestnáctkově."
+        }
       }
     },
     "error": {
@@ -1534,11 +1546,14 @@
       "cloud_unreachable": "Nepodařilo se spojit s cloudovou bránou Samsung a získat UUID potřebné k vystavení certifikátu tohoto zařízení. Zkontrolujte přístup Home Assistanta k internetu a zkuste to znovu.",
       "unexpected_response": "Připojení k zařízení proběhlo úspěšně, ale nevrátilo použitelný popis zařízení. Nemusí jít o spotřebič, který tato integrace podporuje. Co zařízení odeslalo, najdete v logu Home Assistanta.",
       "cannot_connect": "Nelze se připojit k zařízení. Ověřte, že je IP adresa dostupná a že jsou přihlašovací údaje CA správné.",
+      "invalid_auth": "Přihlašovací údaje OwnerPSK byly odmítnuty nebo patří jinému zařízení OCF.",
+      "psk_cannot_connect": "Ke nakonfigurovanému koncovému bodu OCF se nelze připojit. Uložené přihlašovací údaje nebyly změněny.",
       "invalid_ca": "Certifikát CA nebo privátní klíč se nepodařilo načíst. Ověřte, že obsah PEM je správný a že klíč odpovídá certifikátu.",
       "unknown": "Neočekávaná chyba. Podrobnosti najdete v protokolech Home Assistant."
     },
     "abort": {
-      "already_configured": "Zařízení je již nakonfigurováno"
+      "already_configured": "Zařízení je již nakonfigurováno",
+      "reauth_not_supported": "Tato položka nepoužívá ověřování OwnerPSK."
     }
   },
   "options": {

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -1522,6 +1522,18 @@
       "confirm_unknown_type": {
         "title": "Gerätetyp nicht erkannt",
         "description": "Dieses Gerät hat das Modell \"{model}\" gemeldet, das LocalThings noch nicht als bekannten Typ erkennt. Es wird trotzdem hinzugefügt, jedoch nur mit allgemeinen Funktionen (z. B. Ein/Aus, Alarme, sofern vorhanden) und nicht mit dem vollständigen Funktionsumfang seiner Gerätefamilie. Sie können später helfen, die vollständige Unterstützung hinzuzufügen, indem Sie die Diagnosedaten für dieses Gerät herunterladen (Einstellungen > Geräte & Dienste > dieses Gerät > das Menü > Diagnose herunterladen) und sie in einem neuen Issue einreichen. Bestätigen Sie, um es trotzdem hinzuzufügen."
+      },
+      "reauth_confirm": {
+        "title": "OwnerPSK erneut authentifizieren",
+        "description": "Geben Sie die vorhandenen OCF-Eigentümerzugangsdaten für {device} ein. LocalThings validiert und speichert nur bereits vorhandene Zugangsdaten; es erwirbt, leitet, provisioniert oder rotiert sie nicht und überträgt kein Eigentum.",
+        "data": {
+          "owner_uuid": "Eigentümer-UUID",
+          "owner_psk": "OwnerPSK"
+        },
+        "data_description": {
+          "owner_uuid": "Die OCF-Eigentümer-UUID als 16-Byte-PSK-Clientidentität.",
+          "owner_psk": "Der vorhandene, hexadezimal codierte 128- oder 256-Bit-OwnerPSK."
+        }
       }
     },
     "error": {
@@ -1534,11 +1546,14 @@
       "cloud_unreachable": "Das Cloud-Gateway von Samsung konnte nicht erreicht werden, um die für die Zertifikatserstellung dieses Geräts benötigte UUID abzurufen. Prüfen Sie den Internetzugang von Home Assistant und versuchen Sie es erneut.",
       "unexpected_response": "Die Verbindung zum Gerät war erfolgreich, es hat jedoch keine verwendbare Gerätebeschreibung zurückgegeben. Möglicherweise wird dieses Gerät von der Integration nicht unterstützt. Weitere Informationen in den Logs.",
       "cannot_connect": "Verbindung zum Gerät nicht möglich. Prüfen Sie, ob die IP-Adresse erreichbar und die CA-Zugangsdaten korrekt sind.",
+      "invalid_auth": "Die OwnerPSK-Zugangsdaten wurden abgelehnt oder gehören zu einem anderen OCF-Gerät.",
+      "psk_cannot_connect": "Der konfigurierte OCF-Endpunkt ist nicht erreichbar. Die gespeicherten Zugangsdaten wurden nicht geändert.",
       "invalid_ca": "Das CA-Zertifikat oder der Privatschlüssel konnte nicht geladen werden. Prüfen Sie, ob der PEM-Inhalt korrekt ist und der Schlüssel zum Zertifikat passt.",
       "unknown": "Unerwarteter Fehler. Weitere Informationen in den Logs."
     },
     "abort": {
-      "already_configured": "Gerät ist bereits konfiguriert"
+      "already_configured": "Gerät ist bereits konfiguriert",
+      "reauth_not_supported": "Dieser Eintrag verwendet keine OwnerPSK-Authentifizierung."
     }
   },
   "options": {

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -1522,6 +1522,18 @@
       "confirm_unknown_type": {
         "title": "Appliance type not recognized",
         "description": "This appliance reported model \"{model}\", which isn't a type LocalThings recognizes yet. It'll still be added, but only with common capabilities (power, alarms, etc. where present) rather than the full set for its family. You can help add full support afterward by downloading diagnostics for this device (Settings > Devices & Services > this device > the menu > Download diagnostics) and filing them in a new issue. Submit to add it anyway."
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate OwnerPSK",
+        "description": "Enter the existing OCF owner credential for {device}. LocalThings only validates and stores a credential you already possess; it does not acquire, derive, provision, rotate, or transfer ownership.",
+        "data": {
+          "owner_uuid": "Owner UUID",
+          "owner_psk": "OwnerPSK"
+        },
+        "data_description": {
+          "owner_uuid": "The OCF owner UUID used as the 16-byte PSK client identity.",
+          "owner_psk": "The existing 128- or 256-bit OwnerPSK, encoded as hexadecimal."
+        }
       }
     },
     "error": {
@@ -1534,11 +1546,14 @@
       "cloud_unreachable": "Couldn't reach Samsung's cloud gateway to fetch the UUID needed to mint this device's certificate. Check Home Assistant's internet access and try again.",
       "unexpected_response": "Connected to the device successfully, but it didn't return a usable device description. It may not be an appliance this integration supports. The Home Assistant log records what it sent.",
       "cannot_connect": "Cannot connect to the device. Verify the IP address is reachable and the CA credentials are correct.",
+      "invalid_auth": "The OwnerPSK credential was rejected or belongs to a different OCF device.",
+      "psk_cannot_connect": "Could not reach the configured OCF endpoint. The stored credential was not changed.",
       "invalid_ca": "The CA certificate or private key could not be loaded. Verify the PEM contents are correct and the key matches the certificate.",
       "unknown": "Unexpected error. Check the Home Assistant logs for details."
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_not_supported": "This entry does not use OwnerPSK authentication."
     }
   },
   "options": {

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -28,6 +28,18 @@
       "confirm_unknown_type": {
         "title": "Tipo de electrodoméstico no reconocido",
         "description": "Este electrodoméstico informa del modelo «{model}», un tipo que LocalThings aún no reconoce. Se añadirá igualmente, pero solo con las capacidades comunes (alimentación, alarmas, etc. donde existan) en lugar del conjunto completo de su familia. Puedes ayudar a añadir soporte completo después descargando los diagnósticos de este dispositivo (Ajustes > Dispositivos y servicios > este dispositivo > el menú > Descargar diagnósticos) y reportándolos en una nueva incidencia. Envía para añadirlo de todos modos."
+      },
+      "reauth_confirm": {
+        "title": "Volver a autenticar OwnerPSK",
+        "description": "Introduce las credenciales de propietario OCF existentes para {device}. LocalThings solo valida y guarda credenciales que ya posees; no las obtiene, deriva, aprovisiona ni rota, ni transfiere la propiedad.",
+        "data": {
+          "owner_uuid": "UUID del propietario",
+          "owner_psk": "OwnerPSK"
+        },
+        "data_description": {
+          "owner_uuid": "El UUID de propietario OCF usado como identidad de cliente PSK de 16 bytes.",
+          "owner_psk": "El OwnerPSK existente de 128 o 256 bits, codificado en hexadecimal."
+        }
       }
     },
     "error": {
@@ -40,11 +52,14 @@
       "cloud_unreachable": "No se pudo contactar con la pasarela en la nube de Samsung para obtener el UUID necesario para emitir el certificado de este dispositivo. Comprueba el acceso a internet de Home Assistant e inténtalo de nuevo.",
       "unexpected_response": "La conexión con el dispositivo se estableció correctamente, pero no devolvió una descripción de dispositivo utilizable. Puede que no sea un electrodoméstico compatible con esta integración. El registro de Home Assistant recoge lo que envió.",
       "cannot_connect": "No se puede conectar con el dispositivo. Comprueba que la dirección IP sea accesible y que las credenciales CA sean correctas.",
+      "invalid_auth": "Las credenciales OwnerPSK fueron rechazadas o pertenecen a otro dispositivo OCF.",
+      "psk_cannot_connect": "No se pudo alcanzar el extremo OCF configurado. Las credenciales guardadas no se modificaron.",
       "invalid_ca": "No se ha podido cargar el certificado CA o la clave privada. Comprueba que el contenido PEM sea correcto y que la clave coincida con el certificado.",
       "unknown": "Error inesperado. Consulta los registros de Home Assistant para más detalles."
     },
     "abort": {
-      "already_configured": "El dispositivo ya está configurado"
+      "already_configured": "El dispositivo ya está configurado",
+      "reauth_not_supported": "Esta entrada no usa autenticación OwnerPSK."
     }
   },
   "options": {

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -1522,6 +1522,18 @@
       "confirm_unknown_type": {
         "title": "Tipo di elettrodomestico non riconosciuto",
         "description": "Questo apparecchio dichiara il modello \"{model}\", un tipo che LocalThings non riconosce ancora. Verrà comunque aggiunto, ma solo con le funzionalità di base (alimentazione, allarmi, ... se presenti) anziché con tutte le funzionalità della sua famiglia. Puoi contribuire all'aggiunta del supporto completo in seguito scaricando i dati diagnostici per questo dispositivo (Impostazioni > Dispositivi e servizi > questo dispositivo > il menu > Scarica diagnostica) e inviandoli in una nuova segnalazione. Invia comunque la segnalazione per aggiungerlo."
+      },
+      "reauth_confirm": {
+        "title": "Ripeti l'autenticazione OwnerPSK",
+        "description": "Inserisci le credenziali proprietario OCF esistenti per {device}. LocalThings convalida e salva solo credenziali già in tuo possesso; non le acquisisce, deriva, configura o ruota e non trasferisce la proprietà.",
+        "data": {
+          "owner_uuid": "UUID proprietario",
+          "owner_psk": "OwnerPSK"
+        },
+        "data_description": {
+          "owner_uuid": "L'UUID proprietario OCF usato come identità client PSK di 16 byte.",
+          "owner_psk": "L'OwnerPSK esistente a 128 o 256 bit, codificato in esadecimale."
+        }
       }
     },
     "error": {
@@ -1534,11 +1546,14 @@
       "cloud_unreachable": "Impossibile raggiungere il gateway cloud di Samsung per ottenere l'UUID necessario a emettere il certificato di questo dispositivo. Verifica l'accesso a internet di Home Assistant e riprova.",
       "unexpected_response": "Connessione al dispositivo riuscita, ma non ha restituito una descrizione del dispositivo utilizzabile. Potrebbe non essere un apparecchio supportato da questa integrazione. Il log di Home Assistant riporta ciò che ha inviato.",
       "cannot_connect": "Impossibile connettersi al dispositivo. Verificare che l'indirizzo IP sia raggiungibile e che le credenziali CA siano corrette.",
+      "invalid_auth": "Le credenziali OwnerPSK sono state rifiutate o appartengono a un altro dispositivo OCF.",
+      "psk_cannot_connect": "Impossibile raggiungere l'endpoint OCF configurato. Le credenziali salvate non sono state modificate.",
       "invalid_ca": "Impossibile caricare il certificato CA o la chiave privata. Verificare che il contenuto del file PEM sia corretto e che la chiave corrisponda al certificato.",
       "unknown": "Errore imprevisto. Controlla i registri di Home Assistant per i dettagli."
     },
     "abort": {
-      "already_configured": "Il dispositivo è già configurato"
+      "already_configured": "Il dispositivo è già configurato",
+      "reauth_not_supported": "Questa voce non usa l'autenticazione OwnerPSK."
     }
   },
   "options": {

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -1522,6 +1522,18 @@
       "confirm_unknown_type": {
         "title": "가전제품 유형을 인식할 수 없음",
         "description": "이 가전제품이 보고한 모델은 \"{model}\"이며, 아직 LocalThings에서 인식하는 유형이 아닙니다. 그래도 추가할 수 있지만, 해당 제품군의 전체 기능 대신 공통 기능(전원, 알림 등 기기에서 제공하는 기능)만 사용할 수 있습니다. 나중에 이 기기의 진단 정보를 다운로드(설정 > 기기 및 서비스 > 이 기기 > 메뉴 > 진단 정보 다운로드)하여 새 이슈에 첨부하면 전체 기능 지원을 추가하는 데 도움을 줄 수 있습니다. 그래도 추가하려면 제출을 선택하세요."
+      },
+      "reauth_confirm": {
+        "title": "OwnerPSK 다시 인증",
+        "description": "{device}의 기존 OCF 소유자 인증 정보를 입력하세요. LocalThings는 사용자가 이미 보유한 인증 정보만 검증하고 저장하며, 이를 획득·파생·프로비저닝·교체하거나 소유권을 이전하지 않습니다.",
+        "data": {
+          "owner_uuid": "소유자 UUID",
+          "owner_psk": "OwnerPSK"
+        },
+        "data_description": {
+          "owner_uuid": "16바이트 PSK 클라이언트 식별자로 사용하는 OCF 소유자 UUID입니다.",
+          "owner_psk": "16진수로 인코딩된 기존 128비트 또는 256비트 OwnerPSK입니다."
+        }
       }
     },
     "error": {
@@ -1534,11 +1546,14 @@
       "cloud_unreachable": "이 기기의 인증서 발급에 필요한 UUID를 가져오기 위해 삼성 클라우드 게이트웨이에 연결할 수 없습니다. Home Assistant의 인터넷 연결을 확인한 후 다시 시도하세요.",
       "unexpected_response": "기기에 연결했지만 사용할 수 있는 기기 설명을 반환하지 않았습니다. 이 통합 구성요소에서 지원하는 가전제품이 아닐 수 있습니다. 기기가 보낸 내용은 Home Assistant 로그에 기록됩니다.",
       "cannot_connect": "기기에 연결할 수 없습니다. IP 주소에 연결할 수 있는지와 CA 인증 정보가 올바른지 확인하세요.",
+      "invalid_auth": "OwnerPSK 인증 정보가 거부되었거나 다른 OCF 기기에 속합니다.",
+      "psk_cannot_connect": "구성된 OCF 엔드포인트에 연결할 수 없습니다. 저장된 인증 정보는 변경되지 않았습니다.",
       "invalid_ca": "CA 인증서 또는 개인 키를 불러올 수 없습니다. PEM 내용이 올바르고 키가 인증서와 일치하는지 확인하세요.",
       "unknown": "예기치 않은 오류가 발생했습니다. 자세한 내용은 Home Assistant 로그에서 확인하세요."
     },
     "abort": {
-      "already_configured": "기기가 이미 구성되어 있습니다"
+      "already_configured": "기기가 이미 구성되어 있습니다",
+      "reauth_not_supported": "이 항목은 OwnerPSK 인증을 사용하지 않습니다."
     }
   },
   "options": {

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -1522,6 +1522,18 @@
       "confirm_unknown_type": {
         "title": "Apparaattype niet herkend",
         "description": "Dit apparaat meldt model \"{model}\", een type dat LocalThings nog niet herkent. Het apparaat wordt toch toegevoegd, maar alleen met algemene mogelijkheden (zoals voeding en alarmen, voor zover aanwezig), in plaats van alle mogelijkheden voor deze apparaatfamilie. Je kunt daarna helpen volledige ondersteuning toe te voegen door diagnostische gegevens voor dit apparaat te downloaden (Instellingen > Apparaten & diensten > dit apparaat > het menu > Diagnostische gegevens downloaden) en deze bij een nieuw issue te voegen. Kies Verzenden om het apparaat toch toe te voegen."
+      },
+      "reauth_confirm": {
+        "title": "OwnerPSK opnieuw verifiëren",
+        "description": "Voer de bestaande OCF-eigenaarsgegevens voor {device} in. LocalThings valideert en bewaart alleen gegevens die je al bezit; het verkrijgt, herleidt, provisiont of roteert ze niet en draagt geen eigendom over.",
+        "data": {
+          "owner_uuid": "UUID van eigenaar",
+          "owner_psk": "OwnerPSK"
+        },
+        "data_description": {
+          "owner_uuid": "De OCF-eigenaars-UUID die als 16-byte PSK-clientidentiteit wordt gebruikt.",
+          "owner_psk": "De bestaande 128- of 256-bits OwnerPSK, hexadecimaal gecodeerd."
+        }
       }
     },
     "error": {
@@ -1534,11 +1546,14 @@
       "cloud_unreachable": "Kon de cloudgateway van Samsung niet bereiken om de UUID op te halen die nodig is om het certificaat van dit apparaat aan te maken. Controleer de internettoegang van Home Assistant en probeer het opnieuw.",
       "unexpected_response": "Verbinding met het apparaat is gelukt, maar het gaf geen bruikbare apparaatbeschrijving terug. Mogelijk is het geen apparaat dat deze integratie ondersteunt. Het Home Assistant-logboek bevat wat het stuurde.",
       "cannot_connect": "Kan geen verbinding maken met het apparaat. Controleer of het IP-adres bereikbaar is en de CA-inloggegevens juist zijn.",
+      "invalid_auth": "De OwnerPSK-gegevens zijn geweigerd of horen bij een ander OCF-apparaat.",
+      "psk_cannot_connect": "Het geconfigureerde OCF-eindpunt is niet bereikbaar. De opgeslagen gegevens zijn niet gewijzigd.",
       "invalid_ca": "Het CA-certificaat of de privésleutel kon niet worden geladen. Controleer of de PEM-inhoud juist is en of de sleutel bij het certificaat hoort.",
       "unknown": "Onverwachte fout. Raadpleeg de Home Assistant-logboeken voor meer informatie."
     },
     "abort": {
-      "already_configured": "Apparaat is al geconfigureerd"
+      "already_configured": "Apparaat is al geconfigureerd",
+      "reauth_not_supported": "Deze invoer gebruikt geen OwnerPSK-authenticatie."
     }
   },
   "options": {

--- a/tests/localthings/conftest.py
+++ b/tests/localthings/conftest.py
@@ -15,6 +15,8 @@ from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.localthings.const import (
+    AUTH_CERTIFICATE,
+    CONF_AUTH_TYPE,
     CONF_CA_CERT_PEM,
     CONF_CA_KEY_PEM,
     CONF_DEVICE_KEY,
@@ -100,6 +102,7 @@ MOCK_LEAF_KEY_PEM = "-----BEGIN PRIVATE KEY-----\nTEST-LEAF-KEY\n-----END PRIVAT
 ENTRY_DATA = {
     CONF_HOST: MOCK_HOST,
     CONF_PORT: MOCK_PORT,
+    CONF_AUTH_TYPE: AUTH_CERTIFICATE,
     CONF_CA_CERT_PEM: MOCK_CA_CERT_PEM,
     CONF_CA_KEY_PEM: MOCK_CA_KEY_PEM,
     CONF_LEAF_CERT_PEM: MOCK_LEAF_CERT_PEM,
@@ -282,7 +285,7 @@ def mock_entry(hass):
         domain=DOMAIN,
         data=ENTRY_DATA,
         unique_id=f"localthings_{MOCK_DEVICE_KEY}",
-        version=4,
+        version=5,
     )
     entry.add_to_hass(hass)
     return entry

--- a/tests/localthings/test_config_flow.py
+++ b/tests/localthings/test_config_flow.py
@@ -193,7 +193,7 @@ async def test_setup_normalizes_messy_pasted_pem(hass: HomeAssistant, mock_probe
     assert result["data"][CONF_CA_KEY_PEM] == MOCK_CA_KEY_PEM
 
 
-async def test_owner_psk_reauth_form_never_prefills_the_secret(
+async def test_owner_psk_reauth_form_suggests_uuid_without_prefilling_secret(
     hass: HomeAssistant,
 ) -> None:
     entry = _owner_psk_entry(hass)
@@ -204,9 +204,13 @@ async def test_owner_psk_reauth_form_never_prefills_the_secret(
     assert result["step_id"] == "reauth_confirm"
     schema = result["data_schema"]
     assert schema is not None
-    marker = next(key for key in schema.schema if key == CONF_OWNER_PSK)
-    assert marker.default is vol.UNDEFINED
-    selector = schema.schema[marker]
+    uuid_marker = next(key for key in schema.schema if key == CONF_OWNER_UUID)
+    assert uuid_marker.default is vol.UNDEFINED
+    assert uuid_marker.description == {"suggested_value": _OWNER_UUID}
+    psk_marker = next(key for key in schema.schema if key == CONF_OWNER_PSK)
+    assert psk_marker.default is vol.UNDEFINED
+    assert psk_marker.description is None
+    selector = schema.schema[psk_marker]
     assert isinstance(selector, TextSelector)
     assert selector.config["type"] == "password"
     assert _OWNER_PSK not in repr(result)
@@ -270,6 +274,14 @@ async def test_owner_psk_can_be_reconfigured_manually_without_secret_prefill(
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
+    schema = result["data_schema"]
+    assert schema is not None
+    uuid_marker = next(key for key in schema.schema if key == CONF_OWNER_UUID)
+    assert uuid_marker.default is vol.UNDEFINED
+    assert uuid_marker.description == {"suggested_value": _OWNER_UUID}
+    psk_marker = next(key for key in schema.schema if key == CONF_OWNER_PSK)
+    assert psk_marker.default is vol.UNDEFINED
+    assert psk_marker.description is None
     assert _OWNER_PSK not in repr(result)
 
     with (
@@ -311,6 +323,7 @@ async def test_owner_psk_reauth_failure_keeps_stored_credentials_redacted(
 ) -> None:
     entry = _owner_psk_entry(hass)
     before = dict(entry.data)
+    submitted_uuid = "12121212-3434-4656-8787-9a9a9a9a9a9a"
     submitted_psk = "ffeeddccbbaa99887766554433221100"
 
     result = await start_reauth_flow(hass, entry)
@@ -321,7 +334,7 @@ async def test_owner_psk_reauth_failure_keeps_stored_credentials_redacted(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_OWNER_UUID: _OWNER_UUID,
+                CONF_OWNER_UUID: submitted_uuid,
                 CONF_OWNER_PSK: submitted_psk,
             },
         )
@@ -332,8 +345,12 @@ async def test_owner_psk_reauth_failure_keeps_stored_credentials_redacted(
     assert submitted_psk not in repr(result)
     schema = result["data_schema"]
     assert schema is not None
-    marker = next(key for key in schema.schema if key == CONF_OWNER_PSK)
-    assert marker.default is vol.UNDEFINED
+    uuid_marker = next(key for key in schema.schema if key == CONF_OWNER_UUID)
+    assert uuid_marker.default is vol.UNDEFINED
+    assert uuid_marker.description == {"suggested_value": submitted_uuid}
+    psk_marker = next(key for key in schema.schema if key == CONF_OWNER_PSK)
+    assert psk_marker.default is vol.UNDEFINED
+    assert psk_marker.description is None
 
 
 async def test_certificate_entry_does_not_enter_owner_psk_reauth(

--- a/tests/localthings/test_config_flow.py
+++ b/tests/localthings/test_config_flow.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from typing import ClassVar, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+import voluptuous as vol
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.helpers.selector import TextSelector
+from pytest_homeassistant_custom_component.common import MockConfigEntry, start_reauth_flow
 
 from custom_components.localthings.const import (
+    AUTH_CERTIFICATE,
+    AUTH_OWNER_PSK,
+    CONF_AUTH_TYPE,
     CONF_BYPASS_REMOTE_CONTROL,
     CONF_CA_CERT_PEM,
     CONF_CA_KEY_PEM,
@@ -21,9 +26,15 @@ from custom_components.localthings.const import (
     CONF_LEAF_CERT_PEM,
     CONF_LEARN_MODES,
     CONF_LEARNED_MODES,
+    CONF_OWNER_PSK,
+    CONF_OWNER_UUID,
     CONF_PORT,
     CONF_SERIAL,
     DOMAIN,
+)
+from custom_components.localthings.credentials import (
+    InvalidCredentialConfig,
+    OwnerPskDeviceMismatch,
 )
 
 from .conftest import (
@@ -38,6 +49,30 @@ from .conftest import (
     MOCK_SERIAL,
     _probe_result,
 )
+
+_OWNER_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+_OWNER_PSK = "00112233445566778899aabbccddeeff"
+
+
+def _owner_psk_entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Synthetic OCF device",
+        data={
+            CONF_HOST: "192.0.2.10",
+            CONF_PORT: 5684,
+            CONF_AUTH_TYPE: AUTH_OWNER_PSK,
+            CONF_DEVICE_KEY: "11111111-2222-4333-8444-555555555555",
+            CONF_SERIAL: "SYNTHETIC-SERIAL",
+            CONF_OWNER_UUID: _OWNER_UUID,
+            CONF_OWNER_PSK: _OWNER_PSK,
+        },
+        options={"preserved": True},
+        unique_id="localthings_11111111-2222-4333-8444-555555555555",
+        version=5,
+    )
+    entry.add_to_hass(hass)
+    return entry
 
 
 async def test_form_first_device(hass: HomeAssistant) -> None:
@@ -65,6 +100,59 @@ async def test_form_second_device_reuses_creds(hass: HomeAssistant) -> None:
     assert CONF_CA_KEY_PEM not in data_schema.schema
 
 
+async def test_owner_psk_entry_is_never_a_certificate_reuse_source(
+    hass: HomeAssistant,
+) -> None:
+    """A PSK entry cannot be indexed as though it held a reusable CA key."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.0.2.10",
+            CONF_PORT: 5684,
+            CONF_AUTH_TYPE: AUTH_OWNER_PSK,
+            CONF_DEVICE_KEY: "11111111-2222-4333-8444-555555555555",
+            CONF_OWNER_UUID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            CONF_OWNER_PSK: "00112233445566778899aabbccddeeff",
+        },
+        version=5,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    data_schema = result["data_schema"]
+    assert data_schema is not None
+    assert CONF_CA_CERT_PEM in data_schema.schema
+    assert CONF_CA_KEY_PEM in data_schema.schema
+
+
+async def test_certificate_reuse_skips_an_earlier_owner_psk_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Entry order cannot make a PSK record hide a valid certificate source."""
+    psk_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.0.2.10",
+            CONF_PORT: 5684,
+            CONF_AUTH_TYPE: AUTH_OWNER_PSK,
+            CONF_OWNER_UUID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            CONF_OWNER_PSK: "00112233445566778899aabbccddeeff",
+        },
+        version=5,
+    )
+    psk_entry.add_to_hass(hass)
+    certificate_entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, version=5)
+    certificate_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user_reuse"
+
+
 async def test_successful_setup(hass: HomeAssistant, mock_probe) -> None:
     """Happy path: valid IP connects, entry created with discovered port."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
@@ -79,6 +167,7 @@ async def test_successful_setup(hass: HomeAssistant, mock_probe) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_HOST] == MOCK_HOST
     assert result["data"][CONF_PORT] == MOCK_PORT
+    assert result["data"][CONF_AUTH_TYPE] == AUTH_CERTIFICATE
     assert result["data"][CONF_CA_CERT_PEM] == MOCK_CA_CERT_PEM
 
 
@@ -102,6 +191,267 @@ async def test_setup_normalizes_messy_pasted_pem(hass: HomeAssistant, mock_probe
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_CA_CERT_PEM] == MOCK_CA_CERT_PEM
     assert result["data"][CONF_CA_KEY_PEM] == MOCK_CA_KEY_PEM
+
+
+async def test_owner_psk_reauth_form_never_prefills_the_secret(
+    hass: HomeAssistant,
+) -> None:
+    entry = _owner_psk_entry(hass)
+
+    result = await start_reauth_flow(hass, entry)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    schema = result["data_schema"]
+    assert schema is not None
+    marker = next(key for key in schema.schema if key == CONF_OWNER_PSK)
+    assert marker.default is vol.UNDEFINED
+    selector = schema.schema[marker]
+    assert isinstance(selector, TextSelector)
+    assert selector.config["type"] == "password"
+    assert _OWNER_PSK not in repr(result)
+
+
+async def test_owner_psk_reauth_updates_only_normalized_credentials(
+    hass: HomeAssistant,
+) -> None:
+    entry = _owner_psk_entry(hass)
+    before = dict(entry.data)
+    before_unique_id = entry.unique_id
+    before_options = dict(entry.options)
+    replacement_uuid = "12121212-3434-4656-8787-9a9a9a9a9a9a"
+    replacement_psk = "AABBCCDDEEFF00112233445566778899"
+
+    result = await start_reauth_flow(hass, entry)
+    with (
+        patch(
+            "custom_components.localthings.config_flow._verify_owner_psk",
+            return_value=(replacement_uuid, replacement_psk.lower()),
+        ) as verify,
+        patch.object(hass.config_entries, "async_schedule_reload") as schedule_reload,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_OWNER_UUID: replacement_uuid.upper(),
+                CONF_OWNER_PSK: replacement_psk,
+            },
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    verify.assert_called_once_with(
+        before[CONF_HOST],
+        before[CONF_PORT],
+        before[CONF_DEVICE_KEY],
+        replacement_uuid.upper(),
+        replacement_psk,
+    )
+    assert entry.data == {
+        **before,
+        CONF_OWNER_UUID: replacement_uuid,
+        CONF_OWNER_PSK: replacement_psk.lower(),
+    }
+    assert entry.unique_id == before_unique_id
+    assert entry.options == before_options
+    schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+async def test_owner_psk_can_be_reconfigured_manually_without_secret_prefill(
+    hass: HomeAssistant,
+) -> None:
+    """Manual recovery stays available when the transport cannot classify rejection."""
+    entry = _owner_psk_entry(hass)
+    before = dict(entry.data)
+    replacement_uuid = "12121212-3434-4656-8787-9a9a9a9a9a9a"
+    replacement_psk = "aabbccddeeff00112233445566778899"
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert _OWNER_PSK not in repr(result)
+
+    with (
+        patch(
+            "custom_components.localthings.config_flow._verify_owner_psk",
+            return_value=(replacement_uuid, replacement_psk),
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload") as schedule_reload,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_OWNER_UUID: replacement_uuid,
+                CONF_OWNER_PSK: replacement_psk,
+            },
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data == {
+        **before,
+        CONF_OWNER_UUID: replacement_uuid,
+        CONF_OWNER_PSK: replacement_psk,
+    }
+    schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("failure", "error_key"),
+    [
+        (InvalidCredentialConfig("invalid OwnerPSK"), "invalid_auth"),
+        (TimeoutError("endpoint timeout"), "psk_cannot_connect"),
+    ],
+)
+async def test_owner_psk_reauth_failure_keeps_stored_credentials_redacted(
+    hass: HomeAssistant,
+    failure: Exception,
+    error_key: str,
+) -> None:
+    entry = _owner_psk_entry(hass)
+    before = dict(entry.data)
+    submitted_psk = "ffeeddccbbaa99887766554433221100"
+
+    result = await start_reauth_flow(hass, entry)
+    with patch(
+        "custom_components.localthings.config_flow._verify_owner_psk",
+        side_effect=failure,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_OWNER_UUID: _OWNER_UUID,
+                CONF_OWNER_PSK: submitted_psk,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": error_key}
+    assert entry.data == before
+    assert submitted_psk not in repr(result)
+    schema = result["data_schema"]
+    assert schema is not None
+    marker = next(key for key in schema.schema if key == CONF_OWNER_PSK)
+    assert marker.default is vol.UNDEFINED
+
+
+async def test_certificate_entry_does_not_enter_owner_psk_reauth(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=ENTRY_DATA,
+        version=5,
+    )
+    entry.add_to_hass(hass)
+
+    result = await start_reauth_flow(hass, entry)
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_not_supported"
+
+
+async def test_certificate_entry_does_not_enter_owner_psk_reconfigure(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, version=5)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_not_supported"
+
+
+def test_owner_psk_reauth_probe_closes_the_temporary_session() -> None:
+    from custom_components.localthings.config_flow import _verify_owner_psk
+
+    session = MagicMock()
+    with (
+        patch(
+            "custom_components.localthings.config_flow.time.monotonic",
+            side_effect=[100.0, 100.0, 108.0],
+        ),
+        patch(
+            "custom_components.localthings.config_flow.session_factory.create_owner_psk_session",
+            return_value=session,
+        ),
+        patch(
+            "custom_components.localthings.config_flow.read_ocf_device_id",
+            return_value=MOCK_DEVICE_KEY,
+        ) as read_device_id,
+    ):
+        assert _verify_owner_psk(
+            MOCK_HOST,
+            MOCK_PORT,
+            MOCK_DEVICE_KEY,
+            _OWNER_UUID,
+            _OWNER_PSK,
+        ) == (_OWNER_UUID, _OWNER_PSK)
+
+    session.connect.assert_called_once_with(timeout=10.0)
+    session.start_reader.assert_called_once_with()
+    read_device_id.assert_called_once_with(session, timeout=2.0)
+    session.close.assert_called_once_with()
+
+
+def test_owner_psk_reauth_probe_enforces_one_total_deadline() -> None:
+    from custom_components.localthings.config_flow import _verify_owner_psk
+
+    session = MagicMock()
+    with (
+        patch(
+            "custom_components.localthings.config_flow.time.monotonic",
+            side_effect=[100.0, 100.0, 111.0],
+        ),
+        patch(
+            "custom_components.localthings.config_flow.session_factory.create_owner_psk_session",
+            return_value=session,
+        ),
+        patch(
+            "custom_components.localthings.config_flow.read_ocf_device_id",
+        ) as read_device_id,
+        pytest.raises(TimeoutError, match="validation timed out"),
+    ):
+        _verify_owner_psk(
+            MOCK_HOST,
+            MOCK_PORT,
+            MOCK_DEVICE_KEY,
+            _OWNER_UUID,
+            _OWNER_PSK,
+        )
+
+    session.connect.assert_called_once_with(timeout=10.0)
+    session.start_reader.assert_called_once_with()
+    read_device_id.assert_not_called()
+    session.close.assert_called_once_with()
+
+
+def test_owner_psk_reauth_probe_closes_a_mismatched_session() -> None:
+    from custom_components.localthings.config_flow import _verify_owner_psk
+
+    session = MagicMock()
+    with (
+        patch(
+            "custom_components.localthings.config_flow.session_factory.create_owner_psk_session",
+            return_value=session,
+        ),
+        patch(
+            "custom_components.localthings.config_flow.read_ocf_device_id",
+            return_value="11111111-2222-4333-8444-555555555555",
+        ),
+        pytest.raises(OwnerPskDeviceMismatch),
+    ):
+        _verify_owner_psk(
+            MOCK_HOST,
+            MOCK_PORT,
+            MOCK_DEVICE_KEY,
+            _OWNER_UUID,
+            _OWNER_PSK,
+        )
+
+    session.close.assert_called_once_with()
 
 
 def test_normalize_pem_strips_bom_crlf_and_blank_lines() -> None:
@@ -976,7 +1326,7 @@ def test_every_error_key_the_flow_can_raise_has_a_message() -> None:
         if isinstance(cls, type)
         and issubclass(cls, (config_flow.CannotConnect, config_flow.InvalidCA))
     }
-    keys.add("unknown")
+    keys.update({"unknown", "invalid_auth", "psk_cannot_connect"})
 
     catalog = json.loads(
         (

--- a/tests/localthings/test_config_flow.py
+++ b/tests/localthings/test_config_flow.py
@@ -233,6 +233,17 @@ WASHER_DEVICE0 = [
 ]
 
 
+class FakeCertificateAuth:
+    """Synthetic provider that keeps only the credential label tests need."""
+
+    def __init__(self, certificate_pem: str, private_key_pem: str) -> None:
+        self.certificate_pem = certificate_pem
+        self.private_key_pem = private_key_pem
+
+    def configure_context(self, _context) -> None:
+        """Satisfy the authentication-provider protocol."""
+
+
 class FakeSession:
     """Stand-in for DtlsCoapSession that answers /device/0 for any path.
 
@@ -242,6 +253,7 @@ class FakeSession:
     """
 
     instances: ClassVar[list[FakeSession]] = []
+    probe_instances: ClassVar[list[FakeSession]] = []
     reject_certs: ClassVar[set[str]] = set()
     # smartthings-local >= 0.1.3 ("redacted typed failures") no longer puts
     # the alert in connect()'s exception text -- set True to model that, so
@@ -249,8 +261,10 @@ class FakeSession:
     # instead of the legacy _alert_name text-parsing path.
     redact_rejection: ClassVar[bool] = False
 
-    def __init__(self, host, port, cert_pem=None, key_pem=None, **kwargs):
-        self.host, self.port, self.cert_pem = host, port, cert_pem
+    def __init__(self, host, port, cert_pem=None, key_pem=None, auth=None, **kwargs):
+        self.host, self.port = host, port
+        self.auth = auth
+        self.cert_pem = auth.certificate_pem if auth is not None else cert_pem
         FakeSession.instances.append(self)
 
     def connect(self):
@@ -275,12 +289,40 @@ class FakeSession:
         pass
 
 
+class FakeSessionFactory:
+    """Build config-flow sessions with inspectable synthetic providers."""
+
+    @staticmethod
+    def create_certificate_session(
+        host,
+        port,
+        *,
+        certificate_pem,
+        private_key_pem,
+        **kwargs,
+    ) -> FakeSession:
+        session = FakeSession(
+            host,
+            port,
+            auth=FakeCertificateAuth(certificate_pem, private_key_pem),
+            **kwargs,
+        )
+        FakeSession.probe_instances.append(session)
+        return session
+
+
+def _probe_sessions() -> list[FakeSession]:
+    """Sessions opened by the config flow, excluding the loaded coordinator."""
+    return list(FakeSession.probe_instances)
+
+
 @pytest.fixture
 def fake_dtls(monkeypatch):
     """Wire the probe path up to FakeSession with no real network anywhere."""
     from custom_components.localthings import config_flow
 
     FakeSession.instances = []
+    FakeSession.probe_instances = []
     FakeSession.reject_certs = set()
     FakeSession.redact_rejection = False
     monkeypatch.setattr(config_flow, "_fetch_samsung_uuid", lambda: "test-uuid")
@@ -293,6 +335,7 @@ def fake_dtls(monkeypatch):
         "smartthings_local.protocol.dtls_session.DtlsCoapSession",
         FakeSession,
     )
+    monkeypatch.setattr(config_flow, "session_factory", FakeSessionFactory())
     return FakeSession
 
 
@@ -349,7 +392,7 @@ async def test_clienthello_probe_picks_the_confirmed_port(
     # The whole range is probed (cheaply, in parallel) but only the confirmed
     # port is handed a handshake.
     assert set(probed) == set(config_flow.PROBE_PORT_RANGE)
-    assert [s.port for s in FakeSession.instances] == [49153]
+    assert [session.port for session in _probe_sessions()] == [49153]
 
 
 async def test_probe_uses_discovered_low_port(hass: HomeAssistant, monkeypatch, fake_dtls) -> None:
@@ -470,7 +513,7 @@ async def test_second_device_reuses_the_existing_leaf(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_LEAF_CERT_PEM] == MOCK_LEAF_CERT_PEM
-    assert FakeSession.instances[0].cert_pem == MOCK_LEAF_CERT_PEM
+    assert _probe_sessions()[0].cert_pem == MOCK_LEAF_CERT_PEM
 
 
 async def test_rejected_reused_leaf_is_reminted(
@@ -492,7 +535,10 @@ async def test_rejected_reused_leaf_is_reminted(
     assert result["type"] == FlowResultType.CREATE_ENTRY
     # Freshly minted, and it's the fresh one that got stored.
     assert result["data"][CONF_LEAF_CERT_PEM] == "FULLCHAIN"
-    assert [s.cert_pem for s in FakeSession.instances] == [MOCK_LEAF_CERT_PEM, "FULLCHAIN"]
+    assert [session.cert_pem for session in _probe_sessions()] == [
+        MOCK_LEAF_CERT_PEM,
+        "FULLCHAIN",
+    ]
 
 
 async def test_rejected_reused_leaf_is_reminted_against_a_redacted_library(
@@ -529,11 +575,14 @@ async def test_rejected_reused_leaf_is_reminted_against_a_redacted_library(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_LEAF_CERT_PEM] == "FULLCHAIN"
-    assert [s.cert_pem for s in FakeSession.instances] == [MOCK_LEAF_CERT_PEM, "FULLCHAIN"]
+    assert [session.cert_pem for session in _probe_sessions()] == [
+        MOCK_LEAF_CERT_PEM,
+        "FULLCHAIN",
+    ]
     assert diagnosed == [49154]
 
 
-def test_diagnostic_handshake_runs_once_not_once_per_failing_port(monkeypatch) -> None:
+def test_diagnostic_handshake_runs_once_not_once_per_failing_port(monkeypatch, fake_dtls) -> None:
     """_diagnostic_alert commits association state on the device (see its
     own docstring) -- running it once per failing candidate instead of once
     overall would both add latency (each is its own bounded handshake) and
@@ -543,10 +592,8 @@ def test_diagnostic_handshake_runs_once_not_once_per_failing_port(monkeypatch) -
     port, not three times against every candidate in scan order."""
     from custom_components.localthings import config_flow
 
-    FakeSession.instances = []
     FakeSession.reject_certs = {MOCK_LEAF_CERT_PEM}
     FakeSession.redact_rejection = True
-    monkeypatch.setattr("smartthings_local.protocol.dtls_session.DtlsCoapSession", FakeSession)
 
     diagnosed: list[int] = []
 
@@ -597,7 +644,7 @@ async def test_unconfirmed_port_failure_is_not_reminted(
     errors = result["errors"]
     assert errors is not None
     assert errors["base"] == "no_dtls_server"
-    assert len(FakeSession.instances) == 1
+    assert len(_probe_sessions()) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/localthings/test_coordinator.py
+++ b/tests/localthings/test_coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import time
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import cbor2
 import pytest
@@ -20,6 +20,9 @@ from smartthings_local.errors import SessionClosedError, SessionError, SessionTi
 from custom_components.localthings.const import (
     CONF_BYPASS_REMOTE_CONTROL,
     CONF_HOST,
+    CONF_LEAF_CERT_PEM,
+    CONF_LEAF_KEY_PEM,
+    CONF_PORT,
     DOMAIN,
     DTLS_LOCAL_PORT_BASE,
     SUMMARY_INTERVAL_S,
@@ -1898,6 +1901,65 @@ def test_local_source_port_non_ipv4_falls_back_to_hash() -> None:
     port = _local_source_port("some-hostname")
     assert port == _local_source_port("some-hostname")
     assert DTLS_LOCAL_PORT_BASE <= port <= DTLS_LOCAL_PORT_BASE + 0xFF
+
+
+def test_connect_session_preserves_the_certificate_session_contract(
+    hass: HomeAssistant,
+    mock_entry,
+) -> None:
+    """The coordinator owns lifecycle I/O after the factory constructs a session."""
+    coordinator = LocalThingsCoordinator(hass, mock_entry)
+    session = MagicMock()
+    identity = MagicMock()
+
+    with (
+        patch(
+            "custom_components.localthings.coordinator.session_factory.create_certificate_session",
+            return_value=session,
+        ) as session_factory,
+        patch(
+            "custom_components.localthings.coordinator.read_identity",
+            return_value=identity,
+        ) as read_identity,
+    ):
+        coordinator._connect_session()
+
+    session_factory.assert_called_once_with(
+        mock_entry.data[CONF_HOST],
+        mock_entry.data[CONF_PORT],
+        certificate_pem=mock_entry.data[CONF_LEAF_CERT_PEM],
+        private_key_pem=mock_entry.data[CONF_LEAF_KEY_PEM],
+        on_notification=coordinator._observe.on_notification,
+        local_port=_local_source_port(mock_entry.data[CONF_HOST]),
+    )
+    assert session.method_calls[:2] == [call.connect(), call.start_reader()]
+    read_identity.assert_called_once_with(session, None)
+    assert coordinator._session is session
+    assert coordinator._identity is identity
+
+
+def test_connect_session_does_not_publish_an_unstarted_session(
+    hass: HomeAssistant,
+    mock_entry,
+) -> None:
+    """A failed connect remains invisible to poll and command paths."""
+    coordinator = LocalThingsCoordinator(hass, mock_entry)
+    session = MagicMock()
+    session.start_reader.side_effect = RuntimeError("reader failed")
+
+    with (
+        patch(
+            "custom_components.localthings.coordinator.session_factory.create_certificate_session",
+            return_value=session,
+        ),
+        patch("custom_components.localthings.coordinator.read_identity") as read_identity,
+        pytest.raises(RuntimeError, match="reader failed"),
+    ):
+        coordinator._connect_session()
+
+    assert session.method_calls[:2] == [call.connect(), call.start_reader()]
+    read_identity.assert_not_called()
+    assert coordinator._session is None
 
 
 # ----------------------------------------------------------------------

--- a/tests/localthings/test_coordinator.py
+++ b/tests/localthings/test_coordinator.py
@@ -13,15 +13,25 @@ import pytest
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import ConfigEntryAuthFailed, ServiceValidationError
 from homeassistant.helpers import issue_registry as ir
-from smartthings_local.errors import SessionClosedError, SessionError, SessionTimeoutError
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from smartthings_local.errors import (
+    AuthenticationError,
+    SessionClosedError,
+    SessionError,
+    SessionTimeoutError,
+)
 
 from custom_components.localthings.const import (
+    AUTH_OWNER_PSK,
+    CONF_AUTH_TYPE,
     CONF_BYPASS_REMOTE_CONTROL,
+    CONF_DEVICE_KEY,
     CONF_HOST,
-    CONF_LEAF_CERT_PEM,
-    CONF_LEAF_KEY_PEM,
+    CONF_OWNER_PSK,
+    CONF_OWNER_UUID,
     CONF_PORT,
     DOMAIN,
     DTLS_LOCAL_PORT_BASE,
@@ -31,6 +41,10 @@ from custom_components.localthings.coordinator import (
     _RECOVERY_RETRY_S,
     LocalThingsCoordinator,
     _local_source_port,
+)
+from custom_components.localthings.credentials import (
+    InvalidCredentialConfig,
+    OwnerPskDeviceMismatch,
 )
 from custom_components.localthings.observe import MODE_OBSERVE, MODE_POLL, PUSH_HEALTH_WINDOW_S
 from custom_components.localthings.registry.capabilities.common import (
@@ -1914,7 +1928,7 @@ def test_connect_session_preserves_the_certificate_session_contract(
 
     with (
         patch(
-            "custom_components.localthings.coordinator.session_factory.create_certificate_session",
+            "custom_components.localthings.coordinator.session_factory.create_entry_session",
             return_value=session,
         ) as session_factory,
         patch(
@@ -1925,10 +1939,7 @@ def test_connect_session_preserves_the_certificate_session_contract(
         coordinator._connect_session()
 
     session_factory.assert_called_once_with(
-        mock_entry.data[CONF_HOST],
-        mock_entry.data[CONF_PORT],
-        certificate_pem=mock_entry.data[CONF_LEAF_CERT_PEM],
-        private_key_pem=mock_entry.data[CONF_LEAF_KEY_PEM],
+        mock_entry.data,
         on_notification=coordinator._observe.on_notification,
         local_port=_local_source_port(mock_entry.data[CONF_HOST]),
     )
@@ -1949,7 +1960,7 @@ def test_connect_session_does_not_publish_an_unstarted_session(
 
     with (
         patch(
-            "custom_components.localthings.coordinator.session_factory.create_certificate_session",
+            "custom_components.localthings.coordinator.session_factory.create_entry_session",
             return_value=session,
         ),
         patch("custom_components.localthings.coordinator.read_identity") as read_identity,
@@ -1958,8 +1969,157 @@ def test_connect_session_does_not_publish_an_unstarted_session(
         coordinator._connect_session()
 
     assert session.method_calls[:2] == [call.connect(), call.start_reader()]
+    session.close.assert_called_once_with()
     read_identity.assert_not_called()
     assert coordinator._session is None
+
+
+def _owner_psk_entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Synthetic OCF device",
+        data={
+            CONF_HOST: "192.0.2.10",
+            CONF_PORT: 5684,
+            CONF_AUTH_TYPE: AUTH_OWNER_PSK,
+            CONF_DEVICE_KEY: "11111111-2222-4333-8444-555555555555",
+            CONF_OWNER_UUID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            CONF_OWNER_PSK: "00112233445566778899aabbccddeeff",
+        },
+        version=5,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def test_owner_psk_session_is_bound_before_it_is_published(
+    hass: HomeAssistant,
+) -> None:
+    """An authenticated session stays private until /oic/d matches the entry."""
+    entry = _owner_psk_entry(hass)
+    coordinator = LocalThingsCoordinator(hass, entry)
+    session = MagicMock()
+    identity = MagicMock()
+
+    def _reported_device_id(candidate) -> str:
+        assert candidate is session
+        assert coordinator._session is None
+        return entry.data[CONF_DEVICE_KEY]
+
+    with (
+        patch(
+            "custom_components.localthings.coordinator.session_factory.create_entry_session",
+            return_value=session,
+        ) as session_factory,
+        patch(
+            "custom_components.localthings.coordinator.read_ocf_device_id",
+            side_effect=_reported_device_id,
+        ) as read_device_id,
+        patch(
+            "custom_components.localthings.coordinator.read_identity",
+            return_value=identity,
+        ),
+    ):
+        coordinator._connect_session()
+
+    session_factory.assert_called_once_with(
+        entry.data,
+        on_notification=coordinator._observe.on_notification,
+        local_port=_local_source_port(entry.data[CONF_HOST]),
+    )
+    assert session.method_calls[:2] == [call.connect(), call.start_reader()]
+    read_device_id.assert_called_once_with(session)
+    assert coordinator._session is session
+    assert coordinator._identity is identity
+
+
+def test_owner_psk_session_mismatch_is_closed_before_publication(
+    hass: HomeAssistant,
+) -> None:
+    entry = _owner_psk_entry(hass)
+    coordinator = LocalThingsCoordinator(hass, entry)
+    session = MagicMock()
+
+    with (
+        patch(
+            "custom_components.localthings.coordinator.session_factory.create_entry_session",
+            return_value=session,
+        ),
+        patch(
+            "custom_components.localthings.coordinator.read_ocf_device_id",
+            return_value="22222222-3333-4444-8555-666666666666",
+        ),
+        patch("custom_components.localthings.coordinator.read_identity") as read_identity,
+        pytest.raises(OwnerPskDeviceMismatch),
+    ):
+        coordinator._connect_session()
+
+    session.close.assert_called_once_with()
+    read_identity.assert_not_called()
+    assert coordinator._session is None
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        InvalidCredentialConfig("invalid OwnerPSK"),
+        OwnerPskDeviceMismatch("authenticated OCF device did not match"),
+        AuthenticationError(),
+    ],
+)
+async def test_definitive_owner_psk_failure_requests_reauthentication(
+    hass: HomeAssistant,
+    failure: Exception,
+) -> None:
+    entry = _owner_psk_entry(hass)
+    coordinator = LocalThingsCoordinator(hass, entry)
+
+    with (
+        patch.object(coordinator, "_poll_once", side_effect=failure),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+@pytest.mark.parametrize("failure", [SessionError(), TimeoutError()])
+async def test_ambiguous_owner_psk_failure_remains_an_availability_error(
+    hass: HomeAssistant,
+    failure: Exception,
+) -> None:
+    """A silent or unreachable endpoint must not be mislabeled as bad credentials."""
+    entry = _owner_psk_entry(hass)
+    coordinator = LocalThingsCoordinator(hass, entry)
+
+    with (
+        patch.object(coordinator, "_poll_once", side_effect=[failure, failure]),
+        patch(
+            "custom_components.localthings.coordinator.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+async def test_certificate_authentication_error_keeps_existing_behavior(
+    hass: HomeAssistant,
+    mock_entry,
+) -> None:
+    coordinator = LocalThingsCoordinator(hass, mock_entry)
+
+    with (
+        patch.object(
+            coordinator,
+            "_poll_once",
+            side_effect=[AuthenticationError(), AuthenticationError()],
+        ),
+        patch(
+            "custom_components.localthings.coordinator.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
 
 
 # ----------------------------------------------------------------------

--- a/tests/localthings/test_credentials.py
+++ b/tests/localthings/test_credentials.py
@@ -1,0 +1,208 @@
+"""Credential-shape and redaction tests for config-entry authentication."""
+
+from __future__ import annotations
+
+from dataclasses import is_dataclass
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import cbor2
+import pytest
+from smartthings_local.errors import SessionError
+from smartthings_local.protocol import auth as protocol_auth
+
+from custom_components.localthings.const import (
+    AUTH_CERTIFICATE,
+    AUTH_OWNER_PSK,
+    CONF_AUTH_TYPE,
+    CONF_CA_CERT_PEM,
+    CONF_HOST,
+    CONF_LEAF_CERT_PEM,
+    CONF_LEAF_KEY_PEM,
+    CONF_OWNER_PSK,
+    CONF_OWNER_UUID,
+    CONF_PORT,
+)
+from custom_components.localthings.credentials import (
+    InvalidCredentialConfig,
+    OwnerPskCredentials,
+    OwnerPskDeviceMismatch,
+    certificate_credentials_from_entry,
+    normalize_owner_psk,
+    normalize_owner_uuid,
+    owner_psk_credentials_from_entry,
+    require_matching_ocf_uuid,
+)
+from custom_components.localthings.registry.identity import read_ocf_device_id
+
+OWNER_UUID = "12121212-3434-4656-8787-9a9a9a9a9a9a"
+OWNER_PSK = "00112233445566778899aabbccddeeff"
+DEVICE_UUID = "11111111-2222-4333-8444-555555555555"
+
+
+def _owner_psk_data() -> dict:
+    return {
+        CONF_HOST: "192.0.2.10",
+        CONF_PORT: 5684,
+        CONF_AUTH_TYPE: AUTH_OWNER_PSK,
+        CONF_OWNER_UUID: OWNER_UUID,
+        CONF_OWNER_PSK: OWNER_PSK,
+    }
+
+
+def test_owner_uuid_and_key_are_canonicalized() -> None:
+    assert normalize_owner_uuid(f"  {OWNER_UUID.upper()}  ") == OWNER_UUID
+    assert normalize_owner_psk(f"  {OWNER_PSK.upper()}  ") == OWNER_PSK
+    assert normalize_owner_psk("CD" * 32) == "cd" * 32
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not-a-uuid",
+        "00000000-0000-0000-0000-000000000000",
+        # Valid text whose raw UUID contains a NUL byte, which OpenSSL cannot
+        # represent as its NUL-terminated client identity.
+        "01010101-0101-4101-8101-010101010100",
+    ],
+)
+def test_owner_uuid_rejects_invalid_nil_and_nul_values(value: str) -> None:
+    with pytest.raises(InvalidCredentialConfig, match=r"^invalid") as raised:
+        normalize_owner_uuid(value)
+    assert value not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ab" * 15,
+        "ab" * 17,
+        "ab" * 31,
+        "ab" * 33,
+        "gg" * 16,
+        "11" * 7 + "  " + "11" * 8,
+    ],
+)
+def test_owner_psk_rejects_non_hex_wrong_length_and_embedded_space(value: str) -> None:
+    with pytest.raises(InvalidCredentialConfig, match=r"^invalid OwnerPSK$") as raised:
+        normalize_owner_psk(value)
+    assert value not in str(raised.value)
+
+
+def test_owner_credentials_build_exact_protocol_bytes_without_repr_leak() -> None:
+    provider = MagicMock(spec=protocol_auth.PskAuth)
+    with patch.object(protocol_auth, "PskAuth", return_value=provider) as provider_class:
+        credentials = OwnerPskCredentials.from_text(
+            owner_uuid=OWNER_UUID,
+            owner_psk=OWNER_PSK,
+        )
+
+    provider_class.assert_called_once_with(
+        identity=UUID(OWNER_UUID).bytes,
+        key=bytes.fromhex(OWNER_PSK),
+    )
+    assert credentials.authentication_provider() is provider
+    assert repr(credentials) == "OwnerPskCredentials()"
+    assert is_dataclass(credentials) is False
+    with pytest.raises(TypeError):
+        vars(credentials)
+    with pytest.raises(AttributeError, match="immutable"):
+        credentials.extra = "value"
+    for value in (OWNER_UUID, OWNER_PSK):
+        assert value not in repr(credentials)
+
+
+def test_real_owner_provider_is_redacted() -> None:
+    provider = OwnerPskCredentials.from_text(
+        owner_uuid=OWNER_UUID,
+        owner_psk=OWNER_PSK,
+    ).authentication_provider()
+
+    assert repr(provider) == "PskAuth()"
+    assert OWNER_UUID not in repr(provider)
+    assert OWNER_PSK not in repr(provider)
+
+
+def test_legacy_entry_without_auth_type_stays_certificate_backed() -> None:
+    assert certificate_credentials_from_entry(
+        {
+            CONF_LEAF_CERT_PEM: "CERTIFICATE",
+            CONF_LEAF_KEY_PEM: "PRIVATE KEY",
+        }
+    ) == ("CERTIFICATE", "PRIVATE KEY")
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {CONF_AUTH_TYPE: "unknown"},
+        {
+            CONF_AUTH_TYPE: AUTH_CERTIFICATE,
+            CONF_LEAF_CERT_PEM: "CERTIFICATE",
+            CONF_LEAF_KEY_PEM: "PRIVATE KEY",
+            CONF_OWNER_UUID: OWNER_UUID,
+        },
+        {
+            **_owner_psk_data(),
+            CONF_CA_CERT_PEM: "CERTIFICATE",
+        },
+        {
+            CONF_AUTH_TYPE: AUTH_OWNER_PSK,
+            CONF_OWNER_UUID: OWNER_UUID,
+        },
+    ],
+)
+def test_unknown_mixed_and_incomplete_entry_auth_fails_closed(data: dict) -> None:
+    rendered = repr(data)
+    with pytest.raises(InvalidCredentialConfig) as raised:
+        if data.get(CONF_AUTH_TYPE) == AUTH_OWNER_PSK:
+            owner_psk_credentials_from_entry(data)
+        else:
+            certificate_credentials_from_entry(data)
+
+    assert OWNER_PSK not in str(raised.value)
+    assert OWNER_UUID not in str(raised.value)
+    assert rendered not in str(raised.value)
+
+
+def test_authenticated_device_uuid_must_match_exactly() -> None:
+    assert require_matching_ocf_uuid(DEVICE_UUID.upper(), DEVICE_UUID) == DEVICE_UUID
+
+    with pytest.raises(OwnerPskDeviceMismatch, match=r"^authenticated OCF") as raised:
+        require_matching_ocf_uuid(
+            DEVICE_UUID,
+            "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        )
+    assert DEVICE_UUID not in str(raised.value)
+
+
+def test_exact_ocf_device_read_returns_only_the_reported_di() -> None:
+    session = MagicMock()
+    session.get.return_value = (0x45, cbor2.dumps({"di": DEVICE_UUID, "pi": OWNER_UUID}))
+
+    assert read_ocf_device_id(session, timeout=2.5) == DEVICE_UUID
+    session.get.assert_called_once_with(["oic", "d"], timeout=2.5)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        (0x84, b""),
+        (0x45, b"not-cbor"),
+        (0x45, cbor2.dumps([{"di": DEVICE_UUID}])),
+        (0x45, cbor2.dumps({"di": 1234})),
+    ],
+)
+def test_exact_ocf_device_read_rejects_unusable_responses(response: tuple) -> None:
+    session = MagicMock()
+    session.get.return_value = response
+
+    assert read_ocf_device_id(session) is None
+
+
+def test_exact_ocf_device_read_propagates_transport_failures() -> None:
+    session = MagicMock()
+    session.get.side_effect = SessionError()
+
+    with pytest.raises(SessionError):
+        read_ocf_device_id(session)

--- a/tests/localthings/test_diagnostics.py
+++ b/tests/localthings/test_diagnostics.py
@@ -7,9 +7,16 @@ import threading
 from pathlib import Path
 
 from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.localthings import diagnostics as diagnostics_mod
-from custom_components.localthings.const import DOMAIN
+from custom_components.localthings.const import (
+    AUTH_OWNER_PSK,
+    CONF_AUTH_TYPE,
+    CONF_OWNER_PSK,
+    CONF_OWNER_UUID,
+    DOMAIN,
+)
 from custom_components.localthings.diagnostics import async_get_config_entry_diagnostics
 from custom_components.localthings.registry.redact import REDACTED
 
@@ -37,6 +44,36 @@ async def test_diagnostics_shape_and_redaction(
     assert resources["/wirelessinfo/vs/0"]["macaddressWiFi"] == REDACTED
     # Ordinary state survives.
     assert resources["/status/lock/vs/0"]["x.com.samsung.da.ado.devicecontrol"] == "On"
+
+
+async def test_owner_psk_diagnostics_expose_only_the_authentication_type(
+    hass: HomeAssistant, mock_entry, mock_coordinator_session
+) -> None:
+    """Config-entry credentials must never join a diagnostics download."""
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    owner_uuid = "12121212-3434-4656-8787-9a9a9a9a9a9a"
+    owner_psk = "00112233445566778899aabbccddeeff"
+    owner_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_AUTH_TYPE: AUTH_OWNER_PSK,
+            CONF_OWNER_UUID: owner_uuid,
+            CONF_OWNER_PSK: owner_psk,
+        },
+        version=5,
+    )
+    owner_entry.add_to_hass(hass)
+    hass.data[DOMAIN][owner_entry.entry_id] = hass.data[DOMAIN][mock_entry.entry_id]
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, owner_entry)
+    rendered = json.dumps(diagnostics, sort_keys=True)
+
+    assert diagnostics["auth_type"] == AUTH_OWNER_PSK
+    assert set(diagnostics) & {CONF_AUTH_TYPE, CONF_OWNER_UUID, CONF_OWNER_PSK} == {CONF_AUTH_TYPE}
+    assert owner_uuid not in rendered
+    assert owner_psk not in rendered
 
 
 async def test_diagnostics_include_ocf_identity(

--- a/tests/localthings/test_identity_migration.py
+++ b/tests/localthings/test_identity_migration.py
@@ -178,7 +178,7 @@ async def test_v3_entry_moves_onto_the_device_uuid_keeping_its_entity_ids(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.version == 4
+    assert entry.version == 5
     assert entry.data[CONF_DEVICE_KEY] == UUID_A
     # The serial is kept alongside the key, not replaced by it: it is what
     # corroborates a later change of UUID.
@@ -215,7 +215,7 @@ async def test_the_oldest_install_walks_all_the_way_from_v1(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.version == 4
+    assert entry.version == 5
     assert entry.data[CONF_DEVICE_KEY] == UUID_A
     assert entry.unique_id == f"{DOMAIN}_{UUID_A}"
     kept = er.async_get(hass).async_get(existing.entity_id)
@@ -602,7 +602,7 @@ async def test_an_already_migrated_entry_is_left_alone(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.version == 4
+    assert entry.version == 5
     assert entry.data[CONF_DEVICE_KEY] == UUID_A
     assert _device_identifiers(hass, device.id) == {(DOMAIN, UUID_A)}
     assert _entity_unique_id(hass, existing.entity_id) == (f"{DOMAIN}_{UUID_A}_connection_mode")

--- a/tests/localthings/test_migration.py
+++ b/tests/localthings/test_migration.py
@@ -13,7 +13,14 @@ from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.localthings.const import (
+    AUTH_CERTIFICATE,
+    AUTH_OWNER_PSK,
+    CONF_AUTH_TYPE,
+    CONF_DEVICE_KEY,
     CONF_HOST,
+    CONF_OWNER_PSK,
+    CONF_OWNER_UUID,
+    CONF_PORT,
     CONF_SERIAL,
     DOMAIN,
 )
@@ -53,7 +60,7 @@ async def test_migration_recovers_serial_from_unique_id(
     # relabel that no-ops for a family without particulate sensors, and
     # v3 -> v4 only records the legacy key for the coordinator to re-key
     # from once a poll produces an OCF device id.
-    assert entry.version == 4
+    assert entry.version == 5
     assert entry.data[CONF_SERIAL] == MOCK_SERIAL
 
 
@@ -268,10 +275,52 @@ async def test_migration_rejects_a_future_entry_version(hass: HomeAssistant) -> 
     written by a newer release."""
     from custom_components.localthings import async_migrate_entry
 
-    entry = MockConfigEntry(domain=DOMAIN, data=LEGACY_ENTRY_DATA, version=5)
+    entry = MockConfigEntry(domain=DOMAIN, data=LEGACY_ENTRY_DATA, version=6)
     entry.add_to_hass(hass)
+    before = dict(entry.data)
 
     assert await async_migrate_entry(hass, entry) is False
+    assert entry.version == 6
+    assert entry.data == before
+
+
+async def test_v4_migration_adds_only_certificate_discriminator(
+    hass: HomeAssistant,
+) -> None:
+    """The auth migration must preserve every existing credential byte and identity."""
+    from custom_components.localthings import async_migrate_entry
+
+    data = dict(LEGACY_ENTRY_DATA)
+    data[CONF_SERIAL] = MOCK_SERIAL
+    entry = MockConfigEntry(domain=DOMAIN, data=data, version=4)
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 5
+    assert entry.data == {**data, CONF_AUTH_TYPE: AUTH_CERTIFICATE}
+
+
+async def test_current_owner_psk_entry_is_a_migration_noop(
+    hass: HomeAssistant,
+) -> None:
+    """A current PSK entry must never be mistaken for a legacy certificate entry."""
+    from custom_components.localthings import async_migrate_entry
+
+    data = {
+        CONF_HOST: "192.0.2.10",
+        CONF_PORT: 5684,
+        CONF_AUTH_TYPE: AUTH_OWNER_PSK,
+        CONF_DEVICE_KEY: "11111111-2222-4333-8444-555555555555",
+        CONF_OWNER_UUID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        CONF_OWNER_PSK: "00112233445566778899aabbccddeeff",
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data, version=5)
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 5
+    assert entry.data == data
 
 
 async def test_migration_without_a_unique_id_falls_back_to_host(hass: HomeAssistant) -> None:

--- a/tests/localthings/test_session.py
+++ b/tests/localthings/test_session.py
@@ -1,0 +1,110 @@
+"""Tests for DTLS authentication and session construction."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from smartthings_local.protocol import auth as protocol_auth
+from smartthings_local.protocol import dtls_session
+
+from custom_components.localthings import session as session_factory
+
+
+def test_create_certificate_auth_uses_in_memory_credentials() -> None:
+    """Stored certificate entries stay on the existing in-memory provider."""
+    auth = MagicMock(spec=protocol_auth.CertificateAuth)
+
+    with patch.object(
+        protocol_auth.CertificateAuth,
+        "from_memory",
+        return_value=auth,
+    ) as from_memory:
+        result = session_factory.create_certificate_auth("CERTIFICATE", "PRIVATE KEY")
+
+    assert result is auth
+    from_memory.assert_called_once_with("CERTIFICATE", "PRIVATE KEY")
+
+
+def test_create_dtls_session_passes_only_the_explicit_auth_provider() -> None:
+    """The session factory must not mix auth with legacy certificate arguments."""
+    auth = MagicMock(spec=protocol_auth.AuthenticationProvider)
+    callback = MagicMock()
+    session = MagicMock(spec=dtls_session.DtlsCoapSession)
+
+    with patch.object(
+        dtls_session,
+        "DtlsCoapSession",
+        return_value=session,
+    ) as session_class:
+        result = session_factory.create_dtls_session(
+            "192.0.2.10",
+            49154,
+            auth=auth,
+            on_notification=callback,
+            local_port=49742,
+        )
+
+    assert result is session
+    session_class.assert_called_once_with(
+        "192.0.2.10",
+        49154,
+        auth=auth,
+        on_notification=callback,
+        local_port=49742,
+    )
+    assert "cert_pem" not in session_class.call_args.kwargs
+    assert "key_pem" not in session_class.call_args.kwargs
+
+
+def test_create_certificate_session_composes_the_two_factories() -> None:
+    """Certificate callers use the shared session path without lifecycle I/O."""
+    auth = MagicMock(spec=protocol_auth.AuthenticationProvider)
+    callback = MagicMock()
+    session = MagicMock(spec=dtls_session.DtlsCoapSession)
+
+    with (
+        patch.object(
+            session_factory,
+            "create_certificate_auth",
+            return_value=auth,
+        ) as auth_factory,
+        patch.object(
+            session_factory,
+            "create_dtls_session",
+            return_value=session,
+        ) as session_builder,
+    ):
+        result = session_factory.create_certificate_session(
+            "192.0.2.10",
+            49154,
+            certificate_pem="CERTIFICATE",
+            private_key_pem="PRIVATE KEY",
+            on_notification=callback,
+            local_port=49742,
+        )
+
+    assert result is session
+    auth_factory.assert_called_once_with("CERTIFICATE", "PRIVATE KEY")
+    session_builder.assert_called_once_with(
+        "192.0.2.10",
+        49154,
+        auth=auth,
+        on_notification=callback,
+        local_port=49742,
+    )
+    session.connect.assert_not_called()
+    session.start_reader.assert_not_called()
+
+
+def test_real_certificate_provider_is_session_compatible_and_redacted() -> None:
+    """The published provider API accepts the existing in-memory credential shape."""
+    session = session_factory.create_certificate_session(
+        "192.0.2.10",
+        49154,
+        certificate_pem="SYNTHETIC CERTIFICATE",
+        private_key_pem="SYNTHETIC PRIVATE KEY",
+    )
+
+    assert isinstance(session.auth, protocol_auth.CertificateAuth)
+    assert repr(session.auth) == "CertificateAuth()"
+    assert "SYNTHETIC" not in repr(session.auth)

--- a/tests/localthings/test_session.py
+++ b/tests/localthings/test_session.py
@@ -4,10 +4,22 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from smartthings_local.protocol import auth as protocol_auth
 from smartthings_local.protocol import dtls_session
 
 from custom_components.localthings import session as session_factory
+from custom_components.localthings.const import (
+    AUTH_CERTIFICATE,
+    AUTH_OWNER_PSK,
+    CONF_AUTH_TYPE,
+    CONF_HOST,
+    CONF_LEAF_CERT_PEM,
+    CONF_LEAF_KEY_PEM,
+    CONF_OWNER_PSK,
+    CONF_OWNER_UUID,
+    CONF_PORT,
+)
 
 
 def test_create_certificate_auth_uses_in_memory_credentials() -> None:
@@ -94,6 +106,145 @@ def test_create_certificate_session_composes_the_two_factories() -> None:
     )
     session.connect.assert_not_called()
     session.start_reader.assert_not_called()
+
+
+def test_create_owner_psk_session_composes_without_lifecycle_io() -> None:
+    """OwnerPSK construction uses the same provider-based session seam."""
+    auth = MagicMock(spec=protocol_auth.PskAuth)
+    callback = MagicMock()
+    session = MagicMock(spec=dtls_session.DtlsCoapSession)
+
+    with (
+        patch.object(
+            session_factory,
+            "create_owner_psk_auth",
+            return_value=auth,
+        ) as auth_factory,
+        patch.object(
+            session_factory,
+            "create_dtls_session",
+            return_value=session,
+        ) as session_builder,
+    ):
+        result = session_factory.create_owner_psk_session(
+            "192.0.2.10",
+            5684,
+            owner_uuid="12121212-3434-4656-8787-9a9a9a9a9a9a",
+            owner_psk="00112233445566778899aabbccddeeff",
+            on_notification=callback,
+            local_port=49742,
+        )
+
+    assert result is session
+    auth_factory.assert_called_once_with(
+        "12121212-3434-4656-8787-9a9a9a9a9a9a",
+        "00112233445566778899aabbccddeeff",
+    )
+    session_builder.assert_called_once_with(
+        "192.0.2.10",
+        5684,
+        auth=auth,
+        on_notification=callback,
+        local_port=49742,
+    )
+    session.connect.assert_not_called()
+    session.start_reader.assert_not_called()
+
+
+def test_entry_authentication_uses_the_certificate_factory() -> None:
+    data = {
+        CONF_AUTH_TYPE: AUTH_CERTIFICATE,
+        CONF_LEAF_CERT_PEM: "CERTIFICATE",
+        CONF_LEAF_KEY_PEM: "PRIVATE KEY",
+    }
+    auth = MagicMock(spec=protocol_auth.CertificateAuth)
+
+    with patch.object(
+        session_factory,
+        "create_certificate_auth",
+        return_value=auth,
+    ) as certificate_factory:
+        result = session_factory.authentication_provider_from_entry(data)
+
+    assert result is auth
+    certificate_factory.assert_called_once_with("CERTIFICATE", "PRIVATE KEY")
+
+
+def test_entry_authentication_uses_the_owner_psk_factory() -> None:
+    data = {
+        CONF_AUTH_TYPE: AUTH_OWNER_PSK,
+        CONF_OWNER_UUID: "12121212-3434-4656-8787-9a9a9a9a9a9a",
+        CONF_OWNER_PSK: "00112233445566778899aabbccddeeff",
+    }
+    auth = MagicMock(spec=protocol_auth.PskAuth)
+
+    with patch.object(
+        session_factory,
+        "create_owner_psk_auth",
+        return_value=auth,
+    ) as owner_psk_factory:
+        result = session_factory.authentication_provider_from_entry(data)
+
+    assert result is auth
+    owner_psk_factory.assert_called_once_with(
+        "12121212-3434-4656-8787-9a9a9a9a9a9a",
+        "00112233445566778899aabbccddeeff",
+    )
+
+
+def test_create_entry_session_uses_one_validated_provider_and_endpoint() -> None:
+    data = {CONF_HOST: "192.0.2.10", CONF_PORT: 5684, CONF_AUTH_TYPE: AUTH_OWNER_PSK}
+    auth = MagicMock(spec=protocol_auth.PskAuth)
+    callback = MagicMock()
+    session = MagicMock(spec=dtls_session.DtlsCoapSession)
+
+    with (
+        patch.object(
+            session_factory,
+            "authentication_provider_from_entry",
+            return_value=auth,
+        ) as provider_from_entry,
+        patch.object(
+            session_factory,
+            "create_dtls_session",
+            return_value=session,
+        ) as session_builder,
+    ):
+        result = session_factory.create_entry_session(
+            data,
+            on_notification=callback,
+            local_port=49742,
+        )
+
+    assert result is session
+    provider_from_entry.assert_called_once_with(data)
+    session_builder.assert_called_once_with(
+        "192.0.2.10",
+        5684,
+        auth=auth,
+        on_notification=callback,
+        local_port=49742,
+    )
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {},
+        {CONF_HOST: "", CONF_PORT: 5684},
+        {CONF_HOST: "192.0.2.10", CONF_PORT: True},
+        {CONF_HOST: "192.0.2.10", CONF_PORT: 0},
+        {CONF_HOST: "192.0.2.10", CONF_PORT: 65536},
+    ],
+)
+def test_create_entry_session_rejects_invalid_endpoints_before_auth(data: dict) -> None:
+    with (
+        patch.object(session_factory, "authentication_provider_from_entry") as provider,
+        pytest.raises(ValueError, match="session endpoint"),
+    ):
+        session_factory.create_entry_session(data)
+
+    provider.assert_not_called()
 
 
 def test_real_certificate_provider_is_session_compatible_and_redacted() -> None:

--- a/tests/localthings/test_statistics_migration.py
+++ b/tests/localthings/test_statistics_migration.py
@@ -72,7 +72,7 @@ async def test_relabels_every_particulate_sensor(hass: HomeAssistant) -> None:
         # µg/m³ has a converter, so the class must be named, not None --
         # passing neither is deprecated and breaks in HA Core 2026.11.
         assert call.kwargs["new_unit_class"] == "concentration"
-    assert entry.version == 4
+    assert entry.version == 5
 
 
 async def test_leaves_other_sensors_on_the_same_device_alone(hass: HomeAssistant) -> None:
@@ -102,7 +102,7 @@ async def test_skips_families_that_did_not_gain_the_unit(hass: HomeAssistant) ->
             assert await async_migrate_entry(hass, entry) is True
 
         assert relabel.call_args_list == [], device_type
-        assert entry.version == 4
+        assert entry.version == 5
 
 
 async def test_defers_rather_than_consuming_the_migration_without_the_recorder(
@@ -127,7 +127,7 @@ async def test_defers_rather_than_consuming_the_migration_without_the_recorder(
         assert await async_migrate_entry(hass, entry) is True
 
     assert len(relabel.call_args_list) == 1
-    assert entry.version == 4
+    assert entry.version == 5
 
 
 async def test_omits_unit_class_on_an_older_home_assistant(hass: HomeAssistant) -> None:
@@ -151,7 +151,7 @@ async def test_omits_unit_class_on_an_older_home_assistant(hass: HomeAssistant) 
         assert await async_migrate_entry(hass, entry) is True
 
     assert seen == [{"new_unit_of_measurement": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER}]
-    assert entry.version == 4
+    assert entry.version == 5
 
 
 async def test_a_relabel_failure_never_fails_the_entry(hass: HomeAssistant) -> None:
@@ -165,7 +165,7 @@ async def test_a_relabel_failure_never_fails_the_entry(hass: HomeAssistant) -> N
     with patch(RELABEL, autospec=True, side_effect=TypeError("older HA signature")):
         assert await async_migrate_entry(hass, entry) is True
 
-    assert entry.version == 4
+    assert entry.version == 5
 
 
 async def test_follows_a_renamed_entity_rather_than_rebuilding_its_id(
@@ -226,4 +226,4 @@ async def test_a_fresh_entry_starts_at_the_migrated_version(hass: HomeAssistant)
     """
     from custom_components.localthings.config_flow import LocalThingsConfigFlow
 
-    assert LocalThingsConfigFlow.VERSION == 4
+    assert LocalThingsConfigFlow.VERSION == 5

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -130,3 +130,21 @@ def test_bare_key_redaction_does_not_leak_into_substring_matching():
         "spinSpeed": "1200",
         "name": "FilterProgress",
     }
+
+
+def test_redacts_psk_and_credential_keys_without_redacting_ordinary_values():
+    redacted = redact_resources(
+        {
+            "/wireless": {
+                "wifiPsk": "00112233445566778899aabbccddeeff",
+                "ownerCredential": "private-controller-state",
+                "securityType": "WPA2-PSK",
+            },
+        }
+    )
+
+    assert redacted["/wireless"] == {
+        "wifiPsk": REDACTED,
+        "ownerCredential": REDACTED,
+        "securityType": "WPA2-PSK",
+    }


### PR DESCRIPTION
## Depends on #418

This is the immediate step-2 follow-up discussed in #388. It is intentionally a draft while #418 is open.

The branch contains #418's session-factory patch replayed onto current `main`. After #418 merges, I will rebase this branch and drop the duplicated parent commit before requesting review.

## Summary

- add an explicit, fail-closed certificate/OwnerPSK credential model
- migrate legacy v4 entries to explicit certificate mode without changing endpoint, credential, identity, or registry values
- construct OwnerPSK sessions through `PskAuth` and bind the authenticated peer to the configured `/oic/d` device UUID before publishing the session
- add standard Home Assistant reauthentication plus a user-initiated reconfigure path for OwnerPSK replacement
- keep credential material out of representations, diagnostics, errors, and resource dumps

## Why #418 comes first

#418 establishes one provider-based DTLS session-construction seam while preserving existing certificate behavior. This PR selects `CertificateAuth` or `PskAuth` at that seam, so authentication does not branch independently across initial setup, reconnect, and recovery paths.

## Authentication boundary

This consumes an OwnerPSK that the caller already possesses. It does not discover, extract, derive, mint, provision, rotate, transfer ownership, perform OTM, reset a device, or write OCF security resources.

No OwnerPSK onboarding form is added here. This draft establishes the config-entry, runtime, identity-binding, and recovery contract for the concrete device-support work that follows.

Current SmartThings-Local releases classify both a rejected PSK handshake and some endpoint/backend failures as generic `SessionError`. This PR does not guess that every such error is bad credentials. Automatic reauthentication is triggered only for definite invalid configuration, authenticated device mismatch, or an explicit `AuthenticationError`; manual reconfigure remains available for credential replacement. A package-side error-classification improvement can tighten the automatic path later without changing the stored model.

## Follow-up

After #418 and this credential/runtime layer are reviewed, the next changes are:

1. pluggable `/device/0` versus `/oic/res` resource enumeration for #388;
2. a separate, sanitized WD86 capability/entity/status/control PR using this OwnerPSK path; and
3. endpoint rediscovery as its own bounded change.

The WD86 work needs this PR first because its authenticated read and control sessions require an explicit OwnerPSK-backed config entry, exact device binding, and a safe credential-replacement path. Keeping those generic concerns here avoids embedding authentication policy in one appliance profile.

## Integration note

#407 also currently reserves config-entry version 5. If it merges first, this draft will rebase and move this migration to version 6.

## Validation

- `python -m pytest -p no:cacheprovider tests/ -q`: 1,809 passed with SmartThings-Local 0.1.12
- focused credential/session/config-flow/coordinator/diagnostics/migration suite: 222 passed
- Ruff format and lint checks
- `ty check custom_components tests`
- translation JSON parse validation
- `git diff --check origin/main...HEAD`

Relates to #388. Depends on #418. This does not close #388.
