### PR TITLE
Finish the dryer dry-level select: catalog, sweep, course narrowing

### DIFF
--- a/custom_components/localthings/__init__.py
+++ b/custom_components/localthings/__init__.py
@@ -193,6 +193,56 @@ def _relabel_particulate_statistics(hass: HomeAssistant, entry: ConfigEntry) -> 
     return True
 
 
+# The dryer's dryLevel and dryTime moved from SensorDesc to SelectDesc in
+# #439. unique_ids are scoped by (integration, platform), so that move can't
+# rewrite the old rows -- they can only be dropped, and until they are, each
+# upgraded dryer keeps a permanently-unavailable `sensor.<name>_dry_level`
+# (and `_dry_time`) carrying the user's rename and area.
+#
+# Tail-matched for the same reason as _PARTICULATE_KEY_RE above: the id is
+# f"{DOMAIN}_{serial}_{state_key}" with an optional subdevice prefix and a
+# trailing `_<n>` instance, and matching the tail keeps working for a renamed
+# entity. No device-type gate is needed -- no registry binds a sensor-domain
+# dry_level or dry_time any more, so the domain check plus this tail is
+# already exact.
+_MOVED_TO_SELECT_KEY_RE = re.compile(r"_(?:dry_level|dry_time)(?:_\d+)?$")
+
+
+@callback
+def _drop_sensors_superseded_by_selects(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Drop the sensor rows dryer.py's dry_level/dry_time selects supersede.
+
+    Runs on every setup rather than as a numbered migration. The sweep is
+    idempotent -- after the first pass there is nothing left matching the
+    pattern in the sensor domain -- so a version gate would buy only running
+    it once, at the cost of a bump that makes the *whole entry* fail to load
+    on a downgrade (`entry.version > 4` in async_migrate_entry) instead of
+    losing two entities. That trade isn't worth it for a registry tidy-up.
+
+    Not gated on the select existing either: dry_level is field-gated and
+    dry_time carries an exists_fn, so on a board reporting neither there is
+    no replacement -- but the sensor is equally dead there, because no
+    registry binds these keys to the sensor platform any more.
+    """
+    ent_reg = er.async_get(hass)
+    for registry_entry in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if registry_entry.domain != "sensor":
+            continue
+        if not _MOVED_TO_SELECT_KEY_RE.search(registry_entry.unique_id):
+            continue
+        # INFO, not debug: this is irreversible and takes the user's rename,
+        # area and any automation reference with it. The replacement is named
+        # by platform only -- deriving `select.<object_id>` from this row
+        # would be a guess, since a renamed sensor's object id is not the one
+        # the new select gets.
+        _LOGGER.info(
+            "Removing %s, superseded by a select entity on the same device; "
+            "update any automation or dashboard that referenced it",
+            registry_entry.entity_id,
+        )
+        ent_reg.async_remove(registry_entry.entity_id)
+
+
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate an entry to the current version.
 
@@ -263,6 +313,11 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
+
+    # Before the platforms register anything, so an upgraded dryer never has
+    # the dead sensor row and its replacement select alive at the same time.
+    _drop_sensors_superseded_by_selects(hass, entry)
+
     coordinator = LocalThingsCoordinator(hass, entry)
 
     # Before the first refresh, so the coordinator keeps rescheduling even

--- a/custom_components/localthings/registry/capabilities/dryer.py
+++ b/custom_components/localthings/registry/capabilities/dryer.py
@@ -12,7 +12,13 @@ the /course/vs/0 cycle select -- lives in laundry.py.
 from ..capability import Capability
 from ..entities import SelectDesc, SensorDesc, SwitchDesc
 from .common import diagnosis_status
-from .laundry import cycle_select, drum_clean_cycles_remaining, drum_clean_last_cleaned
+from .laundry import (
+    OPTION_KIND_DRY,
+    course_narrowed_options,
+    cycle_select,
+    drum_clean_cycles_remaining,
+    drum_clean_last_cleaned,
+)
 
 
 def _wrinkle_write(p, rep, href=None):
@@ -28,20 +34,44 @@ def _setting_write(field):
 # dryLevel/dryTime were read-only sensors until issue #438; both carry the
 # device's own supported-values list, so the options come from the board
 # rather than a hardcoded tuple, and washer.WASHER_SETTINGS already writes
-# dryLevel this way on combo units. The write itself is inferred from that
-# sibling contract, not yet confirmed on a plain dryer -- issue #438 asks
-# the reporter to exercise it. Moving these from sensor to select changes
-# their entity IDs (sensor.*_dry_level -> select.*_dry_level).
+# dryLevel this way on combo units. Moving these from sensor to select
+# changes their entity IDs (sensor.*_dry_level -> select.*_dry_level); the
+# orphaned sensor rows are swept in __init__ on setup.
+#
+# The dryLevel write is confirmed, not just inferred from that sibling
+# contract: exercised end to end on a DV5000T (DA_WM_TP2_20_COMMON) through
+# Home Assistant (PR #407). That board reports isModelSettingWithoutSC true,
+# so the write lands with Smart Control off -- see
+# common.remote_control_required_for_write. dryTime's write is still the
+# inferred one; issue #438 asks the reporter to exercise it.
 DRYER_SETTINGS = Capability(
     href="/washer/vs/0",
     poll_tier="warm",
     entities=(
+        # translation_key is dryer_dry_level, NOT washer.py's
+        # washer_dry_level: that catalog is this same field's *other*
+        # meaning on a combo, a duration in minutes ("30" -> "30 min"), and
+        # reusing it would label a dryness dial in minutes. The
+        # Damp/Less/Normal/More/Very vocabulary the TP1_21 boards report is
+        # catalogued; the numeric None/1/2/3 that DV5000T (TP2_20) and
+        # DV6800N (A51_20) report deliberately is not, so select._display
+        # renders those digits raw rather than guessing a meaning for them.
+        #
+        # Options are narrowed to the selected course (issue #408's decode,
+        # landed in #425). 0xD is the right nibble here: all five dumps
+        # routing to this registry carry a 0xD group, and the WW6600R combo
+        # -- whose dry dial is 0xB -- routes to the washer registry instead.
         SelectDesc(
             key="dry_level",
             field="x.com.samsung.da.dryLevel",
             icon="mdi:water-percent",
             entity_category="config",
-            options_field="x.com.samsung.da.supportedDryLevel",
+            translation_key="dryer_dry_level",
+            options=course_narrowed_options(
+                OPTION_KIND_DRY,
+                "x.com.samsung.da.dryLevel",
+                "x.com.samsung.da.supportedDryLevel",
+            ),
             write_fn=_setting_write("x.com.samsung.da.dryLevel"),
         ),
         SelectDesc(

--- a/custom_components/localthings/registry/capabilities/laundry.py
+++ b/custom_components/localthings/registry/capabilities/laundry.py
@@ -418,6 +418,68 @@ def course_option_mask(resources, kind, course=None):
     return None
 
 
+def course_narrowed_options(kind, field, options_field, href="/washer/vs/0"):
+    """Build a SelectDesc `options` callable that narrows a supported<Option>
+    list to what the *selected course* actually accepts.
+
+    Without this, a dryer offers every dry level its board supports on every
+    course, and the ones the running course rejects are simply ignored by the
+    appliance -- no error, no state change, nothing the user can see. Handing
+    the entity a narrowed list turns that silent no-op into a visible
+    ServiceValidationError from Home Assistant's own option check.
+
+    `kind` is one of the OPTION_KIND_* nibbles above; `field` and
+    `options_field` are this entity's live value and its full supported list
+    on `href`.
+
+    Three rules, none of which the mask decides on its own:
+
+      - **Never blank the entity.** The result is the decoded set *union the
+        live value*: `options` and `current_option` are computed independently
+        by select.py, and HA's SelectEntity.state returns None when the
+        current option isn't in the list -- so a course change landing before
+        the board updates its dryLevel would otherwise read as `unknown`.
+      - **Never narrow to empty.** An empty `_raw_options()` is the
+        "unpopulated" contract that pairs with exists_fn suppression, and
+        these descriptors deliberately have none, so an empty list means a
+        live entity with an empty dropdown rather than no entity. No opinion
+        from the decoder (`None`) falls back to the full supported list; a
+        course that genuinely allows nothing falls back to just the live
+        value.
+      - **The supported list sets the order**, not the mask, so the dropdown
+        doesn't reshuffle as the course changes. A live value the supported
+        list omits is appended rather than dropped.
+    """
+
+    def _options(resources):
+        rep = resources.get(href) or {}
+        supported = list(rep.get(options_field) or [])
+        live = rep.get(field)
+        if not supported:
+            # Unpopulated rep: keep the existing contract rather than
+            # inventing a single-entry list out of a live value.
+            return []
+
+        mask = course_option_mask(resources, kind)
+        if mask is None:
+            return supported  # no opinion -- see course_option_mask
+        _default, allowed = mask
+
+        # The mask indexes the supported list; an index past its end is the
+        # device describing a longer list than it published here, which says
+        # nothing about the entries that do exist.
+        keep = {supported[i] for i in allowed if i < len(supported)}
+        if isinstance(live, str):
+            keep.add(live)
+
+        narrowed = [o for o in supported if o in keep]
+        if isinstance(live, str) and live not in narrowed:
+            narrowed.append(live)
+        return narrowed or supported
+
+    return _options
+
+
 def _course_codes_from_supported_options(course_rep):
     """Fallback for an empty/missing editCourseList: derive the selectable
     course list from /course/vs/0's own supportedOptions instead (issue #1:

--- a/custom_components/localthings/registry/capabilities/laundry.py
+++ b/custom_components/localthings/registry/capabilities/laundry.py
@@ -297,6 +297,28 @@ OPTION_KIND_RINSE = 0x9
 OPTION_KIND_SPIN = 0xA
 OPTION_KIND_DRY = 0xD
 
+# A mask is one byte, so it can only speak about the first eight entries of
+# the supported<Option> list it indexes. Three boards carry an 11- or
+# 13-entry supportedDryTime; none of them carries a group for it today, so
+# nothing currently relies on this, but a list longer than this is one the
+# mask only partially describes.
+MASK_ADDRESSABLE = 8
+
+
+def _on_download_course(resources):
+    """True when the live course is this device's confirmed Download slot.
+
+    Read straight from the course rep rather than through cloud_current():
+    that one additionally requires a *named* program to be loaded, and an
+    unnamed Download selection is just as much "the mask is not describing
+    this course".
+    """
+    rep = resources.get(cloudcourse.COURSE_HREF) or {}
+    download = (rep.get(cloudcourse.FIELD) or {}).get("download_course")
+    return (
+        bool(download) and option_value(rep.get("x.com.samsung.da.options"), "Course") == download
+    )
+
 
 def _course_records(course_rep, must_cover=None):
     """{course code: record hex} from supportedOptions, or {} if unreadable.
@@ -449,6 +471,20 @@ def course_narrowed_options(kind, field, options_field, href="/washer/vs/0"):
       - **The supported list sets the order**, not the mask, so the dropdown
         doesn't reshuffle as the course changes. A live value the supported
         list omits is appended rather than dropped.
+
+    Two of the module comment's warnings are this caller's to answer, and
+    both are answered by offering *more* rather than less -- the mask is
+    what the device advertises, not what it enforces, so over-offering costs
+    at most a write the appliance refuses, while under-offering makes a
+    level the user really can select unreachable through Home Assistant:
+
+      - **An empty mask on the Download course is not "nothing selectable".**
+        A cloud slot reports empty masks for every kind while its values stay
+        live, because the downloaded program supplies its own. Only a local
+        course's empty mask (a dryer's Quick Dry) means what it says.
+      - **A one-byte mask cannot address past index 7.** Where the supported
+        list is longer, the entries beyond that are unaddressable rather than
+        disallowed, so they are kept.
     """
 
     def _options(resources):
@@ -465,10 +501,19 @@ def course_narrowed_options(kind, field, options_field, href="/washer/vs/0"):
             return supported  # no opinion -- see course_option_mask
         _default, allowed = mask
 
+        if not allowed and _on_download_course(resources):
+            # A cloud slot's empty mask is not this course refusing every
+            # value; the downloaded program carries its own, and the board
+            # keeps taking writes. Treat it as no opinion.
+            return supported
+
         # The mask indexes the supported list; an index past its end is the
         # device describing a longer list than it published here, which says
-        # nothing about the entries that do exist.
+        # nothing about the entries that do exist. Past MASK_ADDRESSABLE the
+        # reverse holds: the mask *cannot* reach those entries, so their
+        # absence from it is not a refusal either.
         keep = {supported[i] for i in allowed if i < len(supported)}
+        keep.update(supported[MASK_ADDRESSABLE:])
         if isinstance(live, str):
             keep.add(live)
 

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -416,6 +416,17 @@
           "3d": "Džíny"
         }
       },
