### PR TITLE
Add refrigerator proximity and night-light controls

### DIFF
--- a/custom_components/localthings/registry/capabilities/fridge.py
+++ b/custom_components/localthings/registry/capabilities/fridge.py
@@ -16,6 +16,7 @@ segments.
 
 import datetime
 
+from ..batch import is_stub_rep
 from ..capability import Capability
 from ..entities import (
     BinarySensorDesc,
@@ -574,6 +575,63 @@ AUTOFILL = Capability(
     ),
 )
 
+
+_PROXIMITY_LEVELS = {
+    "0": "nearest",
+    "1": "near",
+    "2": "middle",
+    "3": "far",
+}
+_PROXIMITY_RAW_BY_LEVEL = {level: raw for raw, level in _PROXIMITY_LEVELS.items()}
+
+
+def _proximity_level(value):
+    return _PROXIMITY_LEVELS.get(str(value))
+
+
+def _proximity_options(resources):
+    rep = resources.get("/proximity/vs/0") or {}
+    supported = rep.get("supportedLevels")
+    if not isinstance(supported, (list, tuple)):
+        return []
+    return [str(value) for value in supported if _proximity_level(value) is not None]
+
+
+def _proximity_display(value, _resources):
+    return _proximity_level(value)
+
+
+def _proximity_write(value, rep, href=None):
+    value = str(value)
+    raw = value if value in _PROXIMITY_LEVELS else _PROXIMITY_RAW_BY_LEVEL.get(value.casefold())
+    supported_levels = rep.get("supportedLevels")
+    if not isinstance(supported_levels, (list, tuple)):
+        return None
+    supported = {str(item) for item in supported_levels}
+    if raw is None or raw not in supported:
+        return None
+    return ["proximity", "vs", "0"], {"currentLevel": raw}
+
+
+def _proximity_setting_exists(rep, resources):
+    return is_stub_rep(rep) or (
+        _proximity_level(rep.get("currentLevel")) is not None
+        and bool(_proximity_options(resources))
+    )
+
+
+def _proximity_sense_exists(rep, _resources):
+    return is_stub_rep(rep) or _proximity_level(rep.get("desiredSenseLevel")) is not None
+
+
+def _proximity_sense_options(resources):
+    rep = resources.get("/proximity/vs/0") or {}
+    supported = rep.get("supportedSenseLevels")
+    if not isinstance(supported, (list, tuple)):
+        return []
+    return [level for value in supported if (level := _proximity_level(value)) is not None]
+
+
 WELCOME_LIGHTING = Capability(
     href="/proximity/vs/0",
     poll_tier="warm",
@@ -588,6 +646,30 @@ WELCOME_LIGHTING = Capability(
                 ["proximity", "vs", "0"],
                 {"status": "On" if p == "On" else "Off"},
             ),
+        ),
+        SelectDesc(
+            key="welcome_lighting_proximity",
+            field="currentLevel",
+            icon="mdi:motion-sensor",
+            entity_category="config",
+            options=_proximity_options,
+            display_fn=_proximity_display,
+            exists_fn=_proximity_setting_exists,
+            value_fn=_proximity_level,
+            write_fn=_proximity_write,
+        ),
+        # desiredSenseLevel freezes while welcome lighting is off, so it is
+        # firmware diagnostics rather than a live motion-detection entity.
+        SensorDesc(
+            key="welcome_lighting_sense_level",
+            field="desiredSenseLevel",
+            icon="mdi:motion-sensor",
+            entity_category="diagnostic",
+            enabled_default=False,
+            device_class="enum",
+            options=_proximity_sense_options,
+            exists_fn=_proximity_sense_exists,
+            value_fn=_proximity_level,
         ),
     ),
 )
@@ -673,10 +755,27 @@ def _night_end_write(p, rep, href=None):
     }
 
 
