### PR TITLE
Fix UUID-prefixed subdevice discovery without device collection

### DIFF
--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -1109,13 +1109,14 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self,
         resources: dict[str, dict],
     ) -> tuple[str, ...]:
-        """Return identity, then live primary-entity hrefs in hot/warm-first order.
+        """Return identity, then live primary-entity hrefs in probe order.
 
         A prefixed subdevice without a Collection endpoint has to be probed
         one Property href at a time. Its identity selects its own registry and
-        device metadata, so probe it before the primary resources declared by
-        the master's registry. This remains device-type agnostic, while unknown
-        devices still get a useful first probe before retaining normal order.
+        device metadata, so probe it first; prefer a composite entity's binding
+        href next so one live response can materialize the useful device, then
+        retain the registry's hot/warm-first order. This remains device-type
+        agnostic, while unknown devices still get a useful first probe.
         """
         identity = ("/information/vs/0",) if "/information/vs/0" in resources else ()
         registry = resolve_registry(
@@ -1135,9 +1136,18 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ]
             if not primary_caps:
                 continue
-            rank = min(tier_rank.get(capability.poll_tier, 2) for capability in primary_caps)
-            ranked.append((rank, order, href))
-        return identity + tuple(href for _, _, href in sorted(ranked))
+            composite_rank = (
+                0
+                if any(
+                    isinstance(desc, ClimateDesc)
+                    for capability in primary_caps
+                    for desc in capability.entities
+                )
+                else 1
+            )
+            tier = min(tier_rank.get(capability.poll_tier, 2) for capability in primary_caps)
+            ranked.append((composite_rank, tier, order, href))
+        return identity + tuple(href for _, _, _, href in sorted(ranked))
 
     def _enumerate_subdevices_blocking(self, resources: dict[str, dict]) -> dict[str, dict]:
         """One-time (first discovery only) probe for sibling indoor

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -1109,21 +1109,21 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self,
         resources: dict[str, dict],
     ) -> tuple[str, ...]:
-        """Return live primary-entity hrefs in hot/warm-first order.
+        """Return identity, then live primary-entity hrefs in hot/warm-first order.
 
         A prefixed subdevice without a Collection endpoint has to be probed
-        one Property href at a time. Resolve the master through the same
-        registry used by discovery and put resources that produce primary
-        entities first. This is metadata-driven rather than an AC-specific
-        list: a future composite appliance gets the priority its own registry
-        declares, while unknown devices simply retain the normal href order.
+        one Property href at a time. Its identity selects its own registry and
+        device metadata, so probe it before the primary resources declared by
+        the master's registry. This remains device-type agnostic, while unknown
+        devices still get a useful first probe before retaining normal order.
         """
+        identity = ("/information/vs/0",) if "/information/vs/0" in resources else ()
         registry = resolve_registry(
             resources,
             device_types=self._identity.device_types if self._identity else (),
         )
         if registry is None:
-            return ()
+            return identity
 
         tier_rank = {"hot": 0, "warm": 1, "cold": 2}
         ranked = []
@@ -1137,7 +1137,7 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 continue
             rank = min(tier_rank.get(capability.poll_tier, 2) for capability in primary_caps)
             ranked.append((rank, order, href))
-        return tuple(href for _, _, href in sorted(ranked))
+        return identity + tuple(href for _, _, href in sorted(ranked))
 
     def _enumerate_subdevices_blocking(self, resources: dict[str, dict]) -> dict[str, dict]:
         """One-time (first discovery only) probe for sibling indoor

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -1109,14 +1109,16 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self,
         resources: dict[str, dict],
     ) -> tuple[str, ...]:
-        """Return identity, then live primary-entity hrefs in probe order.
+        """Return identity, then live operational hrefs in probe order.
 
         A prefixed subdevice without a Collection endpoint has to be probed
         one Property href at a time. Its identity selects its own registry and
         device metadata, so probe it first; prefer a composite entity's binding
