### PR TITLE
Decode what each course allows from supportedOptions (#408, with review fixes)

### DIFF
--- a/custom_components/localthings/registry/capabilities/laundry.py
+++ b/custom_components/localthings/registry/capabilities/laundry.py
@@ -258,9 +258,16 @@ def drum_clean_last_cleaned(rep):
 #
 #   <hdr:1 nibble> ( <course:1> ( <kind:nibble><default:nibble> <mask:1> )* )*
 #
+# The header is the group count, so it states the record width: 1 + 2*hdr
+# bytes. True on all 17 dumps here, across six distinct widths, and it
+# reproduces the codes the old smallest-that-parses scan derived on every
+# one of them -- see _course_records, which keeps that scan as a fallback.
+#
 # The mask indexes that option's own supported<Option> list, and so does
 # the default nibble -- but into the list, not into the mask: a dishwasher
-# reports default 0 with a mask allowing only index 1.
+# reports default 0 with a mask allowing only index 1. It is one byte, so
+# it cannot address past index 7: three boards carry an 11- or 13-entry
+# supportedDryTime, and none of them carries a group for it.
 #
 # Four kinds are named: 0x8 water temperature, 0x9 rinse and 0xA spin from a
 # WW6500 panel reading plus a list-length argument (the reading alone cannot
@@ -294,14 +301,20 @@ OPTION_KIND_DRY = 0xD
 def _course_records(course_rep, must_cover=None):
     """{course code: record hex} from supportedOptions, or {} if unreadable.
 
-    Record width is recovered the way it always has been -- see the guards
-    in _course_codes_from_supported_options, which this backs.
+    The header states the width (1 + 2*hdr bytes), so that split is tried
+    first and taken whenever it satisfies the guards below. The
+    smallest-that-parses scan those guards were written for stays as the
+    fallback: it is what every course list shipped so far was derived from,
+    and the header rule reproduces it exactly on all 17 dumps, so nothing
+    rests on the header being right about a board none of us has seen.
 
-    `must_cover` adds one more: the split's course codes must include every
-    code given. Callers that can see a live editCourseList pass it, which
-    pins the width outright on every dump here that has one; the
-    course-list fallback itself cannot, since it only runs when that list
-    is missing in the first place.
+    `must_cover` is a further check, not a search: the split's codes must
+    include every code given. Callers that can see a live editCourseList
+    pass it. An unsatisfiable one no longer means "say nothing" -- a device
+    that lists a course supportedOptions does not carry (a personal or
+    cloud slot, say) would otherwise switch the decoder off wholesale, and
+    silently, which is the failure mode this module is most anxious about.
+    A covering split wins; failing that, the smallest passing one does.
     """
     raw = course_rep.get("x.com.samsung.da.supportedOptions")
     hexstr = raw[0] if isinstance(raw, list) and raw else raw
@@ -312,22 +325,41 @@ def _course_records(course_rep, must_cover=None):
         return {}
     total_bytes = len(body) // 2
     current = option_value(course_rep.get("x.com.samsung.da.options"), "Course")
-    for k in range(1, total_bytes + 1):
-        if total_bytes % k:
-            continue
+
+    def split(k):
+        """Records at a width of k bytes, or None if k can't be the width."""
+        if k < 1 or total_bytes % k:
+            return None
         n = total_bytes // k
+        # Two records minimum: k == total_bytes satisfies every guard below
+        # trivially, so a table of one is indistinguishable from garbage.
         if n < 2:
-            continue
+            return None
         records = [body[i * k * 2 : (i + 1) * k * 2] for i in range(n)]
         firsts = [r[:2] for r in records]
         if len(set(firsts)) != n:
-            continue
+            return None
         if current is not None and current not in firsts:
-            continue
-        if must_cover and not must_cover <= set(firsts):
-            continue
+            return None
         return dict(zip(firsts, records, strict=True))
-    return {}
+
+    try:
+        stated = split(1 + 2 * int(hexstr[0], 16))
+    except ValueError:
+        stated = None  # header isn't hex, so it states nothing
+    if stated is not None and (not must_cover or must_cover <= set(stated)):
+        return stated
+
+    fallback = None
+    for k in range(1, total_bytes + 1):
+        records = split(k)
+        if records is None:
+            continue
+        if must_cover and not must_cover <= set(records):
+            fallback = fallback or records
+            continue
+        return records
+    return fallback or {}
 
 
 def course_option_mask(resources, kind, course=None):
@@ -345,10 +377,14 @@ def course_option_mask(resources, kind, course=None):
     want a fallback value have to decide for themselves whether an
     out-of-set default is usable.
 
-    Where the device also publishes an editCourseList, the split has to
-    account for every code on it (see _course_records). That check is free
-    here and it is the difference between mis-gating an entity silently and
-    declining to gate it at all.
+    Where the device also publishes an editCourseList, it is handed to
+    _course_records as a check on the split -- free here, and worth having
+    where the header and the scan could disagree.
+
+    `course` is matched case-insensitively. Device-side codes are uppercase
+    hex, but select.py lowercases an entity's options for the translation
+    catalog, so a caller reaching for what the entity displays rather than
+    the raw Course_ token would otherwise get a silent "no opinion".
     """
     course_rep = resources.get("/course/vs/0") or {}
     edit_list = parse_edit_course_list(
@@ -359,7 +395,9 @@ def course_option_mask(resources, kind, course=None):
         return None
     if course is None:
         course = option_value(course_rep.get("x.com.samsung.da.options"), "Course")
-    record = records.get(course)
+    if not isinstance(course, str):
+        return None
+    record = {code.upper(): r for code, r in records.items()}.get(course.upper())
     if record is None:
         return None
     for i in range(2, len(record), 4):
@@ -393,16 +431,12 @@ def _course_codes_from_supported_options(course_rep):
     evenly into `header + N * K bytes` with fully unique first bytes across
     all N records, at the record's true byte width.
 
-    Two conservative guards rather than guessing further: the derived codes
-    must all be distinct, and must include whatever course is currently
-    selected. If no split satisfies both, this returns [].
-
-    Among splits that satisfy both, the smallest passing K wins -- more
-    than one K reliably passes on real data, and smallest-K-wins matches
-    the confirmed answer on all six dumps checked, though it's a heuristic
-    rather than a proof. Not guarded further: course tables are typically
-    large enough that colliding by chance on both checks is unlikely, and
-    no device seen so far needs it.
+    K is the width the header states, checked by two conservative guards
+    rather than trusted outright: the derived codes must all be distinct,
+    and must include whatever course is currently selected. Where the
+    header doesn't hold up, the smallest passing K wins instead -- the
+    heuristic this fallback shipped with, kept because every course list
+    derived so far came out of it. If nothing passes, this returns [].
 
     The record payload behind those first bytes is decoded by
     course_option_mask above; both share _course_records, so the split

--- a/custom_components/localthings/registry/capabilities/laundry.py
+++ b/custom_components/localthings/registry/capabilities/laundry.py
@@ -250,6 +250,158 @@ def drum_clean_last_cleaned(rep):
         return None
 
 
+# ---------------------------------------------------------------------------
+# supportedOptions -- what each course permits.
+#
+# A 1-nibble header followed by one fixed-width record per selectable
+# course. A record is that course's own hex code, then zero or more 2-byte
+# groups; every fixture in the corpus fits `1 + 2*groups` bytes, from an
+# AirDresser carrying no groups at all to an 11-byte WA8000T record.
+#
+#   <hdr:1 nibble> ( <course:1> ( <kind:nibble><default:nibble> <mask:1> )* )*
+#
+# The mask indexes that option's own supported<Option> list, and so does
+# the default nibble -- but into the list, not into the mask: a dishwasher
+# reports default 0 with a mask allowing only index 1.
+#
+# Four kinds are pinned, each against a device that can contradict them:
+#
+#   0xD dry     A DV5000T's fourteen records reproduce exactly what its
+#               panel offers per course -- 1/2/3 on Cotton, only 2 on
+#               Towels, only 1 on Wool, none on Quick Dry or the three
+#               air/time courses.
+#   0x8 temp    A WW6500 owner read one course's three dials off the
+#   0x9 rinse   panel: Cold/20/30/40 with no "None" offered, every rinse
+#   0xA spin    count including none, and every spin including rinse-hold.
+#               Its masks are 0x1E/0x3F/0x3F, which decode to exactly
+#               those sets against supportedWaterTemperature (0x1E skips
+#               bit 0, the "None" the panel indeed omits),
+#               supportedRinseCycles and supportedSpinLevel. Only 0x8
+#               reaches bit 6 anywhere in that table, which none of the
+#               other two lists is long enough to hold.
+#
+# Corroborating all four: across every dump here, each live value sits
+# inside the set its course's mask decodes to. 0x0/0x5/0x6/0x7/0xB/0xC
+# stay unnamed -- nothing pins them, and 0xE looks like dry time on the one
+# board that carries it but no dump proves it.
+#
+# The kinds are not entity names. 0xD is "dry", not "dry level":
+# dishwashers carry it with no supportedDryLevel at all (their dry setting
+# is heated_dry). A caller keys the mask against its own list rather than
+# assuming what it counts.
+#
+# A mask is what supportedOptions advertises, and an appliance can enforce
+# more than it advertises: a WW6500 offers only 2-5 rinses on Baby Care --
+# on its own panel, not just in SmartThings -- where the mask allows all
+# six. Its other thirteen courses match dial for dial, default included.
+# So gating on a mask can offer a little more than the machine really
+# takes. That is the safe direction, since the device refuses what it will
+# not do, but it is not a guarantee and an entity should not present a
+# mask as the appliance's last word.
+#
+# An empty mask means the device declares no range, which is NOT
+# automatically "nothing is selectable". On a dryer's Quick Dry it really
+# is none (panel-confirmed above), but a washer's cloud Download slot
+# reports empty masks for all three of its kinds while still holding live
+# values, because the downloaded program supplies its own. Deciding
+# between those is the caller's job, per entity, with its own evidence.
+# ---------------------------------------------------------------------------
+
+OPTION_KIND_WATER_TEMPERATURE = 0x8
+OPTION_KIND_RINSE = 0x9
+OPTION_KIND_SPIN = 0xA
+OPTION_KIND_DRY = 0xD
+
+
+def _course_records(course_rep, must_cover=None):
+    """{course code: record hex} from supportedOptions, or {} if unreadable.
+
+    Record width is recovered the way it always has been -- see the guards
+    in _course_codes_from_supported_options, which this backs.
+
+    `must_cover` adds one more: the split's course codes must include every
+    code given. Callers that can see a live editCourseList pass it, which
+    pins the width outright on every dump here that has one; the
+    course-list fallback itself cannot, since it only runs when that list
+    is missing in the first place.
+    """
+    raw = course_rep.get("x.com.samsung.da.supportedOptions")
+    hexstr = raw[0] if isinstance(raw, list) and raw else raw
+    if not isinstance(hexstr, str) or len(hexstr) < 3:
+        return {}
+    body = hexstr[1:]
+    if len(body) % 2:
+        return {}
+    total_bytes = len(body) // 2
+    current = option_value(course_rep.get("x.com.samsung.da.options"), "Course")
+    for k in range(1, total_bytes + 1):
+        if total_bytes % k:
+            continue
+        n = total_bytes // k
+        if n < 2:
+            continue
+        records = [body[i * k * 2 : (i + 1) * k * 2] for i in range(n)]
+        firsts = [r[:2] for r in records]
+        if len(set(firsts)) != n:
+            continue
+        if current is not None and current not in firsts:
+            continue
+        if must_cover and not must_cover <= set(firsts):
+            continue
+        return dict(zip(firsts, records, strict=True))
+    return {}
+
+
+def course_option_mask(resources, kind, course=None):
+    """(default index, allowed indices) for `kind` on the selected course.
+
+    None when this device says nothing usable -- no supportedOptions, an
+    unrecognized course, or no group of that kind on the record. Callers
+    treat that as "no opinion" rather than "nothing allowed": several
+    boards carry supported<Option> lists with no supportedOptions groups at
+    all, and refusing everything there would be worse than not gating.
+
+    The default index is into the same supported<Option> list as the
+    allowed indices, but it is NOT necessarily one of them -- a dishwasher
+    reports default 0 alongside a mask allowing only index 1. Callers that
+    want a fallback value have to decide for themselves whether an
+    out-of-set default is usable.
+
+    Where the device also publishes an editCourseList, the split has to
+    account for every code on it (see _course_records). That check is free
+    here and it is the difference between mis-gating an entity silently and
+    declining to gate it at all.
+    """
+    course_rep = resources.get("/course/vs/0") or {}
+    edit_list = parse_edit_course_list(
+        (resources.get("/wm/editcourse/vs/0") or {}).get("x.com.samsung.da.editCourseList")
+    )
+    records = _course_records(course_rep, must_cover=set(edit_list))
+    if not records:
+        return None
+    if course is None:
+        course = option_value(course_rep.get("x.com.samsung.da.options"), "Course")
+    record = records.get(course)
+    if record is None:
+        return None
+    for i in range(2, len(record), 4):
+        group = record[i : i + 4]
+        if len(group) < 4:
+            break
+        try:
+            head = int(group[:2], 16)
+            mask = int(group[2:], 16)
+        except ValueError:
+            # Not hex after all, so this split is not a record table --
+            # the width guards alone can't tell. Say nothing rather than
+            # raise into whatever entity asked.
+            return None
+        if head >> 4 != kind:
+            continue
+        return head & 0xF, [bit for bit in range(8) if mask >> bit & 1]
+    return None
+
+
 def _course_codes_from_supported_options(course_rep):
     """Fallback for an empty/missing editCourseList: derive the selectable
     course list from /course/vs/0's own supportedOptions instead (issue #1:
@@ -273,29 +425,12 @@ def _course_codes_from_supported_options(course_rep):
     rather than a proof. Not guarded further: course tables are typically
     large enough that colliding by chance on both checks is unlikely, and
     no device seen so far needs it.
+
+    The record payload behind those first bytes is decoded by
+    course_option_mask above; both share _course_records, so the split
+    they see can never drift apart.
     """
-    raw = course_rep.get("x.com.samsung.da.supportedOptions")
-    hexstr = raw[0] if isinstance(raw, list) and raw else raw
-    if not isinstance(hexstr, str) or len(hexstr) < 3:
-        return []
-    body = hexstr[1:]
-    if len(body) % 2:
-        return []
-    total_bytes = len(body) // 2
-    current = option_value(course_rep.get("x.com.samsung.da.options"), "Course")
-    for k in range(1, total_bytes + 1):
-        if total_bytes % k:
-            continue
-        n = total_bytes // k
-        if n < 2:
-            continue
-        firsts = [body[i * k * 2 : i * k * 2 + 2] for i in range(n)]
-        if len(set(firsts)) != n:
-            continue
-        if current is not None and current not in firsts:
-            continue
-        return firsts
-    return []
+    return list(_course_records(course_rep))
 
 
 def option_tokens(*pairs):

--- a/custom_components/localthings/registry/capabilities/laundry.py
+++ b/custom_components/localthings/registry/capabilities/laundry.py
@@ -254,9 +254,7 @@ def drum_clean_last_cleaned(rep):
 # supportedOptions -- what each course permits.
 #
 # A 1-nibble header followed by one fixed-width record per selectable
-# course. A record is that course's own hex code, then zero or more 2-byte
-# groups; every fixture in the corpus fits `1 + 2*groups` bytes, from an
-# AirDresser carrying no groups at all to an 11-byte WA8000T record.
+# course: the course's own hex code, then zero or more 2-byte groups.
 #
 #   <hdr:1 nibble> ( <course:1> ( <kind:nibble><default:nibble> <mask:1> )* )*
 #
@@ -264,47 +262,27 @@ def drum_clean_last_cleaned(rep):
 # the default nibble -- but into the list, not into the mask: a dishwasher
 # reports default 0 with a mask allowing only index 1.
 #
-# Four kinds are pinned, each against a device that can contradict them:
+# Four kinds are named: 0x8 water temperature, 0x9 rinse and 0xA spin from a
+# WW6500 panel reading plus a list-length argument (the reading alone cannot
+# separate rinse from spin), 0xD dry from a DV5000T's. The rest stay unnamed,
+# 0xB included -- but 0xB, not 0xD, is the dry dial on the WW6600R combo,
+# which carries no 0xD at all, so a gate keyed on 0xD alone silently no-ops
+# there. Evidence for all of it in docs/investigations/course-option-groups.md.
 #
-#   0xD dry     A DV5000T's fourteen records reproduce exactly what its
-#               panel offers per course -- 1/2/3 on Cotton, only 2 on
-#               Towels, only 1 on Wool, none on Quick Dry or the three
-#               air/time courses.
-#   0x8 temp    A WW6500 owner read one course's three dials off the
-#   0x9 rinse   panel: Cold/20/30/40 with no "None" offered, every rinse
-#   0xA spin    count including none, and every spin including rinse-hold.
-#               Its masks are 0x1E/0x3F/0x3F, which decode to exactly
-#               those sets against supportedWaterTemperature (0x1E skips
-#               bit 0, the "None" the panel indeed omits),
-#               supportedRinseCycles and supportedSpinLevel. Only 0x8
-#               reaches bit 6 anywhere in that table, which none of the
-#               other two lists is long enough to hold.
+# A kind is not an entity name: dishwashers carry 0xD with no
+# supportedDryLevel at all (their dry setting is heated_dry), so callers key
+# the mask against their own list rather than assuming what it counts.
 #
-# Corroborating all four: across every dump here, each live value sits
-# inside the set its course's mask decodes to. 0x0/0x5/0x6/0x7/0xB/0xC
-# stay unnamed -- nothing pins them, and 0xE looks like dry time on the one
-# board that carries it but no dump proves it.
+# Two things a caller cannot infer from the bytes:
 #
-# The kinds are not entity names. 0xD is "dry", not "dry level":
-# dishwashers carry it with no supportedDryLevel at all (their dry setting
-# is heated_dry). A caller keys the mask against its own list rather than
-# assuming what it counts.
-#
-# A mask is what supportedOptions advertises, and an appliance can enforce
-# more than it advertises: a WW6500 offers only 2-5 rinses on Baby Care --
-# on its own panel, not just in SmartThings -- where the mask allows all
-# six. Its other thirteen courses match dial for dial, default included.
-# So gating on a mask can offer a little more than the machine really
-# takes. That is the safe direction, since the device refuses what it will
-# not do, but it is not a guarantee and an entity should not present a
-# mask as the appliance's last word.
-#
-# An empty mask means the device declares no range, which is NOT
-# automatically "nothing is selectable". On a dryer's Quick Dry it really
-# is none (panel-confirmed above), but a washer's cloud Download slot
-# reports empty masks for all three of its kinds while still holding live
-# values, because the downloaded program supplies its own. Deciding
-# between those is the caller's job, per entity, with its own evidence.
+#   - A mask is what the device advertises, not what it enforces. A WW6500
+#     takes only 2-5 rinses on Baby Care -- on its own panel, not just in
+#     SmartThings -- where the mask allows all six. Gating on one offers at
+#     most a little too much, which the appliance then refuses.
+#   - An empty mask is NOT automatically "nothing is selectable". On a
+#     dryer's Quick Dry it is, but a washer's cloud Download slot reports
+#     empty masks for every kind while still holding live values, because
+#     the downloaded program supplies its own. That call is the caller's.
 # ---------------------------------------------------------------------------
 
 OPTION_KIND_WATER_TEMPERATURE = 0x8

--- a/docs/investigations/course-option-groups.md
+++ b/docs/investigations/course-option-groups.md
@@ -1,0 +1,108 @@
+# What each course permits: decoding `supportedOptions`
+
+`laundry.py`'s `course_option_mask` reads `/course/vs/0`'s `supportedOptions`
+past the course codes and into the payload behind each one. The module
+comment carries the conclusions and the caveats a caller needs; this file
+carries the evidence behind the kind numbers, and the one board that does not
+fit them.
+
+## The format
+
+```
+supportedOptions = <1 nibble header> + one record per course
+record           = <course code:1B> then 2-byte groups
+group            = <kind nibble><default nibble> <mask>
+```
+
+Every shipped dump fits `1 + 2×groups` bytes per record — widths of 1, 3, 5,
+7, 9 and 11 bytes, from an AirDresser carrying no groups to the WA8000T. The
+mask indexes that option's own `supported<Option>` list, and so does the
+default nibble — but into the list, not into the mask: the dishwasher reports
+default `0` with a mask allowing only index `1`.
+
+## The four named kinds
+
+| Kind | Named | Evidence |
+| --- | --- | --- |
+| `0x8` | water temperature | WW6500 panel reading; the only kind reaching bit 6 on that table, and `supportedWaterTemperature` its only seven-entry list |
+| `0x9` | rinse | the same reading pins the set; `0xA` is ruled out as rinse below |
+| `0xA` | spin | as above — the only one of the two that can address index 6 |
+| `0xD` | dry | DV5000T owner's per-course panel report, corroborated by the DV6800N on a different board and code space |
+
+**`0xD`.** A DV5000T owner reported what their panel offers per course, and
+its fourteen records reproduce that exactly. The DV6800N (`dryer_dv6800n`) is
+the independent check — different board family, different code space, courses
+labelled — and its policy lands course-for-course on the same shape: full
+range on Cotton/Mixed/Synthetics, one fixed level on Wool and Iron Dry, a
+different one on Bedding and Delicates, a timed dry instead on Cool Air/Warm
+Air/Time Dry, neither on Quick Dry. It is also the only dump carrying both
+`0xD` and `0xE`, and no course offers both.
+
+**`0x8` / `0x9` / `0xA`.** A WW6500 owner read one course's three dials off
+the panel: Cold/20/30/40 with no "None", every rinse count, every spin
+including rinse-hold. Two of its courses carry exactly those sets:
+
+```
+5C  841E 923F A53F
+61  841E 943F A43F
+```
+
+`0x1E` skips bit 0, the `None` the panel indeed omits. The reading pins the
+*sets*, not which of `0x9`/`0xA` is which — their masks are `0x3F` alike, so
+swapping the two constants leaves it passing. What separates them is list
+length: on the `washer` dump `0xA` addresses index 6, which a six-entry
+`supportedRinseCycles` cannot hold, while `0x9` tops out at index 5.
+
+**Record shape.** The WW6500 also carries a `QuickWashSet_5B847E933FA53F`
+token — byte-identical to course `5B`'s record. A standalone copy in a
+separate field pins the width and group structure independently of the
+divisor scan that recovers them.
+
+**Corroboration.** Across every dump, each live `waterTemperature` /
+`rinseCycles` / `spinLevel` / `dryLevel` sits inside its course's decoded set,
+and no dry mask addresses past the end of `supportedDryLevel`.
+
+## The board that uses `0xB` instead of `0xD`
+
+Six dumps carry a `supportedDryLevel`; five route to the dryer registry.
+`washer_dryer_combo` — a WW6600R on `DA_WM_TP2_20_COMMON`, eight entries
+(None, Cupboard, 30, 60, 90, 120, 180, 240) — is the one routing to the
+**washer** registry, so `washer.py`'s `dry_level` select is the entity at
+stake. **It carries no `0xD` group at all**, and its `0xB` is unmistakably the
+dry dial:
+
+| courses | default | allowed |
+| --- | --- | --- |
+| wash+dry (`1C`, `1B`, `1E`, …) | None | None / Cupboard / 30 / 60 / 90 |
+| dry-only (`36`, `38`, `39`) | Cupboard | Cupboard / 30 / 60 / 90 |
+| wash-only (`24`, `30`, `32`, …) | None | *(empty)* |
+
+Dry-only courses dropping `None` and defaulting to `Cupboard` is the
+semantics you would want, the default matches the live `dryLevel` on the
+selected course, and there is no competing list it could be indexing — this
+board has no `supportedDryTime`. Two details for whoever gates it: the list
+mixes a dryness level with durations (`Cupboard`, then 30…240), and no course
+addresses past index 4, so `120`, `180` and `240` are advertised and offered
+by nothing.
+
+`0xB` stays unnamed anyway, because the corpus supports something narrower
+than "`0xB` is dry":
+
+- Not a combo rule — `washer_dryer_onebody_awm` is also a combo and uses
+  `0xD`.
+- Not a board-family rule — the DV5000T that `0xD` was named on is
+  `DA_WM_TP2_20_COMMON`, this WW6600R's own family.
+- The dishwasher cannot arbitrate: it carries `0xB` and `0xD` with
+  byte-identical payloads in every record (`B102 D102`, `B002 D002`; the cloud
+  board adds a matching `0xC`), so it reads as confirming `0xD` while being
+  unable to discriminate it.
+
+**The consequence:** a gate keyed on `0xD` alone silently no-ops on the one
+board whose `dry_level` select it would be narrowing.
+
+## Unnamed
+
+`0x0`, `0x5`, `0x6`, `0x7`, `0xB` and `0xC` all occur, none pinned beyond the
+above. `0xE` behaves like dry time on the DV6800N — decodes against
+`supportedDryTime`, mutually exclusive with `0xD` — but one board is not a
+pin; name it in the change that consumes it.

--- a/docs/investigations/course-option-groups.md
+++ b/docs/investigations/course-option-groups.md
@@ -20,6 +20,30 @@ mask indexes that option's own `supported<Option>` list, and so does the
 default nibble — but into the list, not into the mask: the dishwasher reports
 default `0` with a mask allowing only index `1`.
 
+**The header is the group count**, so the record width is stated rather than
+inferred: `1 + 2×hdr` bytes. It holds on all 17 dumps carrying a
+`supportedOptions`, across all six widths, and the split it gives is the one
+the original smallest-that-parses scan already produced on every one of them —
+so adopting it moved no course list and no golden.
+
+| hdr | 0 | 1 | 2 | 3 | 4 | 5 |
+| --- | --- | --- | --- | --- | --- | --- |
+| width (bytes) | 1 | 3 | 5 | 7 | 9 | 11 |
+| dumps | AirDresser | 5 | 2 | 5 | 3 | WA8000T |
+
+`_course_records` keeps the scan as a fallback for a board that contradicts
+this, and still checks the stated width against the guards the scan was
+written for (distinct course bytes, the selected course present, and any live
+`editCourseList` accounted for) rather than trusting it outright.
+
+**The mask is one byte**, so it cannot address past index 7. Most lists are
+comfortably shorter, but `supportedDryTime` is 11 entries on `dryer` and
+`dryer_tp1_21_drum_clean` and 13 on `washer_dryer_onebody_awm` (as is
+`washer_wa8000t`'s 12-entry `supportedWaterHeight`). None of those boards
+carries a group for it, so nothing here contradicts the format — but whatever
+encodes dry time on them is not an 8-bit-mask group of this shape, which is
+worth knowing before gating a dry-time entity on one.
+
 ## The four named kinds
 
 | Kind | Named | Evidence |
@@ -105,4 +129,11 @@ board whose `dry_level` select it would be narrowing.
 `0x0`, `0x5`, `0x6`, `0x7`, `0xB` and `0xC` all occur, none pinned beyond the
 above. `0xE` behaves like dry time on the DV6800N — decodes against
 `supportedDryTime`, mutually exclusive with `0xD` — but one board is not a
-pin; name it in the change that consumes it.
+pin; name it in the change that consumes it. Note that the DV6800N's
+`supportedDryTime` is six entries, and the three boards with an 11- or
+13-entry one carry no `0xE` at all, so the mask width says nothing has been
+seen that a single byte could not address.
+
+`0x6` is the one kind that reaches bit 7 anywhere in the corpus
+(`washer_wa8000t`, mask `0xA1` on eight of its thirteen courses). No named
+kind does.

--- a/tests/test_laundry_capabilities.py
+++ b/tests/test_laundry_capabilities.py
@@ -1,5 +1,7 @@
 """Tests for the shared laundry capabilities (washer/dryer/dishwasher)."""
 
+from typing import ClassVar
+
 from custom_components.localthings.registry.capabilities import laundry
 from custom_components.localthings.registry.entities import SelectDesc
 
@@ -295,6 +297,296 @@ class TestCourseCodesFromSupportedOptions:
             "8E",
             "8F",
         ]
+
+
+class TestCourseOptionGroups:
+    """The payload behind each supportedOptions record: 2-byte groups of
+    <kind nibble><default nibble> <mask>, the mask indexing that option's
+    own supported<Option> list.
+
+    Only kind 0xD is claimed. It was read off a DV5000T whose fourteen
+    records reproduce exactly what its panel offers per course, and the
+    same shape decodes in range on every dryer-family dump in the corpus
+    (see TestCourseOptionGroupsAcrossCorpus). The washer kinds 0x8/0x9/0xA
+    line up with temperature/rinse/spin by shape only, so nothing here
+    names them.
+    """
+
+    # DA_WM_TP1_21_COMMON DV9400B, from dryer_tp1_21_drum_clean: K=3, so a
+    # single dry group per record. 16 (Cotton) allows Damp/Less/Normal/More
+    # by mask 0x1E and defaults to Normal; 23 (Quick Dry 35') allows none.
+    _DRYER: ClassVar[dict] = {
+        "/course/vs/0": {
+            "x.com.samsung.da.options": ["Course_16"],
+            "x.com.samsung.da.supportedOptions": ["116D31E29D31E23D00017D31E"],
+        }
+    }
+
+    def test_decodes_the_selected_course_by_default(self):
+        assert laundry.course_option_mask(self._DRYER, laundry.OPTION_KIND_DRY) == (3, [1, 2, 3, 4])
+
+    def test_decodes_a_named_course(self):
+        mask = laundry.course_option_mask(self._DRYER, laundry.OPTION_KIND_DRY, course="29")
+        assert mask == (3, [1, 2, 3, 4])
+
+    def test_a_course_allowing_nothing_reports_an_empty_list(self):
+        """Distinct from None: the device does have an opinion here, and it
+        is that this course takes no dry setting at all."""
+        assert laundry.course_option_mask(self._DRYER, laundry.OPTION_KIND_DRY, course="23") == (
+            0,
+            [],
+        )
+
+    def test_none_when_the_course_is_not_in_the_table(self):
+        assert laundry.course_option_mask(self._DRYER, laundry.OPTION_KIND_DRY, course="ZZ") is None
+
+    def test_none_when_the_record_has_no_group_of_that_kind(self):
+        assert laundry.course_option_mask(self._DRYER, 0x9) is None
+
+    def test_none_without_supported_options(self):
+        assert laundry.course_option_mask({}, laundry.OPTION_KIND_DRY) is None
+        assert laundry.course_option_mask({"/course/vs/0": {}}, laundry.OPTION_KIND_DRY) is None
+
+    def test_non_hex_payload_says_nothing_rather_than_raising(self):
+        """The width guards alone can't tell a record table from arbitrary
+        text, so a payload that divides evenly but isn't hex still reaches
+        the group parse. It has to decline, not raise into whichever entity
+        happened to ask."""
+        resources = {
+            "/course/vs/0": {
+                "x.com.samsung.da.options": ["Course_16"],
+                "x.com.samsung.da.supportedOptions": ["016GG000017GG0000"],
+            }
+        }
+        assert laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY) is None
+
+    def test_default_index_is_into_the_list_not_the_allowed_set(self):
+        """A dishwasher reports default 0 while allowing only index 1, so a
+        caller cannot treat the default as a member of the allowed set."""
+        from tests.conftest import _load_device
+
+        resources = _load_device("dishwasher")
+        found = laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY, course="83")
+        assert found == (0, [1])
+
+    def test_edit_course_list_overrides_a_narrower_passing_split(self):
+        """The editCourseList guard only earns its place where the smallest
+        otherwise-valid width is the wrong one -- on every shipped dump the
+        smallest already covers the list, so a corpus fixture cannot tell
+        the guard from its absence.
+
+        Built to be exactly that case: twelve bytes split six ways gives
+        unique first bytes that include the selected course, so the old
+        guards accept it, but two of the four codes the device lists as
+        selectable are then nowhere to be found.
+        """
+        course_rep = {
+            "x.com.samsung.da.options": ["Course_11"],
+            "x.com.samsung.da.supportedOptions": ["1110022334400550066778800"],
+        }
+        assert list(laundry._course_records(course_rep)) == ["11", "22", "44", "55", "66", "88"]
+
+        listed = {"11", "33", "55", "77"}
+        records = laundry._course_records(course_rep, must_cover=listed)
+        assert list(records) == ["11", "33", "55", "77"]
+        assert len(next(iter(records.values()))) == 6  # three bytes, not two
+
+    def test_groups_are_read_on_their_own_boundaries(self):
+        """Groups are two bytes each after the course byte, so the scan has
+        to step four hex digits at a time. A window landing half a group
+        out would still parse -- and answer for a kind the record does not
+        carry -- rather than failing, so nothing else in the corpus would
+        notice the stride being wrong.
+
+        Here every record is <course><A8 9D><31 E2>. Read correctly there
+        is no rinse (0x9) group at all; read two digits out of step, the
+        bytes '9D 31' look exactly like one.
+        """
+        course_rep = {
+            "x.com.samsung.da.options": ["Course_01"],
+            "x.com.samsung.da.supportedOptions": [
+                "1" + "".join(f"{code:02X}A89D31E2" for code in range(1, 7))
+            ],
+        }
+        resources = {"/course/vs/0": course_rep}
+        assert laundry._course_records(course_rep)["01"] == "01A89D31E2"
+
+        assert laundry.course_option_mask(resources, 0x9) is None
+        # The real group, whose mask also reaches bit 7 -- the top of the
+        # byte, unexercised anywhere in the corpus.
+        assert laundry.course_option_mask(resources, 0xA) == (8, [0, 2, 3, 4, 7])
+
+    def test_reads_past_a_group_of_another_kind(self):
+        """A DVE50A8600 record is <course><kind-8 group><dry group>, so the
+        dry mask is only reachable by scanning past a group of another kind.
+
+        Driven off the real dump rather than a trimmed copy of it: the
+        record width is recovered from how the whole table divides, so a
+        two-record excerpt legitimately resolves to a different width than
+        the nineteen-record original.
+        """
+        from tests.conftest import _load_device
+
+        resources = _load_device("dryer_dve50a8600")
+        levels = resources["/washer/vs/0"]["x.com.samsung.da.supportedDryLevel"]
+        assert levels == ["None", "Damp", "Less", "Normal", "More", "Very"]
+
+        default, allowed = laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY)
+        assert [levels[i] for i in allowed] == ["Damp", "Less", "Normal", "More", "Very"]
+        assert levels[default] == "Normal"
+        # The kind-8 group ahead of it decodes too, unnamed on purpose.
+        assert laundry.course_option_mask(resources, 0x8) is not None
+
+
+class TestCourseOptionGroupsAcrossCorpus:
+    """Structure invariants over every shipped dump, so a future fixture
+    that decodes differently fails here rather than silently mis-gating an
+    entity."""
+
+    def _dumps(self):
+        from tests.conftest import FIXTURES, _load_device
+
+        for path in sorted(FIXTURES.glob("*_device.json")):
+            yield path.name, _load_device(path.name[: -len("_device.json")])
+
+    def test_every_record_is_a_course_byte_plus_whole_groups(self):
+        odd = []
+        for name, resources in self._dumps():
+            records = laundry._course_records(resources.get("/course/vs/0") or {})
+            for code, record in records.items():
+                # hex chars: 2 for the course byte, then 4 per group.
+                if (len(record) - 2) % 4:
+                    odd.append((name, code, record))
+        assert odd == []
+
+    def test_confirmed_ww6500_course_matches_its_panel(self):
+        """A WW6500 owner read one course's three dials off the panel:
+        Cold/20/30/40 with no "None" offered, every rinse count including
+        none, and every spin including rinse-hold. Two of its fourteen
+        courses carry exactly those sets (they differ only in defaults), so
+        this pins the sets rather than the course code -- which is all the
+        kind naming rests on.
+        """
+        from tests.conftest import _load_device
+
+        resources = _load_device("washer_ww6500")
+        washer = resources["/washer/vs/0"]
+        lists = (
+            (laundry.OPTION_KIND_WATER_TEMPERATURE, "supportedWaterTemperature"),
+            (laundry.OPTION_KIND_RINSE, "supportedRinseCycles"),
+            (laundry.OPTION_KIND_SPIN, "supportedSpinLevel"),
+        )
+        reported = (
+            ["Cold", "20", "30", "40"],
+            ["0", "1", "2", "3", "4", "5"],
+            ["RinseHold", "NoSpin", "400", "800", "1200", "1400"],
+        )
+        matching = []
+        for code in laundry.cycle_options(resources):
+            decoded = []
+            for kind, field in lists:
+                found = laundry.course_option_mask(resources, kind, course=code)
+                supported = washer[f"x.com.samsung.da.{field}"]
+                decoded.append([supported[i] for i in found[1]] if found else None)
+            if tuple(decoded) == reported:
+                matching.append(code)
+        assert matching == ["5C", "61"]
+
+    def test_dv6800n_dry_policy_agrees_with_the_other_board_family(self):
+        """The DV6800N is the one dump carrying both a dry-level (0xD) and a
+        dry-time (0xE) group, and its courses are labelled -- so it is where
+        the decode can be sanity-checked against meaning rather than bytes.
+
+        Its policy lands course-for-course on what a DV5000T owner reported
+        from their panel, despite a different board family and a different
+        course-code space (Table_00 here, Table_03 there): full range on
+        cottons/mixed/synthetics, a single fixed level on wool and iron dry,
+        a different single level on bedding/delicates, a timed dry instead
+        of a level on the air and time courses, and neither on Quick Dry.
+        Two unrelated code spaces would not agree like that on a mask read
+        at the wrong offset.
+        """
+        from tests.conftest import _load_device
+
+        resources = _load_device("dryer_dv6800n")
+        levels = resources["/washer/vs/0"]["x.com.samsung.da.supportedDryLevel"]
+        times = resources["/washer/vs/0"]["x.com.samsung.da.supportedDryTime"]
+
+        policy = {}
+        for code in laundry.cycle_options(resources):
+            dry = laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY, course=code)
+            timed = laundry.course_option_mask(resources, 0xE, course=code)
+            policy[code] = (
+                [levels[i] for i in dry[1]] if dry else [],
+                [times[i] for i in timed[1]] if timed else [],
+            )
+
+        # No course offers both -- the mutual exclusion the DV5000T owner
+        # described, corroborated here on a board they have never seen.
+        assert [c for c, (lv, tm) in policy.items() if lv and tm] == []
+
+        assert policy["9A"][0] == ["1", "2", "3"]  # Cotton
+        assert policy["B5"][0] == ["1"]  # Wool
+        assert policy["93"][0] == ["1"]  # Iron Dry
+        assert policy["A5"][0] == ["2"]  # Bedding
+        assert policy["EB"][0] == ["2"]  # Delicates
+        assert policy["98"] == ([], [])  # Quick Dry 35 -- neither
+        assert policy["7F"][1] == ["00:30:00", "01:00:00", "01:30:00", "02:00:00", "02:30:00"]
+
+    def test_live_values_sit_inside_their_courses_decoded_set(self):
+        """The strongest cross-check available without hardware: whatever
+        each device currently reports for temperature/rinse/spin/dry has to
+        be something its selected course's mask actually permits. A mask
+        decoded at the wrong offset would put a live value outside its own
+        allowed set almost immediately.
+
+        An empty mask is skipped rather than failed -- a cloud Download
+        slot declares no ranges for any of its kinds while still holding
+        live values, because the downloaded program supplies them.
+        """
+        pairs = (
+            (laundry.OPTION_KIND_WATER_TEMPERATURE, "waterTemperature"),
+            (laundry.OPTION_KIND_RINSE, "rinseCycles"),
+            (laundry.OPTION_KIND_SPIN, "spinLevel"),
+            (laundry.OPTION_KIND_DRY, "dryLevel"),
+        )
+        checked, outside, overflowing = 0, [], []
+        for name, resources in self._dumps():
+            washer = resources.get("/washer/vs/0") or {}
+            for kind, field in pairs:
+                supported = washer.get(f"x.com.samsung.da.supported{field[0].upper()}{field[1:]}")
+                live = washer.get(f"x.com.samsung.da.{field}")
+                found = laundry.course_option_mask(resources, kind)
+                if not supported or live is None or not found or not found[1]:
+                    continue
+                checked += 1
+                # A bit past the end of the list is the failure, not
+                # something to filter away: dropping those would turn a
+                # wide garbage mask into "everything allowed", which any
+                # live value then trivially satisfies.
+                if max(found[1]) >= len(supported):
+                    overflowing.append((name, field, found[1], len(supported)))
+                    continue
+                allowed = [supported[i] for i in found[1]]
+                if live not in allowed:
+                    outside.append((name, field, live, allowed))
+        assert overflowing == []
+        assert outside == []
+        assert checked >= 12, f"expected the corpus to exercise this, saw {checked}"
+
+    def test_dry_masks_stay_inside_the_devices_own_supported_list(self):
+        """The mask indexes supportedDryLevel, so a bit past its end would
+        mean the record is being split at the wrong width."""
+        out_of_range = []
+        for name, resources in self._dumps():
+            levels = (resources.get("/washer/vs/0") or {}).get("x.com.samsung.da.supportedDryLevel")
+            if not levels:
+                continue
+            for code in laundry._course_records(resources.get("/course/vs/0") or {}):
+                found = laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY, course=code)
+                if found and found[1] and max(found[1]) >= len(levels):
+                    out_of_range.append((name, code, found, len(levels)))
+        assert out_of_range == []
 
 
 class TestCycleSelect:

--- a/tests/test_laundry_capabilities.py
+++ b/tests/test_laundry_capabilities.py
@@ -4,6 +4,7 @@ from typing import ClassVar
 
 from custom_components.localthings.registry.capabilities import laundry
 from custom_components.localthings.registry.entities import SelectDesc
+from tests.conftest import FIXTURES, _load_device
 
 
 class TestCourseHelpers:
@@ -304,12 +305,11 @@ class TestCourseOptionGroups:
     <kind nibble><default nibble> <mask>, the mask indexing that option's
     own supported<Option> list.
 
-    Only kind 0xD is claimed. It was read off a DV5000T whose fourteen
-    records reproduce exactly what its panel offers per course, and the
-    same shape decodes in range on every dryer-family dump in the corpus
-    (see TestCourseOptionGroupsAcrossCorpus). The washer kinds 0x8/0x9/0xA
-    line up with temperature/rinse/spin by shape only, so nothing here
-    names them.
+    Four kinds are named -- 0xD dry off a DV5000T's per-course panel
+    report, 0x8/0x9/0xA off a WW6500's; both readings are checked against
+    the corpus in TestCourseOptionGroupsAcrossCorpus. The evidence, and the
+    WW6600R combo that carries its dry dial on 0xB instead, is written up
+    in docs/investigations/course-option-groups.md.
     """
 
     # DA_WM_TP1_21_COMMON DV9400B, from dryer_tp1_21_drum_clean: K=3, so a
@@ -363,8 +363,6 @@ class TestCourseOptionGroups:
     def test_default_index_is_into_the_list_not_the_allowed_set(self):
         """A dishwasher reports default 0 while allowing only index 1, so a
         caller cannot treat the default as a member of the allowed set."""
-        from tests.conftest import _load_device
-
         resources = _load_device("dishwasher")
         found = laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY, course="83")
         assert found == (0, [1])