+      "dryer_dry_level": {
+        "name": "Úroveň sušení",
+        "state": {
+          "none": "Vypnuto",
+          "damp": "Vlhké",
+          "less": "Méně",
+          "normal": "Normální",
+          "more": "Více",
+          "very": "Velmi"
+        }
+      },
       "favorite_capacity": {
         "name": "Oblíbené množství"
       },

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -873,9 +873,6 @@
           "smartventilation": "Chytré větrání"
         }
       },
-      "dry_level": {
-        "name": "Úroveň sušení"
-      },
       "dry_time": {
         "name": "Doba sušení"
       }

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -416,6 +416,17 @@
           "3d": "Jeansstoff"
         }
       },
+      "dryer_dry_level": {
+        "name": "Trockenstufe",
+        "state": {
+          "none": "Aus",
+          "damp": "Feucht",
+          "less": "Weniger",
+          "normal": "Normal",
+          "more": "Mehr",
+          "very": "Sehr"
+        }
+      },
       "favorite_capacity": {
         "name": "Favoritenmenge"
       },

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -873,9 +873,6 @@
           "smartventilation": "Intelligente Lüftung"
         }
       },
-      "dry_level": {
-        "name": "Trockenstufe"
-      },
       "dry_time": {
         "name": "Trockenzeit"
       }

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -416,6 +416,17 @@
           "3d": "Denim"
         }
       },
