### PR TITLE
Fix four idle-state reads on ovens: setpoint, cooking mode, cavity temperature, progress

### DIFF
--- a/custom_components/localthings/registry/capabilities/oven.py
+++ b/custom_components/localthings/registry/capabilities/oven.py
@@ -118,6 +118,29 @@ def _setpoint(desired):
     return None if v == 0 else v
 
 
+# Idle cavity value per unit: ranges floor `current` at Bake's tempMin (175 F
+# on every Fahrenheit range fixture, 80 C on the Celsius one), wall ovens
+# report 0. Neither is a measurement.
+_IDLE_FLOOR = {"°F": 175, "°C": 80}
+
+
+def _current_temp(rep):
+    """None while the oven is idle and `current` sits at or below the idle
+    floor. Both conditions matter: a cool-down after a cook (desired=0,
+    current above the floor) still reads, and a KeepWarm cook at exactly
+    175 F (desired=175) does too."""
+    items = rep.get("x.com.samsung.da.items") or []
+    if not items:
+        return None
+    current = _int(items[0].get("x.com.samsung.da.current"))
+    if current is None:
+        return None
+    idle = _setpoint(items[0].get("x.com.samsung.da.desired")) is None
+    if idle and current <= _IDLE_FLOOR.get(_oven_temp_unit(rep), 0):
+        return None
+    return current
+
+
 # ---------------------------------------------------------------------------
 # Options-array helpers (shared by lamp, sound, fastpreheat, naturalsteam)
 # ---------------------------------------------------------------------------
@@ -207,7 +230,15 @@ def _oven_mode_options(resources):
     fallback has to kick in when the device's own field is absent."""
     rep = resources.get("/mode/vs/0") or {}
     live = rep.get("x.com.samsung.da.supportedModes")
-    return list(live) if live else list(_OVEN_MODES)
+    if not live:
+        return list(_OVEN_MODES)
+    # Ranges (every range fixture, plus #404's) and the #277 wall oven idle
+    # in NoOperation but leave it out of supportedModes; HA's select drops a
+    # current option that isn't in the list, so the idle state showed as
+    # Unknown. Not selectable in practice: _oven_mode_write rejects it.
+    if "NoOperation" in live:
+        return list(live)
+    return ["NoOperation", *live]
 
 
 def _oven_mode_write(p, rep, href=None):
@@ -349,13 +380,10 @@ OVEN_SETPOINT = Capability(
         ),
         SensorDesc(
             key="current_temp_c",
-            field="x.com.samsung.da.items",
             device_class="temperature",
             state_class="measurement",
             unit_fn=_oven_temp_unit,
-            value_fn=lambda items: _int(
-                items[0].get("x.com.samsung.da.current") if items else None
-            ),
+            rep_fn=_current_temp,
         ),
     ),
 )

--- a/custom_components/localthings/registry/capabilities/oven.py
+++ b/custom_components/localthings/registry/capabilities/oven.py
@@ -288,12 +288,19 @@ OVEN_OPERATIONAL_STATE = Capability(
             device_class="running",
             value_fn=lambda v: _SAMSUNG_STATE_TO_OCF.get(v) == "active",
         ),