@@ -425,8 +423,6 @@ class TestCourseOptionGroups:
         two-record excerpt legitimately resolves to a different width than
         the nineteen-record original.
         """
-        from tests.conftest import _load_device
-
         resources = _load_device("dryer_dve50a8600")
         levels = resources["/washer/vs/0"]["x.com.samsung.da.supportedDryLevel"]
         assert levels == ["None", "Damp", "Less", "Normal", "More", "Very"]
@@ -441,11 +437,10 @@ class TestCourseOptionGroups:
 class TestCourseOptionGroupsAcrossCorpus:
     """Structure invariants over every shipped dump, so a future fixture
     that decodes differently fails here rather than silently mis-gating an
-    entity."""
+    entity -- and, alongside them, the individual dumps the kind naming
+    rests on, which are what those invariants are checking is still true."""
 
     def _dumps(self):
-        from tests.conftest import FIXTURES, _load_device
-
         for path in sorted(FIXTURES.glob("*_device.json")):
             yield path.name, _load_device(path.name[: -len("_device.json")])
 
@@ -467,8 +462,6 @@ class TestCourseOptionGroupsAcrossCorpus:
         this pins the sets rather than the course code -- which is all the
         kind naming rests on.
         """
-        from tests.conftest import _load_device
-
         resources = _load_device("washer_ww6500")
         washer = resources["/washer/vs/0"]
         lists = (
@@ -492,6 +485,55 @@ class TestCourseOptionGroupsAcrossCorpus:
                 matching.append(code)
         assert matching == ["5C", "61"]
 
+    def test_spin_cannot_be_rinse_on_a_list_length_argument(self):
+        """The panel reading above cannot in fact tell rinse from spin: on
+        both courses that match it the two masks are 0x3F alike, so swapping
+        the constants leaves it passing. This is the independent structural
+        half -- on the `washer` dump 0xA addresses index 6, which a
+        six-entry supportedRinseCycles cannot hold, so 0xA is not rinse
+        whatever an owner reports. 0x9 tops out at index 5 there, exactly
+        what that list allows."""
+        resources = _load_device("washer")
+        washer = resources["/washer/vs/0"]
+        assert len(washer["x.com.samsung.da.supportedRinseCycles"]) == 6
+        top = {}
+        for code in laundry._course_records(resources["/course/vs/0"]):
+            for kind in (laundry.OPTION_KIND_RINSE, laundry.OPTION_KIND_SPIN):
+                found = laundry.course_option_mask(resources, kind, course=code)
+                if found and found[1]:
+                    top[kind] = max(top.get(kind, 0), max(found[1]))
+        assert top[laundry.OPTION_KIND_SPIN] == 6
+        assert top[laundry.OPTION_KIND_RINSE] == 5
+
+    def test_the_combo_carries_its_dry_dial_on_0xb_not_0xd(self):
+        """Recorded so the next change does not re-derive it: the WW6600R
+        combo is the only board here with a real multi-entry
+        supportedDryLevel, and it has no 0xD group at all -- its dry dial is
+        0xB, dry-only courses dropping "None" and defaulting to Cupboard.
+        A gate keyed on 0xD alone would silently no-op on the one board
+        family that already ships a writable dry_level select.
+
+        0xB stays unnamed: washer_dryer_onebody_awm is also a combo and
+        uses 0xD, so this is not a rule the corpus can state yet. See
+        docs/investigations/course-option-groups.md.
+        """
+        resources = _load_device("washer_dryer_combo")
+        levels = resources["/washer/vs/0"]["x.com.samsung.da.supportedDryLevel"]
+        assert len(levels) == 8
+
+        def decode(kind, course):
+            found = laundry.course_option_mask(resources, kind, course=course)
+            return None if found is None else (levels[found[0]], [levels[i] for i in found[1]])
+
+        # Pinned, so "no course carries 0xD" cannot pass by decoding nothing.
+        records = laundry._course_records(resources["/course/vs/0"])
+        assert len(records) == 24
+        assert all(decode(laundry.OPTION_KIND_DRY, code) is None for code in records)
+        wash_and_dry = ["None", "Cupboard", "30", "60", "90"]
+        assert decode(0xB, "1C") == ("None", wash_and_dry)
+        assert decode(0xB, "36") == ("Cupboard", wash_and_dry[1:])  # dry-only
+        assert decode(0xB, "24") == ("None", [])  # wash-only
+
     def test_dv6800n_dry_policy_agrees_with_the_other_board_family(self):
         """The DV6800N is the one dump carrying both a dry-level (0xD) and a
         dry-time (0xE) group, and its courses are labelled -- so it is where