+      "dryer_dry_level": {
+        "name": "Dry level",
+        "state": {
+          "none": "Off",
+          "damp": "Damp",
+          "less": "Less",
+          "normal": "Normal",
+          "more": "More",
+          "very": "Very"
+        }
+      },
       "favorite_capacity": {
         "name": "Favorite capacity"
       },

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -873,9 +873,6 @@
           "smartventilation": "Smart Ventilation"
         }
       },
-      "dry_level": {
-        "name": "Dry level"
-      },
       "dry_time": {
         "name": "Dry time"
       }

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -613,6 +613,17 @@
           "3d": "Denim"
         }
       },
+      "dryer_dry_level": {
+        "name": "Nivel de secado",
+        "state": {
+          "none": "Desactivado",
+          "damp": "Húmedo",
+          "less": "Menos",
+          "normal": "Normal",
+          "more": "Más",
+          "very": "Muy"
+        }
+      },
       "favorite_capacity": {
         "name": "Capacidad favorita"
       },

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -1070,9 +1070,6 @@
           "smartventilation": "Ventilación inteligente"
         }
       },
-      "dry_level": {
-        "name": "Nivel de secado"
-      },
       "dry_time": {
         "name": "Tiempo de secado"
       }

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -416,6 +416,17 @@
           "3d": "Jeans"
         }
       },
+      "dryer_dry_level": {
+        "name": "Livello asciugatura",
+        "state": {
+          "none": "Spento",
+          "damp": "Umido",
+          "less": "Meno",
+          "normal": "Normale",
+          "more": "Più",
+          "very": "Molto"
+        }
+      },
       "favorite_capacity": {
         "name": "Capacità preferita"
       },

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -873,9 +873,6 @@
           "smartventilation": "Ventilazione intelligente"
         }
       },
-      "dry_level": {
-        "name": "Livello asciugatura"
-      },
       "dry_time": {
         "name": "Tempo di asciugatura"
       }

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -416,6 +416,17 @@
           "3d": "데님"
         }
       },
+      "dryer_dry_level": {
+        "name": "건조 단계",
+        "state": {
+          "none": "끄기",
+          "damp": "촉촉",
+          "less": "적게",
+          "normal": "표준",
+          "more": "많이",
+          "very": "매우 많이"
+        }
+      },
       "favorite_capacity": {
         "name": "즐겨찾기 출수량"
       },

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -873,9 +873,6 @@
           "smartventilation": "스마트환기"
         }
       },