+        # Range firmware parks progressPercentage at 1 while Ready (every range
+        # fixture, the TP2X wall oven) and still reads 1 one second into a
+        # timed bake (#183's cook-started dump). Same not-active-means-0 rule
+        # as operational.py's shared sensor.
         SensorDesc(
             key="progress_percentage",
-            field="x.com.samsung.da.progressPercentage",
             unit="%",
             state_class="measurement",
-            value_fn=_int,
+            rep_fn=lambda rep: (
+                0
+                if _SAMSUNG_STATE_TO_OCF.get(rep.get("x.com.samsung.da.state")) != "active"
+                else _int(rep.get("x.com.samsung.da.progressPercentage"))
+            ),
         ),
         SensorDesc(
             key="operation_time_minutes",

--- a/custom_components/localthings/registry/capabilities/oven.py
+++ b/custom_components/localthings/registry/capabilities/oven.py
@@ -109,6 +109,15 @@ def _op_minutes(op_time):
         return None
 
 
+def _setpoint(desired):
+    """An idle oven reports desired='0' (NX60T8311SS/AA, #444), which HA
+    renders as -18 °C on a metric install once the unit is Fahrenheit. 0 is
+    below every SETPOINT_MIN_* bound, so it gets the same 0-means-unset
+    treatment as _finish_time above."""
+    v = _int(desired)
+    return None if v == 0 else v
+
+
 # ---------------------------------------------------------------------------
 # Options-array helpers (shared by lamp, sound, fastpreheat, naturalsteam)
 # ---------------------------------------------------------------------------
@@ -333,7 +342,7 @@ OVEN_SETPOINT = Capability(
             native_min_fn=lambda rep: float(_setpoint_bounds(rep)[0]),
             native_max_fn=lambda rep: float(_setpoint_bounds(rep)[1]),
             step_fn=lambda rep: float(_setpoint_bounds(rep)[2]),
-            value_fn=lambda items: _int(
+            value_fn=lambda items: _setpoint(
                 items[0].get("x.com.samsung.da.desired") if items else None
             ),
             write_fn=_oven_setpoint_write,

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -527,7 +527,13 @@
           "frozen_pizza_plus": "Mražená pizza+",
           "slow_cook": "Pomalé vaření",
           "plate_warm": "Ohřev talířů",
-          "air_fry": "Fritéza na vzduch"
+          "air_fry": "Fritéza na vzduch",
+          "convection_roast": "Pečení horkým vzduchem",
+          "keep_warm": "Udržování teploty",
+          "bread_proof": "Kynutí těsta",
+          "dehydrate": "Sušení",
+          "self_clean": "Samočištění",
+          "air_fryer": "Horkovzdušná fritéza"
         }
       },
       "operating_mode": {

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -527,7 +527,13 @@
           "frozen_pizza_plus": "Tiefkühlpizza+",
           "slow_cook": "Langsam garen",
           "plate_warm": "Tellerwärmen",
-          "air_fry": "Heißluftfritteuse"
+          "air_fry": "Heißluftfritteuse",
+          "convection_roast": "Umluftbraten",
+          "keep_warm": "Warmhalten",
+          "bread_proof": "Teig gehen lassen",
+          "dehydrate": "Dörren",
+          "self_clean": "Selbstreinigung",
+          "air_fryer": "Heißluftfritteuse"
         }
       },
       "operating_mode": {

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -527,7 +527,13 @@
           "frozen_pizza_plus": "Frozen Pizza+",
           "slow_cook": "Slow cook",
           "plate_warm": "Plate warm",
-          "air_fry": "Air fry"
+          "air_fry": "Air fry",
+          "convection_roast": "Convection roast",
+          "keep_warm": "Keep warm",
+          "bread_proof": "Bread proof",
+          "dehydrate": "Dehydrate",
+          "self_clean": "Self clean",
+          "air_fryer": "Air fry"
         }
       },
       "operating_mode": {

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -724,7 +724,13 @@
           "frozen_pizza_plus": "Pizza congelada+",
           "slow_cook": "Cocción lenta",
           "plate_warm": "Calentar platos",
-          "air_fry": "Freidora de aire"
+          "air_fry": "Freidora de aire",
+          "convection_roast": "Asar por convección",
+          "keep_warm": "Mantener caliente",
+          "bread_proof": "Fermentar masa",
+          "dehydrate": "Deshidratar",
+          "self_clean": "Autolimpieza",
+          "air_fryer": "Freidora de aire"
         }
       },
       "operating_mode": {

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -527,7 +527,13 @@
           "frozen_pizza_plus": "Frozen Pizza+",
           "slow_cook": "Cottura lenta",
           "plate_warm": "Scalda piatti",
-          "air_fry": "Frittura ad aria"
+          "air_fry": "Frittura ad aria",
+          "convection_roast": "Arrosto ventilato",
+          "keep_warm": "Mantieni in caldo",
+          "bread_proof": "Lievitazione",
+          "dehydrate": "Essiccazione",
+          "self_clean": "Autopulizia",
+          "air_fryer": "Friggitrice ad aria"
         }
       },
       "operating_mode": {

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -527,7 +527,13 @@
           "frozen_pizza_plus": "냉동 피자+",
           "slow_cook": "저온 조리",
           "plate_warm": "접시 데우기",
-          "air_fry": "에어프라이"
+          "air_fry": "에어프라이",
+          "convection_roast": "컨벡션 로스트",
+          "keep_warm": "보온",
+          "bread_proof": "발효",
+          "dehydrate": "건조",
+          "self_clean": "자동 세척",
+          "air_fryer": "에어프라이"
         }
       },
       "operating_mode": {

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -527,7 +527,13 @@
           "frozen_pizza_plus": "Frozen Pizza+",
           "slow_cook": "Langzaam garen",
           "plate_warm": "Borden warmhouden",
-          "air_fry": "Airfryen"
+          "air_fry": "Airfryen",
+          "convection_roast": "Heteluchtbraden",
+          "keep_warm": "Warmhouden",
+          "bread_proof": "Deeg rijzen",
+          "dehydrate": "Drogen",
+          "self_clean": "Zelfreiniging",
+          "air_fryer": "Airfryer"
         }
       },
       "operating_mode": {

--- a/tests/test_oven_capabilities.py
+++ b/tests/test_oven_capabilities.py
@@ -397,3 +397,23 @@ def test_current_temp_blanks_idle_floor_only(desired, current, unit, expected):
 def test_current_temp_none_without_items():
     assert _current_temp_desc().rep_fn({}) is None
     assert _current_temp_desc().rep_fn({"x.com.samsung.da.items": []}) is None
+
+
+def _progress_desc():
+    return next(e for e in oven.OVEN_OPERATIONAL_STATE.entities if e.key == "progress_percentage")
+
+
+@pytest.mark.parametrize(
+    ("state", "raw", "expected"),
+    [
+        ("Ready", "1", 0),  # idle floor on every range fixture
+        ("Ready", "0", 0),
+        ("Run", "1", 1),  # one second into a timed bake (#183)
+        ("Run", "57", 57),
+        ("Running", "100", 100),
+        ("Run", None, None),
+    ],
+)
+def test_progress_percentage_reads_zero_unless_active(state, raw, expected):
+    rep = {"x.com.samsung.da.state": state, "x.com.samsung.da.progressPercentage": raw}
+    assert _progress_desc().rep_fn(rep) == expected

--- a/tests/test_oven_capabilities.py
+++ b/tests/test_oven_capabilities.py
@@ -1,5 +1,7 @@
 """Unit tests for oven-family capabilities."""
 
+import pytest
+
 from custom_components.localthings.registry.by_type import for_device_by_model
 from custom_components.localthings.registry.capabilities import oven
 from custom_components.localthings.registry.discovery import discover
@@ -186,15 +188,36 @@ def test_oven_mode_options_falls_back_when_no_live_supported_modes():
 
 
 def test_oven_mode_options_reads_live_supported_modes():
-    """issue #138: the device's own supportedModes list is used verbatim
-    when present, instead of the static _OVEN_MODES guess."""
+    """issue #138: the device's own supportedModes list is used when
+    present, instead of the static _OVEN_MODES guess (plus the idle token,
+    see the next test)."""
     desc = _oven_mode_desc()
     resources = {
         "/mode/vs/0": {
             "x.com.samsung.da.supportedModes": ["Bake", "AirFryer", "SelfClean"],
         }
     }
-    assert desc.options(resources) == ["Bake", "AirFryer", "SelfClean"]
+    assert desc.options(resources) == ["NoOperation", "Bake", "AirFryer", "SelfClean"]
+
+
+def test_oven_mode_options_prepends_idle_token_when_live_list_omits_it():
+    """Ranges idle in NoOperation but leave it out of supportedModes
+    (NX60T8311SS, every range fixture); HA's select renders a current
+    option missing from the list as Unknown."""
+    desc = _oven_mode_desc()
+    resources = {
+        "/mode/vs/0": {
+            "x.com.samsung.da.supportedModes": ["Bake", "Broil", "KeepWarm"],
+            "x.com.samsung.da.modes": ["NoOperation"],
+        }
+    }
+    assert desc.options(resources) == ["NoOperation", "Bake", "Broil", "KeepWarm"]
+
+
+def test_oven_mode_options_does_not_duplicate_idle_token():
+    desc = _oven_mode_desc()
+    resources = {"/mode/vs/0": {"x.com.samsung.da.supportedModes": ["NoOperation", "Bake"]}}
+    assert desc.options(resources) == ["NoOperation", "Bake"]
 
 
 def test_oven_mode_write_round_trips():
@@ -336,3 +359,41 @@ def test_cook_time_rejects_out_of_range():
     assert desc.write_fn is not None
     assert desc.write_fn(-1, {}) is None
     assert desc.write_fn(1440, {}) is None
+
+
+def _current_temp_desc():
+    return next(e for e in oven.OVEN_SETPOINT.entities if e.key == "current_temp_c")
+
+
+def _temps(desired, current, unit):
+    return {
+        "x.com.samsung.da.items": [
+            {
+                "x.com.samsung.da.desired": desired,
+                "x.com.samsung.da.current": current,
+                "x.com.samsung.da.unit": unit,
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    ("desired", "current", "unit", "expected"),
+    [
+        ("0", "175", "Fahrenheit", None),  # idle range, floored at Bake's tempMinF (#444)
+        ("0", "80", "Celsius", None),  # idle Celsius range, floored at tempMinC
+        ("0", "0", "Fahrenheit", None),  # idle wall oven (#300, #277)
+        ("0", "0", "Celsius", None),
+        ("0", "300", "Fahrenheit", 300),  # cooling down after a cook: real reading
+        ("175", "175", "Fahrenheit", 175),  # KeepWarm at exactly the floor
+        ("350", "175", "Fahrenheit", 175),  # preheat from cold shows the floor, like the panel
+        ("350", "212", "Fahrenheit", 212),
+    ],
+)
+def test_current_temp_blanks_idle_floor_only(desired, current, unit, expected):
+    assert _current_temp_desc().rep_fn(_temps(desired, current, unit)) == expected
+
+
+def test_current_temp_none_without_items():
+    assert _current_temp_desc().rep_fn({}) is None
+    assert _current_temp_desc().rep_fn({"x.com.samsung.da.items": []}) is None

--- a/tests/test_oven_capabilities.py
+++ b/tests/test_oven_capabilities.py
@@ -157,6 +157,14 @@ def test_oven_setpoint_native_bounds_track_live_unit():
     assert desc.step_fn(fahrenheit_rep) == 5.0
 
 
+def test_oven_setpoint_idle_zero_reads_as_unknown():
+    """desired='0' is the idle sentinel (NX60T8311SS/AA, #444). Read as
+    0 °F it lands the number entity at -18 °C on a metric install."""
+    desc = _oven_setpoint_desc()
+    assert desc.value_fn(_fahrenheit_rep("0")["x.com.samsung.da.items"]) is None
+    assert desc.value_fn(_fahrenheit_rep("350")["x.com.samsung.da.items"]) == 350
+
+
 # ---------------------------------------------------------------------------
 # OVEN_MODE — SelectDesc with non-empty options
 # ---------------------------------------------------------------------------

--- a/tests/test_range_ne63a6511_capabilities.py
+++ b/tests/test_range_ne63a6511_capabilities.py
@@ -70,7 +70,7 @@ def test_oven_mode_accepts_this_devices_supported_modes():
     desc = cast(SelectDesc, oven.OVEN_MODE.entities[0])
     assert desc.options is not None
     assert desc.write_fn is not None
-    assert desc.options(resources) == live_rep["x.com.samsung.da.supportedModes"]
+    assert desc.options(resources) == ["NoOperation", *live_rep["x.com.samsung.da.supportedModes"]]
     for mode in (
         "ConvectionRoast",
         "KeepWarm",


### PR DESCRIPTION
Fixes #444.

Four idle-state reads on ovens, all from the same "the oven is off" condition. Three commits.

### 1. `oven_setpoint` reads 0 (-18 °C on a metric install)

While the oven is off, the board reports `desired: "0"` on `/temperatures/vs/0`. That's a placeholder for "no setpoint": it's below both minimums in `oven.py` (30 °C, 175 °F), so nothing you can dial in produces it. `oven_setpoint` passed it through as a real value; on a Fahrenheit board HA converts 0 °F for a metric install and the number entity sat at -18 °C. Every range and oven fixture in `tests/` has the same idle `desired: "0"`.

A new `_setpoint()` helper returns `None` when `desired` is `0`. Same treatment `_finish_time` already gives a zero `remainingTime`.

### 2. `oven_mode` shows Unknown while idle

`/mode/vs/0` reports `modes: ["NoOperation"]` when idle but leaves `NoOperation` out of `supportedModes`. The select's option list is that live list, and HA's `SelectEntity.state` returns `None` for a current option that isn't in `options`, so the idle state rendered as Unknown even though the catalog already has `no_operation`. Same shape on every range fixture, #404's range and #277's wall oven; the wall-oven and microwave fixtures include the token, which is why it works there.

`_oven_mode_options()` now prepends `NoOperation` when the live list lacks it. `_oven_mode_write()` still validates against `supportedModes`, so it's display-only. This is the oven case that `learned.py` deliberately keeps its allowlist away from (#327), so the fix lives in the option builder instead.

### 3. `current_temp_c` reads 175 °F while idle

Range firmware floors `current` at Bake's `tempMin` while idle: `175` on every Fahrenheit range fixture and mine, `80` on the Celsius one, matching each unit's `modeSpec`. Wall ovens (#300, #277) report `0`. The sensor forwarded both as measurements, so the history graph is a flat line at 175 with a spike per cook, and with `state_class: measurement` that goes into long-term statistics.

`_current_temp()` returns `None` only when there's no active setpoint **and** `current` is at or below the idle floor for the unit. Both conditions matter, per the #160 rule against broad sentinel collapses: a cool-down after a cook (desired 0, current above the floor) still reads, and a KeepWarm cook at exactly 175 °F (desired 175) does too. Preheat from cold shows the floor, same as the panel.

Also catalogs the six range modes that were falling through to the PascalCase fallback (`ConvectionRoast`, `KeepWarm`, `BreadProof`, `Dehydrate`, `SelfClean`, `AirFryer`), in all seven languages.

### 4. `progress_percentage` reads 1 % while idle

`/operational/state/vs/0` reports `progressPercentage: "1"` with `state: Ready` on every range fixture and the TP2X wall oven (the NV7000BS oven and the microwaves idle at 0). #183's cook-started dump still reads `1` one second into a 30-minute timed bake, so the number only means anything once a cycle is under way. `operational.py`'s shared sensor already returns 0 whenever the state isn't active; `oven.py` had its own copy passing the raw value through. Same rule applied here, firmware's number passed through while active.

### Proof

Two diagnostics dumps from my NX60T8311SS/AA (idle, and idle oven with a burner lit) through `resolve → discover → flatten`, main vs branch:

```
                     main                              branch
oven_setpoint        0                                 None
oven_mode            NoOperation                       NoOperation
oven_mode options    [Bake, Broil, ... SelfClean]      [NoOperation, Bake, Broil, ... SelfClean]
current_temp_c       175                               None
progress_percentage  1                                 0
```

Nothing else in the flattened state changes. `ruff format --check`, `ruff check`, `ty check`, and `pytest tests/ -q` as in `validate.yml`: 1886 passed, all clean. Golden fixtures compare keys only and `flatten()` keeps a `None`-valued key, so no regeneration needed.