@@ -506,8 +548,6 @@ class TestCourseOptionGroupsAcrossCorpus:
         Two unrelated code spaces would not agree like that on a mask read
         at the wrong offset.
         """
-        from tests.conftest import _load_device
-
         resources = _load_device("dryer_dv6800n")
         levels = resources["/washer/vs/0"]["x.com.samsung.da.supportedDryLevel"]
         times = resources["/washer/vs/0"]["x.com.samsung.da.supportedDryTime"]

--- a/tests/test_laundry_capabilities.py
+++ b/tests/test_laundry_capabilities.py
@@ -367,27 +367,51 @@ class TestCourseOptionGroups:
         found = laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY, course="83")
         assert found == (0, [1])
 
-    def test_edit_course_list_overrides_a_narrower_passing_split(self):
-        """The editCourseList guard only earns its place where the smallest
-        otherwise-valid width is the wrong one -- on every shipped dump the
-        smallest already covers the list, so a corpus fixture cannot tell
-        the guard from its absence.
-
-        Built to be exactly that case: twelve bytes split six ways gives
-        unique first bytes that include the selected course, so the old
-        guards accept it, but two of the four codes the device lists as
-        selectable are then nowhere to be found.
+    def test_the_stated_width_beats_a_narrower_passing_split(self):
+        """Where the header and the smallest-that-parses scan disagree, the
+        header wins. No shipped dump is that case -- the two agree on all
+        seventeen (test_the_header_states_the_record_width) -- so it takes a
+        constructed one: twelve bytes split six ways gives unique first
+        bytes that include the selected course, so the scan's guards accept
+        a two-byte width, while the header says three.
         """
         course_rep = {
             "x.com.samsung.da.options": ["Course_11"],
             "x.com.samsung.da.supportedOptions": ["1110022334400550066778800"],
         }