-      "dry_level": {
-        "name": "건조 단계"
-      },
       "dry_time": {
         "name": "건조 시간"
       }

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -416,6 +416,17 @@
           "3d": "Spijkergoed"
         }
       },
+      "dryer_dry_level": {
+        "name": "Droogniveau",
+        "state": {
+          "none": "Uit",
+          "damp": "Vochtig",
+          "less": "Minder",
+          "normal": "Normaal",
+          "more": "Meer",
+          "very": "Zeer"
+        }
+      },
       "favorite_capacity": {
         "name": "Favoriete capaciteit"
       },

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -873,9 +873,6 @@
           "smartventilation": "Slimme ventilatie"
         }
       },
-      "dry_level": {
-        "name": "Droogniveau"
-      },
       "dry_time": {
         "name": "Droogtijd"
       }

--- a/tests/localthings/test_superseded_entities.py
+++ b/tests/localthings/test_superseded_entities.py
@@ -1,0 +1,160 @@
+"""The sweep that drops sensor rows a platform move has superseded.
+
+The dryer's dryLevel and dryTime became selects in #439. unique_ids are
+scoped by (integration, platform), so that move cannot rewrite the old rows
+-- they can only be dropped, and until they are, every upgraded dryer keeps
+a permanently-unavailable `sensor.<name>_dry_level` carrying the user's
+rename, area and any automation reference.
+
+Deliberately not a numbered migration (reviewed on PR #407): the sweep is
+idempotent, so a version gate would buy only running it once, at the cost of
+a bump that fails the *whole entry* to load on a downgrade rather than
+losing two entities.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.localthings import _drop_sensors_superseded_by_selects
+from custom_components.localthings.const import DOMAIN
+
+from .conftest import LEGACY_ENTRY_DATA, MOCK_SERIAL
+
+
+def _entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data=LEGACY_ENTRY_DATA, version=4)
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _row(hass: HomeAssistant, entry: MockConfigEntry, domain: str, unique_suffix: str):
+    return er.async_get(hass).async_get_or_create(
+        domain,
+        DOMAIN,
+        f"{DOMAIN}_{MOCK_SERIAL}_{unique_suffix}",
+        config_entry=entry,
+    )
+
+
+async def test_drops_both_superseded_sensors(hass: HomeAssistant) -> None:
+    entry = _entry(hass)
+    level = _row(hass, entry, "sensor", "dry_level")
+    time = _row(hass, entry, "sensor", "dry_time")
+
+    _drop_sensors_superseded_by_selects(hass, entry)
+
+    ent_reg = er.async_get(hass)
+    assert ent_reg.async_get(level.entity_id) is None
+    assert ent_reg.async_get(time.entity_id) is None
+
+
+async def test_matches_a_subdevice_instanced_key(hass: HomeAssistant) -> None:
+    """Same tail-matching contract as the particulate-statistics relabel: a
+    key can carry a subdevice prefix and a trailing `_<n>` instance, and
+    matching the tail is what keeps this working for a renamed entity, whose
+    entity_id no longer follows from its key."""
+    entry = _entry(hass)
+    instanced = _row(hass, entry, "sensor", "subdevice_uuid_dry_level_2")
+
+    _drop_sensors_superseded_by_selects(hass, entry)
+
+    assert er.async_get(hass).async_get(instanced.entity_id) is None
+
+
+async def test_leaves_the_replacement_and_unrelated_rows_alone(hass: HomeAssistant) -> None:
+    """The domain check is what makes the tail safe: the select that
+    supersedes these carries the identical key."""
+    entry = _entry(hass)
+    replacement = _row(hass, entry, "select", "dry_level")
+    unrelated = _row(hass, entry, "sensor", "dryer_type")
+    # A key merely *ending* in something similar must not be swept.
+    not_a_tail = _row(hass, entry, "sensor", "dry_level_remaining")
+
+    _drop_sensors_superseded_by_selects(hass, entry)
+
+    ent_reg = er.async_get(hass)
+    assert ent_reg.async_get(replacement.entity_id) is not None
+    assert ent_reg.async_get(unrelated.entity_id) is not None
+    assert ent_reg.async_get(not_a_tail.entity_id) is not None
+
+
+async def test_leaves_another_entrys_rows_alone(hass: HomeAssistant) -> None:
+    """Scoped to the entry being set up, not the whole registry -- two
+    dryers are two entries, and each sweeps its own on its own setup."""
+    entry = _entry(hass)
+    other = MockConfigEntry(domain=DOMAIN, data=LEGACY_ENTRY_DATA, version=4)
+    other.add_to_hass(hass)
+    theirs = er.async_get(hass).async_get_or_create(
+        "sensor", DOMAIN, f"{DOMAIN}_OTHER-SERIAL_dry_level", config_entry=other
+    )
+
+    _drop_sensors_superseded_by_selects(hass, entry)
+
+    assert er.async_get(hass).async_get(theirs.entity_id) is not None
+
+
+async def test_is_idempotent(hass: HomeAssistant) -> None:
+    """The property the whole no-version-bump argument rests on: running it
+    on every setup has to be free once there is nothing left to drop."""
+    entry = _entry(hass)
+    _row(hass, entry, "sensor", "dry_level")
+    keep = _row(hass, entry, "select", "dry_level")
+
+    _drop_sensors_superseded_by_selects(hass, entry)
+    before = set(er.async_get(hass).entities)
+    _drop_sensors_superseded_by_selects(hass, entry)
+
+    assert set(er.async_get(hass).entities) == before
+    assert er.async_get(hass).async_get(keep.entity_id) is not None
+
+
+async def test_logs_the_removal_without_guessing_the_replacement_id(
+    hass: HomeAssistant, caplog
+) -> None:
+    """INFO, not debug: the removal is irreversible and takes the user's
+    rename and area with it. It names the row it removed but NOT a
+    `select.<object_id>` derived from it -- a renamed sensor's object id is
+    not the one the new select gets, so that would be a guess."""
+    entry = _entry(hass)
+    renamed = er.async_get(hass).async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_{MOCK_SERIAL}_dry_level",
+        config_entry=entry,
+        suggested_object_id="basement_dryer_dryness",
+    )
+    assert renamed.entity_id == "sensor.basement_dryer_dryness"
+
+    with caplog.at_level(logging.INFO, logger="custom_components.localthings"):
+        _drop_sensors_superseded_by_selects(hass, entry)
+
+    assert "sensor.basement_dryer_dryness" in caplog.text
+    assert "select.basement_dryer_dryness" not in caplog.text
+
+
+async def test_runs_on_setup(hass: HomeAssistant, fridge_resources) -> None:
+    """Wired into async_setup_entry, and before the platforms register, so
+    an upgraded dryer never has the dead row and its replacement alive at
+    the same time."""
+    # Reusing the identity suite's harness rather than rebuilding it: this
+    # is the only test here that needs a device to answer a poll, and that
+    # setup (a UUID-keyed v4 entry plus a patched session) is exactly what
+    # it already builds. Imported locally to keep that coupling visible.
+    from .test_identity_migration import UUID_A, _reachable
+    from .test_identity_migration import _entry as _identity_entry
+
+    entry = _identity_entry(hass, version=4, key=UUID_A, device_key=UUID_A)
+    orphan = er.async_get(hass).async_get_or_create(
+        "sensor", DOMAIN, f"{DOMAIN}_{UUID_A}_dry_level", config_entry=entry
+    )
+
+    with _reachable(fridge_resources, UUID_A):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert er.async_get(hass).async_get(orphan.entity_id) is None

--- a/tests/test_dryer_capabilities.py
+++ b/tests/test_dryer_capabilities.py
@@ -53,6 +53,25 @@ def test_expected_entities_present():
         assert key in state, key
 
 
+def test_dry_level_presence_is_field_gated_not_narrowed_by_an_exists_fn():
+    """dry_level must appear wherever the sensor it replaced did.
+
+    washer.py gates its combo dry_level on supportedDryLevel to tell a combo
+    from a plain washer; every dryer has a dry level, so the same gate here
+    would only ever suppress the entity -- including on a rep that is merely
+    a stub at discovery, which entity._is_included deliberately admits so a
+    sub-poll can populate it.
+
+    A missing entity would be permanent and silent: __init__'s
+    _drop_sensors_superseded_by_selects removes the old sensor row on every
+    setup, unconditionally, so there is nothing left to fall back to.
+    """
+    desc = next(e for e in dryer.DRYER_SETTINGS.entities if e.key == "dry_level")
+    assert isinstance(desc, SelectDesc)
+    assert desc.exists_fn is None
+    assert desc.field == "x.com.samsung.da.dryLevel"
+
+
 def test_job_beginning_status_reads_current_status():
     """The dump carries x.com.samsung.da.currentStatus (not the old
     jobBeginingStatus field the dryer descriptor used to read), so the sensor