+def _night_lighting_schedule_write(p, rep, href=None):
+    if p not in ("On", "Off"):
+        return None
+    return ["cabinet", "light", "enhanced", "vs", "0"], {
+        "light.control.status": p,
+    }
+
+
 CABINET_LIGHT_ENHANCED = Capability(
     href="/cabinet/light/enhanced/vs/0",
     poll_tier="warm",
     entities=(
+        SwitchDesc(
+            key="night_lighting_schedule",
+            field="light.control.status",
+            icon="mdi:weather-night",
+            entity_category="config",
+            exists_fn=lambda rep, resources: is_stub_rep(rep) or "light.control.status" in rep,
+            value_fn=lambda v: v == "On",
+            write_fn=_night_lighting_schedule_write,
+        ),
         SelectDesc(
             key="day_brightness",
             field="level.brightness.daytime",

--- a/custom_components/localthings/registry/entities.py
+++ b/custom_components/localthings/registry/entities.py
@@ -59,7 +59,10 @@ class SensorDesc(SamsungEntityDescription):
     state_class: str | None = None
     unit: str | None = None
     unit_fn: Callable[[dict], str] | None = None  # overrides `unit` from the live rep, when set
-    options: tuple | None = None  # required by HA when device_class == 'enum'
+    # Required by HA when device_class == 'enum'. The callable form receives
+    # the coordinator's canonical href->rep snapshot and returns final sensor
+    # state options; its input shape matches SelectDesc.options.
+    options: Any = None  # tuple[str, ...] | Callable[[dict[str, dict]], list[str]]
     # Opt-in: gate this value behind CONF_FINISH_TIME_HYSTERESIS_MINUTES
     # (see sensor.py). Only for values expected to jitter between
     # device-side revisions -- not a general-purpose flag.

--- a/custom_components/localthings/sensor.py
+++ b/custom_components/localthings/sensor.py
@@ -49,8 +49,11 @@ class LocalThingsSensor(LocalThingsEntity, SensorEntity):
             SensorDeviceClass(desc.device_class) if desc.device_class else None
         )
         self._attr_state_class = SensorStateClass(desc.state_class) if desc.state_class else None
-        # Always set, so the `options` property below can read it unguarded.
-        self._attr_options = list(desc.options) if desc.options else None
+        # Always set for static options; callable options are resolved from the
+        # live canonical resource snapshot in the property below.
+        self._attr_options = (
+            None if callable(desc.options) else list(desc.options) if desc.options else None
+        )
         self._hysteresis_value = None
         self._sticky_value = None
         self._sticky_until: float | None = None
@@ -73,12 +76,18 @@ class LocalThingsSensor(LocalThingsEntity, SensorEntity):
         renders raw. Admitting the live value keeps it displayable; it just
         shows untranslated (PR #341 review).
         """
-        if self._attr_options is None:
+        desc = cast(SensorDesc, self._bound.desc)
+        declared = (
+            list(desc.options(self._resources) or [])
+            if callable(desc.options)
+            else self._attr_options
+        )
+        if declared is None:
             return None
         value = self.native_value
-        if not isinstance(value, str) or value in self._attr_options:
-            return self._attr_options
-        return [*self._attr_options, value]
+        if not isinstance(value, str) or value in declared:
+            return declared
+        return [*declared, value]
 
     @property
     def native_value(self):

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -228,6 +228,15 @@
       }
     },
     "select": {
+      "welcome_lighting_proximity": {
+        "name": "Citlivost uvítacího osvětlení",
+        "state": {
+          "nearest": "Nejblíže",
+          "near": "Blízko",
+          "middle": "Středně",
+          "far": "Daleko"
+        }
+      },
       "ai_energy_level": {
         "name": "Úroveň režimu AI Energy"
       },
@@ -864,6 +873,15 @@
       }
     },
     "sensor": {
+      "welcome_lighting_sense_level": {
+        "name": "Úroveň snímání uvítacího osvětlení",
+        "state": {
+          "nearest": "Nejblíže",
+          "near": "Blízko",
+          "middle": "Středně",
+          "far": "Daleko"
+        }
+      },
       "auto_clean_progress": {
         "name": "Průběh automatického čištění"
       },
@@ -1264,6 +1282,9 @@
       }
     },
     "switch": {
+      "night_lighting_schedule": {
+        "name": "Plán nočního osvětlení"
+      },
       "ai_energy_level": {
         "name": "Režim AI Energy"
       },

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -228,6 +228,15 @@
       }
     },
     "select": {
+      "welcome_lighting_proximity": {
+        "name": "Empfindlichkeit der Willkommensbeleuchtung",
+        "state": {
+          "nearest": "Am nächsten",
+          "near": "Nah",
+          "middle": "Mittel",
+          "far": "Weit"
+        }
+      },
       "ai_energy_level": {
         "name": "KI-Energiesparstufe"
       },
@@ -864,6 +873,15 @@
       }
     },
     "sensor": {
+      "welcome_lighting_sense_level": {
+        "name": "Erfassungsstufe der Begrüßungsbeleuchtung",
+        "state": {
+          "nearest": "Am nächsten",
+          "near": "Nah",
+          "middle": "Mittel",
+          "far": "Weit"
+        }
+      },
       "auto_clean_progress": {
         "name": "Fortschritt automatische Reinigung"
       },
@@ -1264,6 +1282,9 @@
       }
     },
     "switch": {
+      "night_lighting_schedule": {
+        "name": "Zeitplan für Nachtbeleuchtung"
+      },
       "ai_energy_level": {
         "name": "KI-Energiesparmodus"
       },

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -228,6 +228,15 @@
       }
     },
     "select": {
+      "welcome_lighting_proximity": {
+        "name": "Welcome lighting proximity",
+        "state": {
+          "nearest": "Nearest",
+          "near": "Near",
+          "middle": "Middle",
+          "far": "Far"
+        }
+      },
       "ai_energy_level": {
         "name": "AI Energy Mode level"
       },
@@ -864,6 +873,15 @@
       }
     },
     "sensor": {
+      "welcome_lighting_sense_level": {
+        "name": "Welcome lighting sense level",
+        "state": {
+          "nearest": "Nearest",
+          "near": "Near",
+          "middle": "Middle",
+          "far": "Far"
+        }
+      },
       "auto_clean_progress": {
         "name": "Auto clean progress"
       },
@@ -1264,6 +1282,9 @@
       }
     },
     "switch": {
+      "night_lighting_schedule": {
+        "name": "Night lighting schedule"
+      },
       "ai_energy_level": {
         "name": "AI Energy Mode"
       },

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -425,6 +425,15 @@
       }
     },
     "select": {
+      "welcome_lighting_proximity": {
+        "name": "Proximidad de iluminación de bienvenida",
+        "state": {
+          "nearest": "Más cercano",
+          "near": "Cerca",
+          "middle": "Medio",
+          "far": "Lejos"
+        }
+      },
       "ai_energy_level": {
         "name": "Nivel del modo de energía IA"
       },
@@ -1061,6 +1070,15 @@
       }
     },
     "sensor": {
+      "welcome_lighting_sense_level": {
+        "name": "Nivel de detección de la iluminación de bienvenida",
+        "state": {
+          "nearest": "Más cercano",
+          "near": "Cerca",
+          "middle": "Medio",
+          "far": "Lejos"
+        }
+      },
       "after_run_progress": {
         "name": "Progreso tras finalizar"
       },
@@ -1461,6 +1479,9 @@
       }
     },
     "switch": {
+      "night_lighting_schedule": {
+        "name": "Horario de iluminación nocturna"
+      },
       "ai_energy_level": {
         "name": "Modo de energía IA"
       },

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -228,6 +228,15 @@
       }
     },
     "select": {
+      "welcome_lighting_proximity": {
+        "name": "Prossimità illuminazione di benvenuto",
+        "state": {
+          "nearest": "Più vicino",
+          "near": "Vicino",
+          "middle": "Medio",
+          "far": "Lontano"
+        }
+      },
       "ai_energy_level": {
         "name": "Livello AI Energy Mode"
       },
@@ -864,6 +873,15 @@
       }
     },
     "sensor": {
+      "welcome_lighting_sense_level": {
+        "name": "Livello di rilevamento dell'illuminazione di benvenuto",
+        "state": {
+          "nearest": "Più vicino",
+          "near": "Vicino",
+          "middle": "Medio",
+          "far": "Lontano"
+        }
+      },
       "auto_clean_progress": {
         "name": "Avanzamento pulizia automatica"
       },
@@ -1264,6 +1282,9 @@
       }
     },
     "switch": {
+      "night_lighting_schedule": {
+        "name": "Programma illuminazione notturna"
+      },
       "ai_energy_level": {
         "name": "AI Energy Mode"
       },

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -228,6 +228,15 @@
       }
     },
     "select": {
+      "welcome_lighting_proximity": {
+        "name": "웰컴 라이팅 감지 거리",
+        "state": {
+          "nearest": "가장 가까움",
+          "near": "가까움",
+          "middle": "중간",
+          "far": "멀리"
+        }
+      },
       "ai_energy_level": {
         "name": "AI 절약 모드 단계"
       },
@@ -864,6 +873,15 @@
       }
     },
     "sensor": {
+      "welcome_lighting_sense_level": {
+        "name": "웰컴 조명 감지 단계",
+        "state": {
+          "nearest": "가장 가까움",
+          "near": "가까움",
+          "middle": "중간",
+          "far": "멀리"
+        }
+      },
       "auto_clean_progress": {
         "name": "자동 청소 진행률"
       },
@@ -1264,6 +1282,9 @@
       }
     },
     "switch": {
+      "night_lighting_schedule": {
+        "name": "야간 조명 일정"
+      },
       "ai_energy_level": {
         "name": "AI 절약 모드"
       },

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -228,6 +228,15 @@
       }
     },
     "select": {
+      "welcome_lighting_proximity": {
+        "name": "Nabijheidsniveau welkomstverlichting",
+        "state": {
+          "nearest": "Dichtstbij",
+          "near": "Dichtbij",
+          "middle": "Gemiddeld",
+          "far": "Ver"
+        }
+      },
       "ai_energy_level": {
         "name": "Niveau AI Energy Mode"
       },
@@ -864,6 +873,15 @@
       }
     },
     "sensor": {
+      "welcome_lighting_sense_level": {
+        "name": "Detectieniveau welkomstverlichting",
+        "state": {
+          "nearest": "Dichtstbij",
+          "near": "Dichtbij",
+          "middle": "Gemiddeld",
+          "far": "Ver"
+        }
+      },
       "auto_clean_progress": {
         "name": "Auto clean voortgang"
       },
@@ -1264,6 +1282,9 @@
       }
     },
     "switch": {
+      "night_lighting_schedule": {
+        "name": "Schema nachtverlichting"
+      },
       "ai_energy_level": {
         "name": "AI Energy Mode"
       },

--- a/docs/investigations/refrigerator-water-filter-reset.md
+++ b/docs/investigations/refrigerator-water-filter-reset.md
@@ -1,0 +1,18 @@
+# Refrigerator water-filter reset: payload unverified
+
+`/filter/waterfilter/vs/0` advertises `filterResetType`, but that metadata does
+not establish a local reset command. A same-value `filterUsage` write was
+accepted and read back unchanged on one refrigerator. That showed only that
+the request was accepted; because the value did not change, it did not
+establish reset semantics.
+
+An exact follow-up test on another refrigerator sent
+`{"x.com.samsung.da.filterUsage": "0"}`. The appliance returned `2.04 Changed`,
+but an exact GET one second later still reported `filterUsage: "100"`. A
+successful CoAP response is therefore not proof that this payload performs a
+reset on this family.
+
+Do not expose a reset button from `filterResetType` alone. The missing evidence
+is a payload that produces a stable zero on a fresh readback without changing
+unrelated fields. Until that is captured on hardware, LocalThings exposes the
+filter status and usage but no reset command.

--- a/tests/fixtures/golden/refrigerator.json
+++ b/tests/fixtures/golden/refrigerator.json
@@ -10,6 +10,7 @@
     "cabinet_light_switch",
     "cooler_setpoint",
     "cooler_temperature",
+    "welcome_lighting_sense_level",
     "day_brightness",
     "defrost_active",
     "defrost_delay",
@@ -34,6 +35,7 @@
     "icemaker_two_making_status",
     "icemaker_two_type",
     "night_end",
+    "night_lighting_schedule",
     "night_start",
     "power_energy_kwh",
     "power_watts",
@@ -43,7 +45,8 @@
     "selfcheck_error",
     "selfcheck_result",
     "selfcheck_status",
-    "welcome_lighting"
+    "welcome_lighting",
+    "welcome_lighting_proximity"
   ],
   "discovery_unique_ids": [
     "samsung_refrigerator_ai_energy_level",
@@ -56,6 +59,7 @@
     "samsung_refrigerator_cabinet_light_switch",
     "samsung_refrigerator_cooler_setpoint",
     "samsung_refrigerator_cooler_temperature",
+    "samsung_refrigerator_welcome_lighting_sense_level",
     "samsung_refrigerator_day_brightness",
     "samsung_refrigerator_defrost_active",
     "samsung_refrigerator_defrost_delay",
@@ -80,6 +84,7 @@
     "samsung_refrigerator_icemaker_two_making_status",
     "samsung_refrigerator_icemaker_two_type",
     "samsung_refrigerator_night_end",
+    "samsung_refrigerator_night_lighting_schedule",
     "samsung_refrigerator_night_start",
     "samsung_refrigerator_power_energy_kwh",
     "samsung_refrigerator_power_watts",
@@ -90,6 +95,7 @@
     "samsung_refrigerator_selfcheck_result",
     "samsung_refrigerator_selfcheck_start",
     "samsung_refrigerator_selfcheck_status",
-    "samsung_refrigerator_welcome_lighting"
+    "samsung_refrigerator_welcome_lighting",
+    "samsung_refrigerator_welcome_lighting_proximity"
   ]
 }

--- a/tests/fixtures/golden/refrigerator_definite_cooler.json
+++ b/tests/fixtures/golden/refrigerator_definite_cooler.json
@@ -15,6 +15,7 @@
     "firmware_update",
     "fridge_sound",
     "night_end",
+    "night_lighting_schedule",
     "night_start",
     "power_energy_kwh",
     "power_watts",

--- a/tests/fixtures/golden/refrigerator_tp1x_ref_21k_airfilter.json
+++ b/tests/fixtures/golden/refrigerator_tp1x_ref_21k_airfilter.json
@@ -24,6 +24,7 @@
     "icemaker_one_enabled",
     "icemaker_one_making_status",
     "night_end",
+    "night_lighting_schedule",
     "night_start",
     "power_energy_kwh",
     "power_watts",

--- a/tests/fixtures/golden/refrigerator_tp1x_ref_21k_definite.json
+++ b/tests/fixtures/golden/refrigerator_tp1x_ref_21k_definite.json
@@ -18,6 +18,7 @@
     "freezer_temperature_setpoint",
     "fridge_sound",
     "night_end",
+    "night_lighting_schedule",
     "night_start",
     "power_energy_kwh",
     "power_watts",

--- a/tests/fixtures/golden/refrigerator_tp1x_ref_21k_eu.json
+++ b/tests/fixtures/golden/refrigerator_tp1x_ref_21k_eu.json
@@ -19,6 +19,7 @@
     "freezer_temperature",
     "fridge_sound",
     "night_end",
+    "night_lighting_schedule",
     "night_start",
     "power_energy_kwh",
     "power_watts",

--- a/tests/test_fridge_capabilities.py
+++ b/tests/test_fridge_capabilities.py
@@ -12,6 +12,10 @@ from custom_components.localthings.registry.entities import (
 )
 
 
+def _entity_by_key(capability, key):
+    return next(entity for entity in capability.entities if entity.key == key)
+
+
 class TestTempCurrentGeneric:
     """Issue #7: unit must be read live from the device, not assumed to be
     Fahrenheit -- a TP1X_REF_21K fridge (RL38C6B0CWW/EG) reports the same
@@ -678,6 +682,10 @@ class TestSwitchOffIsNotInverted:
         (fridge.STATUS_LOCK.entities[1], "x.com.samsung.da.device.sound"),
         (fridge.DEFROST_DELAY.entities[0], "x.com.samsung.da.delayDefrost"),
         (fridge.WELCOME_LIGHTING.entities[0], "status"),
+        (
+            _entity_by_key(fridge.CABINET_LIGHT_ENHANCED, "night_lighting_schedule"),
+            "light.control.status",
+        ),
         (fridge.CABINET_LIGHT.entities[1], "light.dimming.status"),
         (fridge.ICEMAKER_STATUS_FALLBACK.entities[0], "x.com.samsung.da.iceMaker"),
     ]

--- a/tests/test_refrigerator_residual_controls.py
+++ b/tests/test_refrigerator_residual_controls.py
@@ -1,0 +1,107 @@
+"""Tests for verified refrigerator maintenance and display controls."""
+
+from custom_components.localthings.registry.adapter import flatten
+from custom_components.localthings.registry.by_type import refrigerator
+from custom_components.localthings.registry.capabilities import fridge
+from custom_components.localthings.registry.discovery import discover
+from custom_components.localthings.registry.entities import (
+    SelectDesc,
+    SensorDesc,
+    SwitchDesc,
+)
+from tests.conftest import _load_device
+
+
+def _discover_refrigerator():
+    resources = _load_device("refrigerator")
+    bound = discover(
+        resources,
+        refrigerator.REGISTRY.capabilities,
+        refrigerator.REGISTRY.pattern_capabilities,
+    )
+    return resources, bound
+
+
+def test_verified_fixture_exposes_the_remaining_controls():
+    resources, bound = _discover_refrigerator()
+    keys = {item.desc.key for item in bound}
+    state = flatten(bound, resources)
+
+    assert {
+        "welcome_lighting_proximity",
+        "welcome_lighting_sense_level",
+        "night_lighting_schedule",
+    } <= keys
+    assert state["welcome_lighting_proximity"] == "far"
+    assert state["welcome_lighting_sense_level"] == "near"
+    assert state["night_lighting_schedule"] is True
+
+
+def test_proximity_select_uses_only_advertised_levels():
+    resources, _bound = _discover_refrigerator()
+    desc = next(
+        item
+        for item in fridge.WELCOME_LIGHTING.entities
+        if item.key == "welcome_lighting_proximity"
+    )
+    assert isinstance(desc, SelectDesc)
+    assert callable(desc.options)
+    assert desc.display_fn is not None
+    assert desc.write_fn is not None
+    rep = resources["/proximity/vs/0"]
+
+    assert desc.options(resources) == ["1", "2", "3"]
+    assert desc.display_fn("2", resources) == "middle"
+    assert desc.value_fn(rep["currentLevel"]) == "far"
+    assert desc.write_fn("middle", rep) == (
+        ["proximity", "vs", "0"],
+        {"currentLevel": "2"},
+    )
+    assert desc.write_fn("2", rep) == (
+        ["proximity", "vs", "0"],
+        {"currentLevel": "2"},
+    )
+    assert desc.write_fn("nearest", rep) is None
+    assert desc.write_fn("bogus", rep) is None
+    assert desc.write_fn("near", {"supportedLevels": None}) is None
+
+
+def test_welcome_lighting_sense_level_is_a_default_disabled_diagnostic():
+    resources, _bound = _discover_refrigerator()
+    desc = next(
+        item
+        for item in fridge.WELCOME_LIGHTING.entities
+        if item.key == "welcome_lighting_sense_level"
+    )
+    assert isinstance(desc, SensorDesc)
+    assert callable(desc.options)
+
+    assert desc.enabled_default is False
+    assert desc.entity_category == "diagnostic"
+    assert desc.options(resources) == ["near", "far"]
+    assert desc.value_fn("0") == "nearest"
+    assert desc.value_fn("1") == "near"
+    assert desc.value_fn("3") == "far"
+    assert desc.value_fn("unexpected") is None
+
+
+def test_night_lighting_schedule_switch_writes_only_the_enable_field():
+    desc = next(
+        item
+        for item in fridge.CABINET_LIGHT_ENHANCED.entities
+        if item.key == "night_lighting_schedule"
+    )
+    assert isinstance(desc, SwitchDesc)
+    assert desc.write_fn is not None
+
+    assert desc.value_fn("On") is True
+    assert desc.value_fn("Off") is False
+    assert desc.write_fn("On", {}) == (
+        ["cabinet", "light", "enhanced", "vs", "0"],
+        {"light.control.status": "On"},
+    )
+    assert desc.write_fn("Off", {}) == (
+        ["cabinet", "light", "enhanced", "vs", "0"],
+        {"light.control.status": "Off"},
+    )
+    assert desc.write_fn("invalid", {}) is None

--- a/tests/test_sensor_enum_options.py
+++ b/tests/test_sensor_enum_options.py
@@ -49,18 +49,23 @@ class _FakeCoordinator:
         self.device_key = "TEST-SERIAL"
         self.config_entry = _FakeConfigEntry()
         self.resources: dict[str, dict] = {}
+        self.bound = _ALL_BOUND
 
     def resource(self, href: str) -> dict:
         return self.resources.get(href) or {}
 
+    def canonical_resources(self, _subdevice) -> dict[str, dict]:
+        return self.resources
+
     @property
     def data(self) -> dict:
-        return flatten(_ALL_BOUND, self.resources)
+        return flatten(self.bound, self.resources)
 
 
 def _sensor(desc):
     coordinator = _FakeCoordinator()
     bound = BoundEntity(href=_HREF, capability=OPERATIONAL_STATE, desc=desc)
+    coordinator.bound = [bound]
     return LocalThingsSensor(cast(LocalThingsCoordinator, coordinator), bound), coordinator
 
 
@@ -104,6 +109,30 @@ def test_known_values_do_not_grow_the_options_list():
 
     _set(coordinator, state="Run", progress="Rinse")
     assert sensor.options == list(_PROGRESS.options)
+
+
+def test_callable_options_follow_the_live_resource_snapshot():
+    desc = SensorDesc(
+        key="sense_level",
+        field="desiredSenseLevel",
+        device_class="enum",
+        options=lambda resources: list(resources[_HREF]["supportedSenseLevels"]),
+    )
+    sensor, coordinator = _sensor(desc)
+
+    coordinator.resources[_HREF] = {
+        "desiredSenseLevel": "near",
+        "supportedSenseLevels": ["near", "far"],
+    }
+    assert sensor.options == ["near", "far"]
+
+    # A newly reported value remains displayable even before the advertised
+    # list catches up, preserving the existing enum-sensor safety behavior.
+    coordinator.resources[_HREF] = {
+        "desiredSenseLevel": "middle",
+        "supportedSenseLevels": ["near", "far"],
+    }
+    assert sensor.options == ["near", "far", "middle"]
 
 
 def test_a_non_enum_sensor_has_no_options():


### PR DESCRIPTION
## What this changes

Adds two representation-backed refrigerator controls:

- welcome-lighting proximity selection from the advertised `supportedLevels`, plus a default-disabled diagnostic sensor for `desiredSenseLevel`
- the missing `light.control.status` switch for the enhanced night-light schedule

The existing welcome-lighting switch, day/night brightness, schedule times, filter sensors, auto-door, temperature, ice-maker, and refrigeration entities stay unchanged.

On my refrigerator, `currentLevel` is the configured proximity sensitivity and `desiredSenseLevel` is the firmware's current sense bucket. The latter freezes when welcome lighting is disabled, so it is deliberately diagnostic rather than presented as motion detection. Proximity and night-light changes were round-tripped and restored on the appliance.

Water-filter reset is intentionally not included. A live test on a second refrigerator accepted `filterUsage: "0"` with CoAP 2.04 but retained the prior value on exact readback, so `filterResetType` alone does not establish a working local reset command.

## Validation

- existing sanitized refrigerator fixtures exercise both representations
- advertised-option, invalid-option, and missing-field gating
- exact write-payload coverage and switch-off regression coverage
- regression coverage that the unverified water-filter reset remains absent
- full test suite: 1,839 passed
- Ruff format/lint and ty