-        href next so one live response can materialize the useful device, then
-        retain the registry's hot/warm-first order. This remains device-type
-        agnostic, while unknown devices still get a useful first probe.
+        href next so one live response can materialize the useful device. Include
+        every hot/warm capability after that: composite entities such as climate
+        consume no-entity resources (power, target temperature, wind) from the
+        same snapshot. Cold primary entities remain useful late probes. This is
+        registry-driven and device-type agnostic.
         """
         identity = ("/information/vs/0",) if "/information/vs/0" in resources else ()
         registry = resolve_registry(
@@ -1129,23 +1131,24 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         tier_rank = {"hot": 0, "warm": 1, "cold": 2}
         ranked = []
         for order, href in enumerate(resources):
-            primary_caps = [
+            operational_caps = [
                 capability
                 for capability in registry.capabilities.get(href, ())
-                if any(desc.entity_category is None for desc in capability.entities)
+                if capability.poll_tier in ("hot", "warm")
+                or any(desc.entity_category is None for desc in capability.entities)
             ]
-            if not primary_caps:
+            if not operational_caps:
                 continue
             composite_rank = (
                 0
                 if any(
                     isinstance(desc, ClimateDesc)
-                    for capability in primary_caps
+                    for capability in operational_caps
                     for desc in capability.entities
                 )
                 else 1
             )
-            tier = min(tier_rank.get(capability.poll_tier, 2) for capability in primary_caps)
+            tier = min(tier_rank.get(capability.poll_tier, 2) for capability in operational_caps)
             ranked.append((composite_rank, tier, order, href))
         return identity + tuple(href for _, _, _, href in sorted(ranked))
 

--- a/custom_components/localthings/registry/subdevices.py
+++ b/custom_components/localthings/registry/subdevices.py
@@ -342,14 +342,49 @@ def enumerate_subdevices(
         if sub_id.lower() in probed_ids:
             return
         probed_ids.add(sub_id.lower())
+
+        ordered_hrefs = tuple(_flat_probe_hrefs())
+        flat_hrefs = []
+        attempted_hrefs: set[str] = set()
+
+        def _probe_flat(href: str) -> bool:
+            """Probe one prefixed Property; return whether it was attempted."""
+            timeout = _next_timeout(property_timeout)
+            if timeout is None:
+                return False
+            if attempted_hrefs:
+                sess.pace()
+            attempted_hrefs.add(href)
+            actual = f"/{sub_id}{href}"
+            rep = _get_property(sess, tuple(actual.strip("/").split("/")), timeout)
+            _probed(actual, rep)
+            if rep:
+                flat_hrefs.append(href)
+                fetched[actual] = rep
+            return True
+
+        # A live identity leaf proves this UUID's Property namespace routes.
+        # Read it, then the highest-priority primary/composite-entity leaf,
+        # before spending most of the shared deadline on a Collection that
+        # some firmware does not expose. If the Collection works below, its
+        # batch remains authoritative and these preflight reads are discarded.
+        if ordered_hrefs and ordered_hrefs[0] == "/information/vs/0":
+            _probe_flat(ordered_hrefs[0])
+            if flat_hrefs and len(ordered_hrefs) > 1:
+                _probe_flat(ordered_hrefs[1])
+
         seed = (sub_id, "device", "0")
         timeout = _next_timeout(collection_timeout)
-        if timeout is None:
-            return
-        batch = _get_batch(sess, seed, timeout)
-        _probed(_seed_href(seed), batch)
+        batch = {}
+        if timeout is not None:
+            if attempted_hrefs:
+                sess.pace()
+            batch = _get_batch(sess, seed, timeout)
+            _probed(_seed_href(seed), batch)
         if batch:
             subdevice = Subdevice(kind="prefixed", key=sub_id, seed_path=seed)
+            for href in flat_hrefs:
+                fetched.pop(f"/{sub_id}{href}", None)
             fetched.update(normalize_seed_batch(subdevice, batch))
             subdevices.append(subdevice)
             return
@@ -371,21 +406,11 @@ def enumerate_subdevices(
         # #205's unit answered only 1 of 31 probes), so this hasn't been
         # guarded against -- the fix would compare a candidate's confirmed
         # reps against the master's own values for the same hrefs.
-        flat_hrefs = []
-        first = True
-        for href in _flat_probe_hrefs():
-            if not first:
-                sess.pace()
-            first = False
-            timeout = _next_timeout(property_timeout)
-            if timeout is None:
+        for href in ordered_hrefs:
+            if href in attempted_hrefs:
+                continue
+            if not _probe_flat(href):
                 break
-            actual = f"/{sub_id}{href}"
-            rep = _get_property(sess, tuple(actual.strip("/").split("/")), timeout)
-            _probed(actual, rep)
-            if rep:
-                flat_hrefs.append(href)
-                fetched[actual] = rep
         if not flat_hrefs:
             return
         subdevices.append(

--- a/custom_components/localthings/registry/subdevices.py
+++ b/custom_components/localthings/registry/subdevices.py
@@ -343,6 +343,7 @@ def enumerate_subdevices(
             return
         probed_ids.add(sub_id.lower())
 
+        priority_hrefs = tuple(dict.fromkeys(href for href in preferred_hrefs if href in resources))
         ordered_hrefs = tuple(_flat_probe_hrefs())
         flat_hrefs = []
         attempted_hrefs: set[str] = set()
@@ -364,14 +365,21 @@ def enumerate_subdevices(
             return True
 
         # A live identity leaf proves this UUID's Property namespace routes.
-        # Read it, then the highest-priority primary/composite-entity leaf,
-        # before spending most of the shared deadline on a Collection that
-        # some firmware does not expose. If the Collection works below, its
-        # batch remains authoritative and these preflight reads are discarded.
-        if ordered_hrefs and ordered_hrefs[0] == "/information/vs/0":
-            _probe_flat(ordered_hrefs[0])
-            if flat_hrefs and len(ordered_hrefs) > 1:
-                _probe_flat(ordered_hrefs[1])
+        # If its highest-priority operational leaf also answers, read the rest
+        # of the registry-selected hot/warm and primary leaves before spending
+        # most of the shared deadline on a Collection that some firmware does
+        # not expose. Composite entities need those sibling resources even
+        # though they do not bind entities of their own (power, target
+        # temperature, wind, ...). If the Collection works below, its batch
+        # remains authoritative and these preflight reads are discarded.
+        if priority_hrefs and priority_hrefs[0] == "/information/vs/0":
+            _probe_flat(priority_hrefs[0])
+            if flat_hrefs and len(priority_hrefs) > 1:
+                _probe_flat(priority_hrefs[1])
+                if len(flat_hrefs) == 2:
+                    for href in priority_hrefs[2:]:
+                        if not _probe_flat(href):
+                            break
 
         seed = (sub_id, "device", "0")
         timeout = _next_timeout(collection_timeout)

--- a/tests/test_subdevice_discovery.py
+++ b/tests/test_subdevice_discovery.py
@@ -292,7 +292,7 @@ async def test_fac_bora_2in1_unique_ids_include_subdevice_prefix(hass: HomeAssis
 # ---------------------------------------------------------------------------
 
 
-async def test_flat_probe_priority_puts_live_climate_state_before_cold_metrics(
+async def test_flat_probe_priority_puts_identity_then_climate_state_before_cold_metrics(
     hass: HomeAssistant,
 ):
     """Registry metadata drives fallback order without a model-specific list."""
@@ -301,8 +301,59 @@ async def test_flat_probe_priority_puts_live_climate_state_before_cold_metrics(
 
     priority = coordinator._subdevice_probe_priority(resources)
 
+    assert priority[0] == "/information/vs/0"
     assert "/mode/vs/0" in priority[:4]
     assert priority.index("/mode/vs/0") < priority.index("/energy/consumption/vs/0")
+
+
+async def test_artik051_fac_bora_flat_subdevice_materializes_climate_and_device(
+    hass: HomeAssistant,
+):
+    """A live UUID-prefixed AC does not require its own Collection endpoint."""
+    resources, oic_res, _collection_seeds = _load_device_full("airconditioner_fac_bora_2in1")
+    resources["/information/vs/0"] = {
+        **resources["/information/vs/0"],
+        "x.com.samsung.da.modelNum": "ARTIK051_FAC_BORA_20K|TEST",
+        "x.com.samsung.da.description": "ARTIK051_FAC_BORA_20K",
+    }
+    live_hrefs = (
+        "/information/vs/0",
+        "/power/0",
+        "/power/vs/0",
+        "/mode/vs/0",
+        "/temperature/current/0",
+        "/temperature/desired/0",
+        "/temperatures/vs/0",
+        "/wind/strength/vs/0",
+        "/wind/direction/vs/0",
+        "/humidity/vs/0",
+        "/option/autoclean/vs/0",
+        "/configuration/vs/0",
+        "/alarms/vs/0",
+    )
+    seeds = {f"/{_SUB_UUID}{href}": dict(resources[href]) for href in live_hrefs}
+    seeds[f"/{_SUB_UUID}/information/vs/0"].update(
+        {
+            "x.com.samsung.da.modelNum": "ARTIK051_FAC_BORA_RAC_20K|TEST",
+            "x.com.samsung.da.description": "ARTIK051_FAC_BORA_RAC_20K",
+        }
+    )
+    coordinator = _coordinator(hass)
+
+    await _discover_with(coordinator, resources, oic_res, seeds)
+
+    assert [subdevice.key for subdevice in coordinator.subdevices] == [_SUB_UUID]
+    subdevice = coordinator.subdevices[0]
+    assert subdevice.seed_path == ()
+    assert subdevice.flat_hrefs[0] == "/information/vs/0"
+    assert coordinator._subdevice_probes[f"/{_SUB_UUID}/device/0"] is False
+    assert _climate_bound(coordinator, _SUB_UUID) is not None
+
+    _register_master(hass, coordinator)
+    info = coordinator.device_info_for(subdevice)
+    assert info["identifiers"] == {(DOMAIN, f"{coordinator.device_key}_{_SUB_UUID}")}
+    assert info["model"] == "ARTIK051_FAC_BORA_RAC_20K"
+    assert linked_parent(hass, info) == (DOMAIN, coordinator.device_key)
 
 
 async def test_fac_bora_205_flat_fallback_finds_candidate_but_gate_holds_it_back(

--- a/tests/test_subdevice_discovery.py
+++ b/tests/test_subdevice_discovery.py
@@ -301,8 +301,7 @@ async def test_flat_probe_priority_puts_identity_then_climate_state_before_cold_
 
     priority = coordinator._subdevice_probe_priority(resources)
 
-    assert priority[0] == "/information/vs/0"
-    assert "/mode/vs/0" in priority[:4]
+    assert priority[:2] == ("/information/vs/0", "/mode/vs/0")
     assert priority.index("/mode/vs/0") < priority.index("/energy/consumption/vs/0")
 
 
@@ -346,6 +345,11 @@ async def test_artik051_fac_bora_flat_subdevice_materializes_climate_and_device(
     subdevice = coordinator.subdevices[0]
     assert subdevice.seed_path == ()
     assert subdevice.flat_hrefs[0] == "/information/vs/0"
+    assert list(coordinator._subdevice_probes)[:3] == [
+        f"/{_SUB_UUID}/information/vs/0",
+        f"/{_SUB_UUID}/mode/vs/0",
+        f"/{_SUB_UUID}/device/0",
+    ]
     assert coordinator._subdevice_probes[f"/{_SUB_UUID}/device/0"] is False
     assert _climate_bound(coordinator, _SUB_UUID) is not None
 

--- a/tests/test_subdevice_discovery.py
+++ b/tests/test_subdevice_discovery.py
@@ -302,7 +302,20 @@ async def test_flat_probe_priority_puts_identity_then_climate_state_before_cold_
     priority = coordinator._subdevice_probe_priority(resources)
 
     assert priority[:2] == ("/information/vs/0", "/mode/vs/0")
+    for href in (
+        "/power/0",
+        "/power/vs/0",
+        "/mode/convenient/vs/0",
+        "/temperature/current/0",
+        "/temperature/desired/0",
+        "/temperatures/vs/0",
+        "/wind/strength/vs/0",
+        "/wind/direction/vs/0",
+        "/humidity/vs/0",
+    ):
+        assert href in priority
     assert priority.index("/mode/vs/0") < priority.index("/energy/consumption/vs/0")
+    assert priority.index("/wind/strength/vs/0") < priority.index("/energy/consumption/vs/0")
 
 
 async def test_artik051_fac_bora_flat_subdevice_materializes_climate_and_device(
@@ -320,6 +333,7 @@ async def test_artik051_fac_bora_flat_subdevice_materializes_climate_and_device(
         "/power/0",
         "/power/vs/0",
         "/mode/vs/0",
+        "/mode/convenient/vs/0",
         "/temperature/current/0",
         "/temperature/desired/0",
         "/temperatures/vs/0",
@@ -337,6 +351,45 @@ async def test_artik051_fac_bora_flat_subdevice_materializes_climate_and_device(
             "x.com.samsung.da.description": "ARTIK051_FAC_BORA_RAC_20K",
         }
     )
+    seeds[f"/{_SUB_UUID}/temperature/current/0"] = {
+        "range": [16.0, 30.0],
+        "units": "C",
+        "temperature": 27.0,
+    }
+    seeds[f"/{_SUB_UUID}/temperature/desired/0"] = {
+        "range": [16.0, 30.0],
+        "units": "C",
+        "temperature": 27.0,
+    }
+    seeds[f"/{_SUB_UUID}/wind/strength/vs/0"] = {
+        "x.com.samsung.da.modes": "0",
+        "x.com.samsung.da.supportedModes": ["0", "31", "32", "33", "34", "35"],
+        "x.com.samsung.da.modesName": ["Auto", "1", "2", "3", "4", "Max"],
+    }
+    seeds[f"/{_SUB_UUID}/wind/direction/vs/0"] = {
+        "x.com.samsung.da.modes": "Fix",
+        "x.com.samsung.da.supportedModes": [
+            "Off",
+            "Up_And_Low",
+            "Fix",
+            "Left_And_Right",
+            "All",
+        ],
+    }
+    seeds[f"/{_SUB_UUID}/humidity/vs/0"] = {
+        "x.com.samsung.da.fivepercentHumidity": "57",
+    }
+    seeds[f"/{_SUB_UUID}/mode/convenient/vs/0"] = {
+        "x.com.samsung.da.modes": "Off",
+        "x.com.samsung.da.supportedModes": [
+            "Off",
+            "Sleep",
+            "Quiet",
+            "Smart",
+            "Nano",
+            "NanoSleep",
+        ],
+    }
     coordinator = _coordinator(hass)
 
     await _discover_with(coordinator, resources, oic_res, seeds)
@@ -345,13 +398,45 @@ async def test_artik051_fac_bora_flat_subdevice_materializes_climate_and_device(
     subdevice = coordinator.subdevices[0]
     assert subdevice.seed_path == ()
     assert subdevice.flat_hrefs[0] == "/information/vs/0"
-    assert list(coordinator._subdevice_probes)[:3] == [
+    critical_hrefs = {
+        "/power/0",
+        "/power/vs/0",
+        "/mode/vs/0",
+        "/mode/convenient/vs/0",
+        "/temperature/current/0",
+        "/temperature/desired/0",
+        "/temperatures/vs/0",
+        "/wind/strength/vs/0",
+        "/wind/direction/vs/0",
+        "/humidity/vs/0",
+    }
+    assert critical_hrefs <= set(subdevice.flat_hrefs)
+    probes = list(coordinator._subdevice_probes)
+    collection_index = probes.index(f"/{_SUB_UUID}/device/0")
+    assert probes[:2] == [
         f"/{_SUB_UUID}/information/vs/0",
         f"/{_SUB_UUID}/mode/vs/0",
-        f"/{_SUB_UUID}/device/0",
     ]
+    assert all(probes.index(f"/{_SUB_UUID}{href}") < collection_index for href in critical_hrefs)
     assert coordinator._subdevice_probes[f"/{_SUB_UUID}/device/0"] is False
-    assert _climate_bound(coordinator, _SUB_UUID) is not None
+    sub_climate = _climate_bound(coordinator, _SUB_UUID)
+    assert sub_climate is not None
+
+    from custom_components.localthings.climate import LocalThingsClimate
+
+    climate = LocalThingsClimate(coordinator, sub_climate)
+    assert climate.current_temperature == 27.0
+    assert climate.target_temperature == 27.0
+    assert climate.fan_modes == ["auto", "1", "2", "3", "4", "max"]
+    assert climate.swing_modes == ["vertical", "off", "horizontal", "both"]
+    assert "nano" in climate.preset_modes
+    assert coordinator.canonical_resources(subdevice)["/humidity/vs/0"] == {
+        "x.com.samsung.da.fivepercentHumidity": "57"
+    }
+    assert any(
+        bound.subdevice.key == _SUB_UUID and bound.desc.key == "humidity"
+        for bound in coordinator.bound
+    )
 
     _register_master(hass, coordinator)
     info = coordinator.device_info_for(subdevice)

--- a/tests/test_subdevices.py
+++ b/tests/test_subdevices.py
@@ -463,10 +463,10 @@ def test_enumeration_keeps_preferred_response_found_before_budget_expires(
     assert clock.now == 7.0
 
 
-def test_prefixed_identity_and_primary_leaf_are_probed_before_missing_collection(
+def test_prefixed_operational_leaves_are_probed_before_missing_collection(
     monkeypatch,
 ):
-    """A missing Collection cannot consume the budget before live leaves."""
+    """A missing Collection cannot consume the budget before operational leaves."""
 
     class Clock:
         now = 0.0
@@ -522,7 +522,8 @@ def test_prefixed_identity_and_primary_leaf_are_probed_before_missing_collection
     assert session.calls == [
         ((_UUID, "information", "vs", "0"), 1.0),
         ((_UUID, "mode", "vs", "0"), 1.0),
-        ((_UUID, "device", "0"), 4.0),
+        ((_UUID, "power", "vs", "0"), 1.0),
+        ((_UUID, "device", "0"), 3.0),
     ]
 
 

--- a/tests/test_subdevices.py
+++ b/tests/test_subdevices.py
@@ -463,6 +463,115 @@ def test_enumeration_keeps_preferred_response_found_before_budget_expires(
     assert clock.now == 7.0
 
 
+def test_prefixed_identity_and_primary_leaf_are_probed_before_missing_collection(
+    monkeypatch,
+):
+    """A missing Collection cannot consume the budget before live leaves."""
+
+    class Clock:
+        now = 0.0
+
+        def monotonic(self):
+            return self.now
+
+    class LeafFirstSession:
+        def __init__(self, clock):
+            self.clock = clock
+            self.calls = []
+
+        def get(self, path, timeout=10.0):
+            path = tuple(path)
+            self.calls.append((path, timeout))
+            if path == (_UUID, "information", "vs", "0"):
+                return 0x45, cbor2.dumps({"model": "subdevice"})
+            if path == (_UUID, "mode", "vs", "0"):
+                return 0x45, cbor2.dumps({"mode": "Cool"})
+            self.clock.now += timeout
+            raise TimeoutError
+
+        def pace(self):
+            pass
+
+    clock = Clock()
+    session = LeafFirstSession(clock)
+    monkeypatch.setattr(subdevices_module.time, "monotonic", clock.monotonic)
+    resources = {
+        "/subdevices/vs/0": {"x.com.samsung.da.subdeviceIdList": [_UUID]},
+        "/information/vs/0": {"model": "main"},
+        "/mode/vs/0": {"mode": "Cool"},
+        "/power/vs/0": {"power": "On"},
+    }
+
+    found, extra = enumerate_subdevices(
+        session,
+        resources,
+        oic_res_links=[],
+        preferred_hrefs=("/information/vs/0", "/mode/vs/0", "/power/vs/0"),
+        time_budget=4.0,
+        collection_timeout=4.0,
+        property_timeout=1.0,
+    )
+
+    assert len(found) == 1
+    assert found[0].seed_path == ()
+    assert found[0].flat_hrefs == ("/information/vs/0", "/mode/vs/0")
+    assert extra == {
+        f"/{_UUID}/information/vs/0": {"model": "subdevice"},
+        f"/{_UUID}/mode/vs/0": {"mode": "Cool"},
+    }
+    assert session.calls == [
+        ((_UUID, "information", "vs", "0"), 1.0),
+        ((_UUID, "mode", "vs", "0"), 1.0),
+        ((_UUID, "device", "0"), 4.0),
+    ]
+
+
+def test_prefixed_preflight_keeps_working_collection_authoritative():
+    """Preflight does not switch an existing Collection subdevice to flat mode."""
+
+    class RecordingSession(_FakeSession):
+        def __init__(self, table):
+            super().__init__(table)
+            self.calls = []
+
+        def get(self, path, timeout=10.0):
+            self.calls.append(tuple(path))
+            return super().get(path, timeout)
+
+    resources = {
+        "/subdevices/vs/0": {"x.com.samsung.da.subdeviceIdList": [_UUID]},
+        "/information/vs/0": {"model": "main"},
+        "/mode/vs/0": {"mode": "Cool"},
+    }
+    sess = RecordingSession(
+        {
+            (_UUID, "information", "vs", "0"): {"model": "subdevice"},
+            (_UUID, "mode", "vs", "0"): {"mode": "preflight"},
+            (_UUID, "device", "0"): [
+                _DEVCOL_REP,
+                {"href": "/mode/vs/0", "rep": {"mode": "collection"}},
+            ],
+        }
+    )
+
+    found, extra = enumerate_subdevices(
+        sess,
+        resources,
+        oic_res_links=[],
+        preferred_hrefs=("/information/vs/0", "/mode/vs/0"),
+    )
+
+    assert len(found) == 1
+    assert found[0].seed_path == (_UUID, "device", "0")
+    assert found[0].flat_hrefs == ()
+    assert extra == {f"/{_UUID}/mode/vs/0": {"mode": "collection"}}
+    assert sess.calls[:3] == [
+        (_UUID, "information", "vs", "0"),
+        (_UUID, "mode", "vs", "0"),
+        (_UUID, "device", "0"),
+    ]
+
+
 def test_enumerate_prefixed_flat_fallback_with_no_master_hrefs_to_probe_is_a_no_op():
     """The master itself having nothing but /subdevices/vs/0 in its own
     resources this cycle (e.g. a very first, mostly-empty poll) must not


### PR DESCRIPTION
## Summary
- probe a UUID-prefixed subdevice's identity and highest-priority primary entity resource before its optional device collection
- retain confirmed flat resources when the collection is absent or consumes the discovery budget, while keeping a working collection authoritative
- prioritize climate binding metadata without hardcoding Samsung model names
- cover the ARTIK051 FAC BORA 2-in-1 resource surface and preserve existing collection discovery behavior

## Testing
- 1837 passed
- ruff format --check custom_components tests
- ruff check custom_components tests
- ty check custom_components tests