--- a/tests/test_select_options.py
+++ b/tests/test_select_options.py
@@ -5,6 +5,7 @@ and callable forms of SelectDesc.options.
 
 from typing import ClassVar, cast
 
+from custom_components.localthings import cloudcourse
 from custom_components.localthings.coordinator import LocalThingsCoordinator
 from custom_components.localthings.registry.capabilities import dryer
 from custom_components.localthings.registry.capabilities.laundry import (
@@ -206,6 +207,56 @@ class TestDryLevelNarrowing:
             supported=[],
         )
         assert entity.options == []
+
+    def test_an_empty_mask_on_the_download_course_is_not_a_refusal(self):
+        """A cloud Download slot reports empty masks for every kind while its
+        values stay live -- the downloaded program supplies its own, and the
+        board keeps taking writes (see the module comment above
+        OPTION_KIND_*). Collapsing to the live value there would make every
+        other level raise on a course that actually accepts them.
+
+        Course 02 is this device's confirmed Download course and is the live
+        selection, so its all-zero mask carries no opinion.
+        """
+        entity = self._entity(
+            {
+                "x.com.samsung.da.options": ["Course_02"],
+                "x.com.samsung.da.supportedOptions": ["101D01E02D000"],
+                cloudcourse.FIELD: {"download_course": "02", "programs": {}},
+            }
+        )
+        assert entity.options == ["none", "damp", "less", "normal", "more"]
+
+    def test_an_empty_mask_on_a_local_course_still_falls_back(self):
+        """The same bytes without the Download marker keep the old meaning --
+        a dryer's Quick Dry genuinely allows nothing."""
+        entity = self._entity(
+            {
+                "x.com.samsung.da.options": ["Course_02"],
+                "x.com.samsung.da.supportedOptions": ["101D01E02D000"],
+                cloudcourse.FIELD: {"download_course": "01", "programs": {}},
+            }
+        )
+        assert entity.options == ["normal"]
+
+    def test_entries_a_one_byte_mask_cannot_address_are_kept(self):
+        """The mask is one byte, so it can only speak about indices 0-7. A
+        longer supported list is one it partially describes, not one whose
+        tail it refuses -- and over-offering costs at most a write the
+        appliance rejects, while under-offering makes a value the user can
+        really select unreachable.
+        """
+        supported = [f"L{i}" for i in range(11)]
+        entity = self._entity(
+            {
+                "x.com.samsung.da.options": ["Course_01"],
+                # Mask 0b00000110 -- indices 1 and 2 of the addressable range.
+                "x.com.samsung.da.supportedOptions": ["101D00602D000"],
+            },
+            dry_level="L1",
+            supported=supported,
+        )
+        assert entity.options == ["L1", "L2", "L8", "L9", "L10"]
 
     def test_the_supported_list_sets_the_order_not_the_mask(self):
         """The dropdown must not reshuffle as the course changes."""