-        assert list(laundry._course_records(course_rep)) == ["11", "22", "44", "55", "66", "88"]
-
-        listed = {"11", "33", "55", "77"}
-        records = laundry._course_records(course_rep, must_cover=listed)
+        records = laundry._course_records(course_rep)
         assert list(records) == ["11", "33", "55", "77"]
         assert len(next(iter(records.values()))) == 6  # three bytes, not two
+
+    def test_the_edit_course_list_still_arbitrates_where_the_header_cannot(self):
+        """Same twelve bytes, but the header now says one byte per record --
+        a width whose first bytes repeat, so it states nothing usable and
+        the scan takes over. The scan's own smallest passing width is two
+        bytes; the editCourseList is what pushes it to three, and it is the
+        only thing that can once the header is out.
+        """
+        course_rep = {
+            "x.com.samsung.da.options": ["Course_11"],
+            "x.com.samsung.da.supportedOptions": ["0110022334400550066778800"],
+        }
+        assert list(laundry._course_records(course_rep)) == ["11", "22", "44", "55", "66", "88"]
+
+        records = laundry._course_records(course_rep, must_cover={"11", "33", "55", "77"})
+        assert list(records) == ["11", "33", "55", "77"]
+
+    def test_an_unsatisfiable_edit_course_list_falls_back_rather_than_going_dark(self):
+        """A device that lists a course its supportedOptions does not carry
+        -- a personal or cloud slot -- must not switch the decoder off for
+        every kind on the whole device. No width can cover 'AA' here, so the
+        smallest passing split stands, which is what the course-list
+        fallback would have returned anyway.
+        """
+        course_rep = {
+            "x.com.samsung.da.options": ["Course_11"],
+            "x.com.samsung.da.supportedOptions": ["0110022334400550066778800"],
+        }
+        records = laundry._course_records(course_rep, must_cover={"11", "AA"})
+        assert list(records) == ["11", "22", "44", "55", "66", "88"]
 
     def test_groups_are_read_on_their_own_boundaries(self):
         """Groups are two bytes each after the course byte, so the scan has
@@ -396,22 +420,23 @@ class TestCourseOptionGroups:
         carry -- rather than failing, so nothing else in the corpus would
         notice the stride being wrong.
 
-        Here every record is <course><A8 9D><31 E2>. Read correctly there
-        is no rinse (0x9) group at all; read two digits out of step, the
-        bytes '9D 31' look exactly like one.
+        Here every record is <course><A8 9D><31 E2>, two groups -- hence the
+        header of 2. Read correctly there is no rinse (0x9) group at all;
+        read two digits out of step, the bytes '9D 31' look exactly like one.
         """
         course_rep = {
             "x.com.samsung.da.options": ["Course_01"],
             "x.com.samsung.da.supportedOptions": [
-                "1" + "".join(f"{code:02X}A89D31E2" for code in range(1, 7))
+                "2" + "".join(f"{code:02X}A89D31E2" for code in range(1, 7))
             ],
         }
         resources = {"/course/vs/0": course_rep}
         assert laundry._course_records(course_rep)["01"] == "01A89D31E2"
 
         assert laundry.course_option_mask(resources, 0x9) is None
