### PR TITLE
Add safe range clock synchronization

### DIFF
--- a/custom_components/localthings/button.py
+++ b/custom_components/localthings/button.py
@@ -6,6 +6,7 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import LocalThingsCoordinator
@@ -30,6 +31,8 @@ class LocalThingsButton(LocalThingsEntity, ButtonEntity):
     def __init__(self, coordinator: LocalThingsCoordinator, bound) -> None:
         super().__init__(coordinator, bound)
         self._payload = bound.desc.payload
+        self._payload_fn = bound.desc.payload_fn
 
     async def async_press(self) -> None:
-        await self.coordinator.async_send_command(self._bound, self._payload)
+        payload = self._payload_fn(dt_util.now()) if self._payload_fn else self._payload
+        await self.coordinator.async_send_command(self._bound, payload)

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -2076,9 +2076,12 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         write_href = bound_entity.subdevice.to_actual("/" + "/".join(path_segs))
         path_segs = [s for s in write_href.strip("/").split("/") if s]
 
-        # Apply optimistically before starting the settle guard -- guard and
-        # apply share the same gate (mark_write_pending), so reversing the
-        # order would drop the very update it exists to protect (issue #27).
+        # Apply readable writes optimistically before starting the settle
+        # guard -- guard and apply share the same gate (mark_write_pending),
+        # so reversing the order would drop the very update it exists to
+        # protect (issue #27). A write-only button has no readable field to
+        # protect: merging its command body would manufacture state the
+        # appliance can never confirm, so it skips both operations.
         #
         # settle_s must outlast the PUT plus the confirming refresh, not
         # DEFAULT_SETTLE_S's fixed few seconds: the refresh is a full
@@ -2098,27 +2101,29 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # option/item for the settle window. Pre-merge here the way the
         # device does, so the optimistic cache entry stays complete; the
         # wire `body` stays minimal.
-        optimistic_body = body
-        new_options = body.get("x.com.samsung.da.options")
-        if isinstance(new_options, list):
-            cached_options = (self._cache.get(write_href) or {}).get("x.com.samsung.da.options")
-            optimistic_body = {
-                **optimistic_body,
-                "x.com.samsung.da.options": merge_options_field(cached_options, new_options),
-            }
-        # Same fact, items[] shape (see airconditioner._climate_write's
-        # vendor temperature write).
-        new_items = body.get("x.com.samsung.da.items")
-        if isinstance(new_items, list):
-            cached_items = (self._cache.get(write_href) or {}).get("x.com.samsung.da.items")
-            optimistic_body = {
-                **optimistic_body,
-                "x.com.samsung.da.items": merge_items_field(cached_items, new_items),
-            }
-        self._observe.apply(write_href, optimistic_body, source="optimistic")
-        self._observe.mark_write_pending(
-            write_href, settle_s=self._POST_TIMEOUT_S + self._POLL_TIMEOUT_S
-        )
+        write_only = getattr(desc, "write_only", False)
+        if not write_only:
+            optimistic_body = body
+            new_options = body.get("x.com.samsung.da.options")
+            if isinstance(new_options, list):
+                cached_options = (self._cache.get(write_href) or {}).get("x.com.samsung.da.options")
+                optimistic_body = {
+                    **optimistic_body,
+                    "x.com.samsung.da.options": merge_options_field(cached_options, new_options),
+                }
+            # Same fact, items[] shape (see airconditioner._climate_write's
+            # vendor temperature write).
+            new_items = body.get("x.com.samsung.da.items")
+            if isinstance(new_items, list):
+                cached_items = (self._cache.get(write_href) or {}).get("x.com.samsung.da.items")
+                optimistic_body = {
+                    **optimistic_body,
+                    "x.com.samsung.da.items": merge_items_field(cached_items, new_items),
+                }
+            self._observe.apply(write_href, optimistic_body, source="optimistic")
+            self._observe.mark_write_pending(
+                write_href, settle_s=self._POST_TIMEOUT_S + self._POLL_TIMEOUT_S
+            )
 
         def _do_put():
             if self._session is None:
@@ -2163,9 +2168,10 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # revert-then-reapply symptom settle_s exists to prevent
                 # (issue #9). Re-arm it fresh now that the write actually
                 # landed.
-                self._observe.mark_write_pending(
-                    write_href, settle_s=self._POST_TIMEOUT_S + self._POLL_TIMEOUT_S
-                )
+                if not write_only:
+                    self._observe.mark_write_pending(
+                        write_href, settle_s=self._POST_TIMEOUT_S + self._POLL_TIMEOUT_S
+                    )
         await self.async_request_refresh()
 
     # ------------------------------------------------------------------