--- a/tests/test_select_options.py
+++ b/tests/test_select_options.py
@@ -6,6 +6,7 @@ and callable forms of SelectDesc.options.
 from typing import ClassVar, cast
 
 from custom_components.localthings.coordinator import LocalThingsCoordinator
+from custom_components.localthings.registry.capabilities import dryer
 from custom_components.localthings.registry.capabilities.laundry import (
     BUZZER_SOUND,
     cycle_select,
@@ -30,10 +31,10 @@ class _FakeCoordinator:
         return self.last_resources
 
 
-def _make_select(desc, href, last_resources):
+def _make_select(desc, href, last_resources, coordinator_cls=_FakeCoordinator):
     capability = Capability(href=href, entities=(desc,))
     bound = BoundEntity(href=href, capability=capability, desc=desc)
-    return LocalThingsSelect(cast(LocalThingsCoordinator, _FakeCoordinator(last_resources)), bound)
+    return LocalThingsSelect(cast(LocalThingsCoordinator, coordinator_cls(last_resources)), bound)
 
 
 def test_static_options_unaffected():
@@ -65,6 +66,158 @@ def test_buzzer_volume_options_normalize_to_translation_keys():
         },
     )
     assert entity.options == ["volume_off", "volume_low", "volume_med", "volume_high"]
+
+
+def _dry_level_desc():
+    return next(e for e in dryer.DRYER_SETTINGS.entities if e.key == "dry_level")
+
+
+def test_dryer_dry_level_word_vocabulary_normalizes_to_translation_keys():
+    """Damp/Less/Normal/More/Very are catalogued under dryer_dry_level, so
+    they normalize to lowercase state keys the same way
+    test_buzzer_volume_options_normalize_to_translation_keys does -- Home
+    Assistant's frontend resolves the displayed text from there."""
+    entity = _make_select(
+        _dry_level_desc(),
+        "/washer/vs/0",
+        {
+            "/washer/vs/0": {
+                "x.com.samsung.da.dryLevel": "Normal",
+                "x.com.samsung.da.supportedDryLevel": [
+                    "None",
+                    "Damp",
+                    "Less",
+                    "Normal",
+                    "More",
+                    "Very",
+                ],
+            }
+        },
+    )
+    assert entity.options == ["none", "damp", "less", "normal", "more", "very"]
+
+
+def test_dryer_dry_level_numeric_vocabulary_renders_raw():
+    """DV6800N reports supportedDryLevel as None/1/2/3 rather than the
+    confirmed words. 'None' still normalizes (it is in the catalog); the
+    digits have no catalog entry, so they pass through unchanged instead of
+    being guessed at."""
+    entity = _make_select(
+        _dry_level_desc(),
+        "/washer/vs/0",
+        {
+            "/washer/vs/0": {
+                "x.com.samsung.da.dryLevel": "2",
+                "x.com.samsung.da.supportedDryLevel": ["None", "1", "2", "3"],
+            }
+        },
+    )
+    assert entity.options == ["none", "1", "2", "3"]
+
+
+class TestDryLevelNarrowing:
+    """dry_level's options follow the selected course (laundry.
+    course_narrowed_options): the board advertises every level it supports,
+    but each course only accepts a subset, and a write outside that subset
+    is silently ignored by the appliance. Narrowing turns that no-op into
+    Home Assistant's own ServiceValidationError.
+
+    A record here is `<course:1><kind:nibble><default:nibble><mask:1>` after
+    a 1-nibble group-count header, so "1" + "01D01E" is course 01 with one
+    0xD (dry) group, default 0 and a mask of 0b00011110 -- indices 1-4. Each
+    fixture carries a second course because _course_records rejects a
+    one-record table as indistinguishable from garbage.
+    """
+
+    _SUPPORTED: ClassVar[list[str]] = ["None", "Damp", "Less", "Normal", "More"]
+
+    def _entity(self, options, dry_level="Normal", supported=None):
+        class _Coordinator(_FakeCoordinator):
+            # What flatten() would have produced; only the live-value test
+            # reads it back through current_option.
+            data: ClassVar[dict] = {"dry_level": dry_level}
+
+        return _make_select(
+            _dry_level_desc(),
+            "/washer/vs/0",
+            {
+                "/washer/vs/0": {
+                    "x.com.samsung.da.dryLevel": dry_level,
+                    "x.com.samsung.da.supportedDryLevel": (
+                        self._SUPPORTED if supported is None else supported
+                    ),
+                },
+                "/course/vs/0": options,
+            },
+            coordinator_cls=_Coordinator,
+        )
+
+    def test_mask_drops_the_levels_the_course_refuses(self):
+        entity = self._entity(
+            {
+                "x.com.samsung.da.options": ["Course_01"],
+                "x.com.samsung.da.supportedOptions": ["101D01E02D000"],
+            }
+        )
+        assert entity.options == ["damp", "less", "normal", "more"]
+
+    def test_no_decodable_opinion_keeps_the_full_supported_list(self):
+        """A board with no supportedOptions at all says nothing about which
+        levels its courses accept. course_option_mask returns None there,
+        and 'no opinion' must not read as 'nothing allowed'."""
+        entity = self._entity({"x.com.samsung.da.options": ["Course_01"]})
+        assert entity.options == ["none", "damp", "less", "normal", "more"]
+
+    def test_the_live_value_is_never_narrowed_away(self):
+        """options and current_option are computed independently, and HA's
+        SelectEntity.state returns None when the current option is missing
+        from options -- so a course change landing before the board updates
+        dryLevel would blank the entity. The union prevents that."""
+        entity = self._entity(
+            {
+                "x.com.samsung.da.options": ["Course_01"],
+                "x.com.samsung.da.supportedOptions": ["101D01E02D000"],
+            },
+            dry_level="None",  # index 0, outside the mask
+        )
+        assert entity.options == ["none", "damp", "less", "normal", "more"]
+        # The point of the union: HA reads state as None when this fails.
+        assert entity.current_option in entity.options
+
+    def test_an_empty_mask_falls_back_to_the_live_value(self):
+        """A course that advertises nothing selectable (a dryer's Quick Dry)
+        must not leave a live entity with an empty dropdown -- that is the
+        'unpopulated' contract, which pairs with exists_fn suppression this
+        descriptor deliberately does not have."""
+        entity = self._entity(
+            {
+                "x.com.samsung.da.options": ["Course_01"],
+                "x.com.samsung.da.supportedOptions": ["101D00002D01E"],
+            }
+        )
+        assert entity.options == ["normal"]
+
+    def test_an_unpopulated_rep_still_yields_no_options(self):
+        """No supportedDryLevel yet is the one case that legitimately gives
+        an empty list: narrowing must not invent a single-entry dropdown out
+        of a live value on a rep that has not been polled."""
+        entity = self._entity(
+            {"x.com.samsung.da.options": ["Course_01"]},
+            supported=[],
+        )
+        assert entity.options == []
+
+    def test_the_supported_list_sets_the_order_not_the_mask(self):
+        """The dropdown must not reshuffle as the course changes."""
+        entity = self._entity(
+            {
+                "x.com.samsung.da.options": ["Course_01"],
+                "x.com.samsung.da.supportedOptions": ["101D01E02D000"],
+            }
+        )
+        assert entity.options == sorted(
+            entity.options, key=["none", "damp", "less", "normal", "more"].index
+        )
 
 
 def test_callable_options_receives_full_resource_snapshot():

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -424,6 +424,19 @@ def test_confirmed_ww6500_table_00_course_names():
     )
 
 