-        # The real group, whose mask also reaches bit 7 -- the top of the
-        # byte, unexercised anywhere in the corpus.
+        # The real group, whose mask reaches bit 7 -- the top of the byte,
+        # which no *named* kind exercises in the corpus (washer_wa8000t's
+        # unnamed 0x6 does, with mask 0xA1).
         assert laundry.course_option_mask(resources, 0xA) == (8, [0, 2, 3, 4, 7])
 
     def test_reads_past_a_group_of_another_kind(self):
@@ -443,6 +468,58 @@ class TestCourseOptionGroupsAcrossCorpus:
     def _dumps(self):
         for path in sorted(FIXTURES.glob("*_device.json")):
             yield path.name, _load_device(path.name[: -len("_device.json")])
+
+    def test_the_header_states_the_record_width(self):
+        """The header nibble is the group count, so 1 + 2*hdr bytes is the
+        record width -- true on every dump here, across six distinct widths
+        (1, 3, 5, 7, 9, 11 bytes). This is what lets _course_records take a
+        stated width instead of guessing the smallest one that parses.
+        """
+        disagreeing = []
+        for name, resources in self._dumps():
+            course_rep = resources.get("/course/vs/0") or {}
+            raw = course_rep.get("x.com.samsung.da.supportedOptions")
+            hexstr = raw[0] if isinstance(raw, list) and raw else raw
+            records = laundry._course_records(course_rep)
+            if not isinstance(hexstr, str) or not records:
+                continue
+            header = int(hexstr[0], 16)
+            width = len(next(iter(records.values()))) // 2
+            if width != 1 + 2 * header:
+                disagreeing.append((name, header, width))
+        assert disagreeing == []
+
+    def test_the_stated_width_reproduces_the_scan_it_replaced(self):
+        """Nothing shipped changes shape: on every dump the header-derived
+        split is the one the smallest-that-parses scan already returned, so
+        no course list -- and no golden that depends on one -- moves.
+        """
+        differing = []
+        for name, resources in self._dumps():
+            course_rep = resources.get("/course/vs/0") or {}
+            raw = course_rep.get("x.com.samsung.da.supportedOptions")
+            hexstr = raw[0] if isinstance(raw, list) and raw else raw
+            if not isinstance(hexstr, str):
+                continue
+            # A non-hex header states nothing, which is how the scan gets
+            # driven from here without a second entry point into it.
+            scanned = laundry._course_records(
+                {**course_rep, "x.com.samsung.da.supportedOptions": "Z" + hexstr[1:]}
+            )
+            if list(scanned) != list(laundry._course_records(course_rep)):
+                differing.append(name)
+        assert differing == []
+
+    def test_a_course_code_is_matched_case_insensitively(self):
+        """select.py lowercases an entity's options for the translation
+        catalog, so a caller that reaches for what the entity displays
+        rather than the raw Course_ token still has to get an answer --
+        silently getting "no opinion" is how a gate no-ops without anyone
+        noticing."""
+        resources = _load_device("dryer_dv6800n")
+        upper = laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY, course="9A")
+        assert upper == laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY, course="9a")
+        assert upper is not None
 
     def test_every_record_is_a_course_byte_plus_whole_groups(self):
         odd = []