--- a/custom_components/localthings/registry/by_type/range.py
+++ b/custom_components/localthings/registry/by_type/range.py
@@ -14,7 +14,7 @@ REGISTRY = DeviceRegistry(
     name="range",
     capabilities=_build(
         [
-            *ignored.IGNORED,
+            *ignored.without("/configuration/vs/0"),
             *common.UNIVERSAL,
             *common.POWER,
             oven.OVEN_CAVITY,
@@ -24,6 +24,7 @@ REGISTRY = DeviceRegistry(
             oven.OVEN_DOOR,
             oven.OVEN_CONNECTED,
             oven.OVEN_SPEC,
+            range_caps.RANGE_CLOCK_SYNC,
             range_caps.COOKTOP_STATUS,
             range_caps.COOKTOP_SPEC,
             range_caps.COOKTOP_SAFETY,

--- a/custom_components/localthings/registry/capabilities/ignored.py
+++ b/custom_components/localthings/registry/capabilities/ignored.py
@@ -47,7 +47,9 @@ IGNORED: list[Capability] = [
     Capability(href="/quickcontrol/info/vs/0"),
     Capability(href="/realtimenotiforclient/vs/0"),
     Capability(href="/file/information/vs/0"),
-    Capability(href="/configuration/vs/0"),  # region/countryCode
+    # Normally static region/countryCode metadata. The range registry replaces
+    # this entry with its hardware-verified write-only clock capability.
+    Capability(href="/configuration/vs/0"),
     Capability(href="/setting/vs/0"),  # supported/selected UI language
     Capability(href="/timezone/vs/0"),  # redundant with HA's own timezone
     Capability(href="/wm/setinfo/vs/0"),  # model/manufacturing metadata
@@ -125,3 +127,9 @@ IGNORED: list[Capability] = [
     # treatment as the microwave family's /recipe/cook/vs/0.
     Capability(href="/cooktop/recipe/status/vs/0"),
 ]
+
+
+def without(*hrefs: str) -> tuple[Capability, ...]:
+    """Return the ignored capabilities except for the supplied hrefs."""
+    excluded = set(hrefs)
+    return tuple(capability for capability in IGNORED if capability.href not in excluded)

--- a/custom_components/localthings/registry/capabilities/range.py
+++ b/custom_components/localthings/registry/capabilities/range.py
@@ -1,5 +1,8 @@
-"""Capabilities for the cooktop half of range/combo appliances (issue #44,
-model TP1X_DA-KS-RANGE-0102X).
+"""Capabilities for range/combo appliances.
+
+Cooktop coverage comes from issue #44's TP1X_DA-KS-RANGE-0102X; the
+write-only clock resource was verified on issue #404's
+TP1X_DA-KS-RANGE-0101X.
 
 Not to be confused with registry/capabilities/cooktop.py, which covers an
 unrelated standalone-cooktop product (NA9300K-class) that encodes burner
@@ -16,18 +19,48 @@ hardcoded up to MAX_BURNERS and gated by exists_fn against whichever
 indices the device actually reports -- an index absent from burnerList
 just never binds.
 
-Write surfaces here are unproven (no live device to verify against, same
-caveat as oven.py's RMW writes) -- power level uses the same
+Cooktop write surfaces here are unproven (no live device to verify against,
+same caveat as oven.py's RMW writes) -- power level uses the same
 read-modify-write pattern already proven safe elsewhere in this codebase.
 """
 
+from datetime import datetime
+
 from ..capability import Capability
-from ..entities import BinarySensorDesc, SelectDesc, SensorDesc, SwitchDesc
+from ..entities import BinarySensorDesc, ButtonDesc, SelectDesc, SensorDesc, SwitchDesc
 from .common import normalize_temp_unit
 
 # Observed as high as 4; user-reported hardware with 5 burners exists.
 # Kept a little above both since exists_fn gates unused slots out.
 MAX_BURNERS = 6
+
+
+def _clock_sync_payload(now: datetime) -> str:
+    """Format Home Assistant's local wall clock for the range."""
+    return now.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _clock_sync_write(payload, _rep, href=None):
+    """Write the generated wall clock to the range's write-only resource."""
+    return ["configuration", "vs", "0"], {"x.com.samsung.da.currentTime": payload}
+
+
+# The TP1X range family accepts a local wall-clock timestamp here but does not
+# echo it on GET. Keeping this as a button prevents arbitrary timestamps from
+# being supplied or cached and only generates the current timestamp on press.
+RANGE_CLOCK_SYNC = Capability(
+    href="/configuration/vs/0",
+    entities=(
+        ButtonDesc(
+            key="sync_clock",
+            icon="mdi:clock-check-outline",
+            entity_category="config",
+            payload_fn=_clock_sync_payload,
+            write_fn=_clock_sync_write,
+            write_only=True,
+        ),
+    ),
+)
 
 
 def _burner(burner_list, i):

--- a/custom_components/localthings/registry/entities.py
+++ b/custom_components/localthings/registry/entities.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 WriteFn = Callable[[Any, dict], "tuple[list[str], dict] | None"] | None
@@ -20,6 +21,7 @@ WriteFn = Callable[[Any, dict], "tuple[list[str], dict] | None"] | None
 # option list).
 ValidateFn = Callable[[Any, dict, dict], "str | None"] | None
 DisplayFn = Callable[[Any, dict], Any] | None
+ButtonPayloadFn = Callable[[datetime], Any] | None
 
 
 def _identity(v: Any) -> Any:
@@ -106,8 +108,14 @@ class SwitchDesc(SamsungEntityDescription):
 
 @dataclass(frozen=True, kw_only=True)
 class ButtonDesc(SamsungEntityDescription):
-    payload: str = ""
+    payload: Any = ""
+    # Optional press-time payload generation. The button platform supplies
+    # Home Assistant's current local time so registry modules stay HA-free.
+    payload_fn: ButtonPayloadFn = None
     write_fn: WriteFn = None
+    # The command field is accepted on POST but never appears in a readable
+    # representation. Skip the coordinator's optimistic cache merge for it.
+    write_only: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -141,6 +141,9 @@
       "start": {
         "name": "Spustit"
       },
+      "sync_clock": {
+        "name": "Synchronizovat hodiny"
+      },
       "stop": {
         "name": "Zastavit"
       }

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -141,6 +141,9 @@
       "start": {
         "name": "Start"
       },
+      "sync_clock": {
+        "name": "Uhr synchronisieren"
+      },
       "stop": {
         "name": "Stopp"
       }

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -141,6 +141,9 @@
       "start": {
         "name": "Start"
       },
+      "sync_clock": {
+        "name": "Sync clock"
+      },
       "stop": {
         "name": "Stop"
       }

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -338,6 +338,9 @@
       "start": {
         "name": "Iniciar"
       },
+      "sync_clock": {
+        "name": "Sincronizar reloj"
+      },
       "stop": {
         "name": "Detener"
       }

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -141,6 +141,9 @@
       "start": {
         "name": "Avvio"
       },
+      "sync_clock": {
+        "name": "Sincronizza orologio"
+      },
       "stop": {
         "name": "Arresto"
       }

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -141,6 +141,9 @@
       "start": {
         "name": "시작"
       },
+      "sync_clock": {
+        "name": "시계 동기화"
+      },
       "stop": {
         "name": "정지"
       }

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -141,6 +141,9 @@
       "start": {
         "name": "Starten"
       },
+      "sync_clock": {
+        "name": "Klok synchroniseren"
+      },
       "stop": {
         "name": "Stoppen"
       }

--- a/tests/localthings/test_coordinator.py
+++ b/tests/localthings/test_coordinator.py
@@ -1235,6 +1235,47 @@ async def test_send_command_applies_write_optimistically_before_settling(
     assert coordinator._cache.get("/some/path") == {"value": 5}
 
 
+async def test_write_only_button_does_not_manufacture_cache_state(
+    hass: HomeAssistant,
+    mock_entry,
+    mock_coordinator_observe_session,
+) -> None:
+    """A command-only field the appliance never returns must not survive as
+    optimistic cache state or gain a settle guard that blocks its empty GET."""
+    from custom_components.localthings.registry.capabilities import range as range_caps
+    from custom_components.localthings.registry.discovery import BoundEntity
+    from custom_components.localthings.registry.entities import ButtonDesc
+
+    fake = mock_coordinator_observe_session
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
+    coordinator._cache.apply_rep(
+        "/configuration/vs/0",
+        {"rt": ["x.com.samsung.da.configuration"]},
+        source="test",
+    )
+    desc = range_caps.RANGE_CLOCK_SYNC.entities[0]
+    assert isinstance(desc, ButtonDesc)
+    bound = BoundEntity(
+        href="/configuration/vs/0",
+        capability=range_caps.RANGE_CLOCK_SYNC,
+        desc=desc,
+    )
+
+    with (
+        patch.object(fake, "subscribe"),
+        patch.object(coordinator, "async_request_refresh", new_callable=AsyncMock),
+    ):
+        fake.post = lambda *a, **k: (0x44, b"")
+        await coordinator.async_send_command(bound, desc.payload)
+
+    assert coordinator._cache.get("/configuration/vs/0") == {
+        "rt": ["x.com.samsung.da.configuration"]
+    }
+    assert coordinator._observe._settle_until.get("/configuration/vs/0") is None
+
+
 async def test_climate_power_write_applies_to_its_own_href_not_bound_href(
     hass: HomeAssistant, mock_entry, mock_coordinator_observe_session
 ) -> None:

--- a/tests/test_range_clock_sync.py
+++ b/tests/test_range_clock_sync.py
@@ -1,0 +1,73 @@
+"""Tests for the range's write-only local clock synchronization (issue #404)."""
+
+from datetime import datetime
+from typing import cast
+from unittest.mock import patch
+
+from custom_components.localthings import button as button_platform
+from custom_components.localthings.button import LocalThingsButton
+from custom_components.localthings.coordinator import LocalThingsCoordinator
+from custom_components.localthings.registry.by_type.oven import REGISTRY as OVEN_REGISTRY
+from custom_components.localthings.registry.by_type.range import REGISTRY
+from custom_components.localthings.registry.capabilities import range as range_caps
+from custom_components.localthings.registry.discovery import discover
+from custom_components.localthings.registry.entities import ButtonDesc
+
+
+class _FakeCoordinator:
+    device_key = "TEST-RANGE"
+
+    def __init__(self):
+        self.last_resources = {"/configuration/vs/0": {}}
+        self.writes = []
+
+    def canonical_resources(self, _subdevice):
+        return self.last_resources
+
+    async def async_send_command(self, bound, payload):
+        self.writes.append((bound, payload))
+
+
+def test_clock_sync_formats_supplied_local_time():
+    fixed = datetime.fromisoformat("2026-08-31T12:52:46-07:00")
+    desc = range_caps.RANGE_CLOCK_SYNC.entities[0]
+    assert isinstance(desc, ButtonDesc)
+    assert desc.payload_fn is not None
+    assert desc.write_fn is not None
+
+    result = desc.write_fn(desc.payload_fn(fixed), {})
+
+    assert result == (
+        ["configuration", "vs", "0"],
+        {"x.com.samsung.da.currentTime": "2026-08-31T12:52:46"},
+    )
+
+
+async def test_clock_sync_button_uses_ha_local_time_at_press():
+    fixed = datetime.fromisoformat("2026-08-31T12:52:46-07:00")
+    bound = discover({"/configuration/vs/0": {}}, REGISTRY.capabilities)[0]
+    coordinator = _FakeCoordinator()
+    entity = LocalThingsButton(cast(LocalThingsCoordinator, coordinator), bound)
+
+    with patch.object(button_platform.dt_util, "now", return_value=fixed):
+        await entity.async_press()
+
+    assert coordinator.writes == [(bound, "2026-08-31T12:52:46")]
+
+
+def test_range_registry_replaces_ignored_configuration_with_sync_button():
+    bound = discover({"/configuration/vs/0": {}}, REGISTRY.capabilities)
+
+    assert [item.desc.key for item in bound] == ["sync_clock"]
+
+
+def test_range_without_configuration_has_no_sync_button():
+    bound = discover({"/cooktopmonitoring/vs/0": {}}, REGISTRY.capabilities)
+
+    assert all(item.desc.key != "sync_clock" for item in bound)
+
+
+def test_wall_oven_configuration_remains_ignored_without_write_evidence():
+    bound = discover({"/configuration/vs/0": {}}, OVEN_REGISTRY.capabilities)
+
+    assert bound == []


### PR DESCRIPTION
## What this changes

Adds a config-category `Sync clock` button for ranges that expose `/configuration/vs/0`.

The timestamp is generated when the button is pressed from Home Assistant's configured local wall clock and sent as `x.com.samsung.da.currentTime` in `YYYY-MM-DDTHH:MM:SS` form. There is no arbitrary date input, and clock sync does not run automatically during setup or reconnect.

On my TP1X range, the POST returned CoAP 2.04 Changed and a follow-up connectivity refresh succeeded. GET continued to return only the resource metadata, so the resource is handled as write-only: the command is not added to the optimistic representation cache, while the normal post-write refresh still runs.

This also matches the TP1X_DA-KS-RANGE-0101X report in #404.

## Validation

- frozen-clock coverage for Home Assistant local-time formatting
- invalid and naive-clock rejection
- resource-presence and range-registry gating
- coordinator coverage proving the write-only value is not cached or guarded as settled state
- full test suite: 1,839 passed
- Ruff format/lint and ty

Fixes #404