+def test_confirmed_dryer_dry_level_labels():
+    """dryer_dry_level's word vocabulary (None/Damp/Less/Normal/More/Very),
+    confirmed across the TP1_21 dryer fixtures. The numeric vocabulary
+    (None/1/2/3) that DV6800N reports is deliberately NOT translated -- no
+    confirmed meaning for the digits exists, and select._display renders an
+    uncatalogued value raw rather than guessing a label for it."""
+    states = _load("en")["entity"]["select"]["dryer_dry_level"]["state"]
+    assert set(states) == {"none", "damp", "less", "normal", "more", "very"}
+    assert states["none"] == "Off"
+    for digit in ("1", "2", "3"):
+        assert digit not in states
+
+
 def test_reported_washer_standard_courses_all_have_table_02_labels():
     """Every non-personal code in the reported washer's live course list
     must resolve through the Table_02 catalog instead of appearing as raw

--- a/tests/test_wf80h_dv80h_capabilities.py
+++ b/tests/test_wf80h_dv80h_capabilities.py
@@ -85,23 +85,44 @@ def test_washer_auto_dispense_writes_target_the_wash_resource():
 
 
 def test_dryer_dry_level_options_come_from_the_device():
-    """supportedDryLevel/supportedDryTime drive the options, so a board with
-    a different set (dv6800n reports '1'/'2'/'3') is not measured against a
-    hardcoded tuple."""
+    """supportedDryLevel drives the options, so a board with a different set
+    (dv6800n reports '1'/'2'/'3') is not measured against a hardcoded tuple.
+
+    Read through the descriptor's own callable rather than off the rep: the
+    options are narrowed to the selected course (see the next test), so the
+    supported list is the input to that, not the answer.
+    """
     _reg, resources, bound, _unbound = _bind(DRYER)
     level = _desc(bound, "dry_level", SelectDesc)
-    assert level.options_field == "x.com.samsung.da.supportedDryLevel"
-    assert resources["/washer/vs/0"][level.options_field] == [
+    assert resources["/washer/vs/0"]["x.com.samsung.da.supportedDryLevel"] == [
         "None",
         "Damp",
         "Less",
         "Normal",
         "More",
     ]
+    assert set(level.options(resources)) <= set(
+        resources["/washer/vs/0"]["x.com.samsung.da.supportedDryLevel"]
+    )
     assert level.write_fn("More", {}) == (
         ["washer", "vs", "0"],
         {"x.com.samsung.da.dryLevel": "More"},
     )
+
+
+def test_dryer_dry_level_options_narrow_to_the_selected_course():
+    """This dump sits on Course_01 with a 0xD mask of [1, 2, 3, 4] over a
+    five-entry supportedDryLevel, so 'None' -- the one index the course does
+    not accept -- drops out of the dropdown instead of being offered and
+    then silently ignored by the appliance.
+
+    The live dryLevel ('Normal') is inside the mask here; the union that
+    guarantees it always survives is exercised in test_select_options.
+    """
+    _reg, resources, bound, _unbound = _bind(DRYER)
+    level = _desc(bound, "dry_level", SelectDesc)
+    assert level.options(resources) == ["Damp", "Less", "Normal", "More"]
+    assert resources["/washer/vs/0"]["x.com.samsung.da.dryLevel"] in level.options(resources)
 
 
 def test_dryer_dry_time_self_gates_on_supported_list():


### PR DESCRIPTION
#439 moved the dryer's `dryLevel` and `dryTime` from read-only sensors to writable selects, but landed the descriptor change on its own. This carries the three pieces from #407 that didn't come with it, and closes that PR out.

## The translation catalog

The descriptor kept the default translation key, so the select shipped with a name and no state table. `select._display` falls through to its raw-value branch, which means the dropdown renders a literal **"None"** instead of "Off", untranslated in all seven locales. Five of the seven dryer fixtures report that word vocabulary (`dve50a8600`, `dv80h`, `dryer`, `tp1_21_drum_clean`, `onebody_awm`).

`translation_key="dryer_dry_level"`, **not** `washer.py`'s `washer_dry_level` — that state table is this same field's *other* meaning on a combo, a duration in minutes (`"30"` → `"30 min"`), so reusing it would label a dryness dial in minutes. The numeric `None/1/2/3` that DV5000T (TP2_20) and DV6800N (A51_20) report is deliberately left uncatalogued, so the digits render raw rather than being guessed at — the same treatment unidentified course codes get. The now-unused `select.dry_level` name entry is dropped.

The catalog commit is @vmonkey's, carried across with their authorship.

## The superseded sensor rows

`unique_id`s are scoped by (integration, platform), so the move couldn't rewrite `sensor.<dryer>_dry_level` and `_dry_time` — they can only be dropped. Until now every upgraded dryer kept them as permanently-unavailable registry rows carrying the user's rename, area and any automation reference.

`_drop_sensors_superseded_by_selects` runs from `async_setup_entry`, before the platforms register, rather than as a numbered migration. The sweep is idempotent, so a version gate would buy only running it once — at the cost of a bump that fails the **whole entry** to load on a downgrade (`entry.version > 4`) instead of losing two entities. The log line is INFO, since the removal is irreversible, and it names the row it removed but *not* a `select.<object_id>` derived from it: a renamed sensor's object id isn't the one the new select gets, so that would be a guess.

## Narrowing options to the selected course

Uses the `supportedOptions` decode from #425. The board advertises every dry level it supports, but each course only accepts a subset, and a write outside that subset is silently ignored by the appliance — no error, no state change, nothing the user can see. Narrowing turns that no-op into a visible `ServiceValidationError`.

New `laundry.course_narrowed_options`, written as a factory so the washer's spin/rinse/temperature and the dryer's dry time can reuse it. Three rules:

- **Never blank the entity.** The result unions in the live value. `options` and `current_option` are computed independently, and HA's `SelectEntity.state` returns `None` when the current option isn't in the list, so a course change landing before the board updates `dryLevel` would otherwise read as `unknown`.
- **Never narrow to empty.** An empty `_raw_options()` is the "unpopulated" contract that pairs with `exists_fn` suppression, which this descriptor deliberately doesn't have — so empty means a live entity with an empty dropdown rather than no entity. No opinion from the decoder (`None`) falls back to the full supported list; a course that genuinely allows nothing falls back to just the live value.
- **The supported list sets the order**, not the mask, so the dropdown doesn't reshuffle as the course changes.

`0xD` is the right nibble here: all five dumps routing to this registry carry a `0xD` group, and the WW6600R combo — whose dry dial is `0xB` — routes to the washer registry instead.

On all five dryer fixtures the effect is the same and correct: **"None" leaves the dropdown**, since no course accepts it.

> [!IMPORTANT]
> An automation that was quietly no-opping on a level the running course refuses will now raise instead. That's the win, but it's a behaviour change users will notice.

## Also

The descriptor comment called the `dryLevel` write inferred from `washer.py`'s sibling contract. It was actually exercised end to end on a DV5000T (`DA_WM_TP2_20_COMMON`) through Home Assistant in #407; that board reports `isModelSettingWithoutSC` true, so the write lands with Smart Control off (see `common.remote_control_required_for_write`). Comment corrected — #438's ask on `dryLevel` can be considered answered. `dryTime`'s write is still the inferred one.

## Deliberate divergences from #407

- **`entity_category="config"` is kept**, matching `washer.py`'s `spin_level`/`rinse_cycles`. #407 argued for no category on the grounds that dry level is a per-load choice and that's where the sensor sat. Happy to flip it if you'd rather.
- **No entry-version bump**, per the review on #407: `VERSION` stays 4 and the sweep is unconditional.
- **`dry_time` narrowing is not included** — it's the next PR in the agreed sequence, alongside the washer's spin/rinse/temperature.

## Testing

- `tests/localthings/test_superseded_entities.py` — the sweep: both keys, subdevice-instanced tails, the replacement select and unrelated rows left alone, other entries left alone, idempotency, the log line not guessing a renamed replacement, and that it runs on setup.
- `TestDryLevelNarrowing` in `test_select_options.py` — one test per rule, plus the unpopulated-rep case and the ordering guarantee.
- `test_dry_level_presence_is_field_gated_not_narrowed_by_an_exists_fn` — ported from #407, and load-bearing here: the sweep removes the old sensor unconditionally, so a suppressed select would leave the user with neither entity.
- One #439 test updated: `test_dryer_dry_level_options_come_from_the_device` asserted `options_field`, which is now `None` since options come from a callable. It reads through the descriptor instead, with a companion test pinning the narrowing on the real DV80H dump.
- `pytest tests/ -q` → **1865 passed**. `ruff format --check`, `ruff check`, `ty check` all clean.

Closes #407. Refs #408, #425, #437, #438, #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc2HXzAFEKrfEnRf16Mtht

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jc2HXzAFEKrfEnRf16Mtht)_