### PR DESCRIPTION
Carries @vmonkey's #408 (both commits, unchanged) plus the fixes from its second review round.

## What #408 brings

`/course/vs/0`'s `supportedOptions` was already split far enough to recover the course codes; the payload behind each one — which wash temperatures, rinse counts, spin speeds and dry levels a given course permits — was dropped. `course_option_mask` decodes it once, since three entities are about to want it. Four kinds named (`0x8` temperature, `0x9` rinse, `0xA` spin, `0xD` dry), the evidence in `docs/investigations/course-option-groups.md`, and the WW6600R combo that carries its dry dial on `0xB` with no `0xD` at all pinned by a test.

## Review fixes on top

**The header nibble is the group count, so the record width is stated, not inferred** — `1 + 2×hdr` bytes. True on all 17 dumps carrying a `supportedOptions`, across all six widths (1, 3, 5, 7, 9, 11 bytes), and the split it gives is the one the smallest-that-parses scan already produced on every one — so no course list moves and no golden changes. The scan stays as the fallback, and the stated width is still checked against the guards the scan was written for.

**The `editCourseList` check no longer switches the decoder off wholesale.** An unsatisfiable one returned `{}`, which reads as "this device says nothing" to every kind on the device — so a board listing a course its `supportedOptions` doesn't carry (a personal or cloud slot) would have silently no-opped every gate built on this. A covering split still wins; failing that, the smallest passing split stands, which is what the course-list fallback returned before any of this.

**`course_option_mask` matches a course code case-insensitively.** Codes are uppercase hex device-side, but `select.py` lowercases an entity's options for the translation catalog, so a caller reaching for what the entity displays rather than the raw `Course_` token got a silent "no opinion".

**Two corrections.** The mask is one byte and cannot address past index 7 — three boards carry an 11- or 13-entry `supportedDryTime` and none carries a group for it, so nothing is contradicted, but dry time is named as the next consumer. And bit 7 is not "unexercised anywhere in the corpus" as the stride test claimed: `washer_wa8000t`'s unnamed `0x6` reaches it with mask `0xA1` on eight of its thirteen courses. No *named* kind does.

## Validation

- 1834 tests pass; `ruff check` / `ruff format --check` / `ty check custom_components tests` clean
- Each new guard mutation-tested: breaking the header width, removing the header path, restoring the go-dark behaviour, and making the course lookup case-sensitive each fail a test that passes otherwise
- No golden changes, as above — the header-derived split is byte-for-byte what shipped

Still nothing consumes the decoder; #407 is the first caller.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LLBR8hw7Q3v91VsdQ52ybq)_