### PR TITLE
Record the OCF device UUID separately from the registry key

### DIFF
--- a/custom_components/localthings/config_flow.py
+++ b/custom_components/localthings/config_flow.py
@@ -51,6 +51,7 @@ from .const import (
     CONF_LEARN_MODES,
     CONF_MANUFACTURER,
     CONF_MODEL,
+    CONF_OCF_DEVICE_ID,
     CONF_PORT,
     CONF_SERIAL,
     DEFAULT_CLOUD_COURSES_ENABLED,
@@ -664,6 +665,7 @@ def _read_device(sess, host: str, port: int) -> dict:
     from .registry.batch import parse_device0_batch
     from .registry.by_type import resolve as resolve_registry
     from .registry.identity import (
+        proven_ocf_device_id,
         read_identity,
         resolve_device_key,
         resolve_model,
@@ -698,6 +700,10 @@ def _read_device(sess, host: str, port: int) -> dict:
         # change of key against it (issue #381). read_identity has already
         # fetched /oic/p and /oic/d above, so this costs no extra round trip.
         "device_key": resolve_device_key(identity, raw_serial, host),
+        # The `di` this handshake actually proved, kept beside `device_key`
+        # rather than folded into it -- see const.CONF_OCF_DEVICE_ID. None
+        # when the device reported no usable one.
+        "ocf_device_id": proven_ocf_device_id(identity),
         "serial": resolve_serial(raw_serial, host),
         "model": resolve_model(info.get("x.com.samsung.da.modelNum", ""), identity),
         "manufacturer": identity.manufacturer or "Samsung",
@@ -849,6 +855,11 @@ class LocalThingsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_LEAF_CERT_PEM: info["leaf_cert_pem"],
                 CONF_LEAF_KEY_PEM: info["leaf_key_pem"],
                 CONF_DEVICE_KEY: info["device_key"],
+                **(
+                    {CONF_OCF_DEVICE_ID: info["ocf_device_id"]}
+                    if info["ocf_device_id"] is not None
+                    else {}
+                ),
                 CONF_SERIAL: info["serial"],
                 CONF_MODEL: info["model"],
                 CONF_MANUFACTURER: info["manufacturer"],

--- a/custom_components/localthings/const.py
+++ b/custom_components/localthings/const.py
@@ -35,6 +35,14 @@ CONF_SERIAL = "serial"
 # key to re-key from, and as what corroborates a later change of UUID.
 # Absent until the first live poll, since only the device can report it.
 CONF_DEVICE_KEY = "device_key"
+# The OCF device UUID this appliance actually proved over an authenticated
+# session -- /oic/d's `di` and nothing else. Deliberately separate from
+# CONF_DEVICE_KEY: that is a registry key resolved through a fallback chain
+# (`di` -> /oic/p's `pi` -> serialNum -> host), so it is not proof of the OCF
+# identity and can hold a platform UUID, a serial, or an address. Absent
+# until a live authenticated read reports a usable `di`, and never used to
+# key devices or entities.
+CONF_OCF_DEVICE_ID = "ocf_device_id"
 CONF_MODEL = "model"
 CONF_MANUFACTURER = "manufacturer"
 CONF_DEVICE_TYPE = "device_type"

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -1585,15 +1585,25 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # writing a key here would freeze a pre-v4 entry's legacy key in as
         # if a poll had confirmed it, and the real UUID would later look
         # like an identity to defend against rather than one to adopt.
+        #
+        # The proven `di` gets the same None for the same reason, and one
+        # more: only when this entry actually *is* the device that answered.
+        # `_resolve_identity` returns the registered key unchanged when an
+        # uncorroborated appliance answers at this address ("keeping the
+        # registered identity"), and it withholds that appliance's serial
+        # for exactly this reason -- recording its `di` instead would hand
+        # the intruder the very field issue #435's credential binding is
+        # meant to catch it with. When a poll does report a usable `di`
+        # that is the whole of `_resolve_identity`'s answer, so key equality
+        # is precisely "this entry adopted what just answered".
+        proven = None if from_snapshot else proven_ocf_device_id(ident)
         self._persist_identity(
             None if from_snapshot else key,
             serial,
             model,
             mfr,
             device_type_name,
-            # Same reason as the key above: a snapshot replay never reached
-            # the device, so it has proved nothing about which one answered.
-            None if from_snapshot else proven_ocf_device_id(ident),
+            proven if proven == key else None,
         )
         if not from_snapshot:
             # A coverage gap is a claim about what the device reports, so only

--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -40,6 +40,7 @@ from .const import (
     CONF_LEARNED_MODES,
     CONF_MANUFACTURER,
     CONF_MODEL,
+    CONF_OCF_DEVICE_ID,
     CONF_PORT,
     CONF_SERIAL,
     DEFAULT_CLOUD_COURSES_ENABLED,
@@ -70,6 +71,7 @@ from .registry.identity import (
     DeviceIdentity,
     device_display_name,
     ocf_device_key,
+    proven_ocf_device_id,
     read_identity,
     resolve_model,
     resolve_serial,
@@ -1287,6 +1289,7 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         model: str,
         manufacturer: str,
         device_type_name: str | None,
+        ocf_device_id: str | None = None,
     ) -> None:
         """Write this device's resolved identity back onto the config entry.
 
@@ -1303,10 +1306,19 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         None leaves whatever key is already stored untouched -- see the
         caller for why a snapshot replay must not write one.
 
+        `ocf_device_id` is the `di` this poll actually proved, recorded
+        beside the key rather than folded into it (const.CONF_OCF_DEVICE_ID).
+        None leaves the stored value alone, so one read that fails to report
+        a usable `di` doesn't erase what an earlier authenticated read
+        established. Nothing acts on a change here yet -- what a *different*
+        `di` means is the credential profiles' decision (issue #435); this
+        only has to have recorded the value by the time they land.
+
         Runs on the event loop, which async_update_entry requires.
         """
         identity = {
             **({CONF_DEVICE_KEY: device_key} if device_key is not None else {}),
+            **({CONF_OCF_DEVICE_ID: ocf_device_id} if ocf_device_id is not None else {}),
             CONF_SERIAL: serial,
             CONF_MODEL: model,
             CONF_MANUFACTURER: manufacturer,
@@ -1573,7 +1585,16 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # writing a key here would freeze a pre-v4 entry's legacy key in as
         # if a poll had confirmed it, and the real UUID would later look
         # like an identity to defend against rather than one to adopt.
-        self._persist_identity(None if from_snapshot else key, serial, model, mfr, device_type_name)
+        self._persist_identity(
+            None if from_snapshot else key,
+            serial,
+            model,
+            mfr,
+            device_type_name,
+            # Same reason as the key above: a snapshot replay never reached
+            # the device, so it has proved nothing about which one answered.
+            None if from_snapshot else proven_ocf_device_id(ident),
+        )
         if not from_snapshot:
             # A coverage gap is a claim about what the device reports, so only
             # a live poll gets to make it. Replaying a snapshot would restate

--- a/custom_components/localthings/diagnostics.py
+++ b/custom_components/localthings/diagnostics.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.loader import async_get_integration
 
 from . import cloudcourse
-from .const import DOMAIN
+from .const import CONF_OCF_DEVICE_ID, DOMAIN
 from .coordinator import LocalThingsCoordinator
 from .registry.capabilities.laundry import cycle_options
 from .registry.encode import json_safe
@@ -82,6 +82,11 @@ async def async_get_config_entry_diagnostics(
             "device_type": coordinator.device_type_name or "unknown",
             "one_ui_version": coordinator.one_ui_version,
             "identity": {
+                # The `di` an authenticated read proved, as stored on the
+                # entry -- absent until one has. `di`/`pi` are deliberately
+                # not redacted (see registry/redact.py), so this adds no
+                # identifier the resource dump below doesn't already carry.
+                "ocf_device_id": entry.data.get(CONF_OCF_DEVICE_ID),
                 "manufacturer": identity.manufacturer,
                 "model": identity.model,
                 "device_types": list(identity.device_types),

--- a/custom_components/localthings/registry/identity.py
+++ b/custom_components/localthings/registry/identity.py
@@ -99,6 +99,24 @@ def ocf_device_key(identity: DeviceIdentity | None) -> str | None:
     return None
 
 
+def proven_ocf_device_id(identity: DeviceIdentity | None) -> str | None:
+    """/oic/d's `di` alone, when the device reported a usable one.
+
+    Deliberately not `ocf_device_key`'s chain: that falls back to /oic/p's
+    `pi`, which is platform-scoped and shared by every logical device on one
+    board, and then to the serial and the host. Those are fine for minting a
+    stable registry key but none of them is the OCF device identity, so
+    anything checking *which device answered* needs this narrower answer.
+    Normalized the same way, so the two are comparable when they do agree.
+    """
+    if identity is None:
+        return None
+    device_id = identity.device_id
+    if device_id is None or not is_usable_device_id(device_id):
+        return None
+    return device_id.strip().lower()
+
+
 def resolve_device_key(identity: DeviceIdentity | None, raw_serial: str | None, host: str) -> str:
     """The identity to mint this device's permanent registry keys from.
 

--- a/tests/localthings/conftest.py
+++ b/tests/localthings/conftest.py
@@ -168,6 +168,10 @@ def _probe_result(*, recognized: bool) -> dict:
     return {
         "port": MOCK_PORT,
         "device_key": MOCK_DEVICE_KEY,
+        # A device that reports a usable `di` resolves both from it, so the
+        # realistic fake has them agree; the cases where they diverge get
+        # their own tests.
+        "ocf_device_id": MOCK_DEVICE_KEY,
         "serial": MOCK_SERIAL,
         "model": MOCK_MODEL,
         "manufacturer": "Samsung",

--- a/tests/localthings/test_ocf_device_id.py
+++ b/tests/localthings/test_ocf_device_id.py
@@ -1,0 +1,248 @@
+"""Recording the OCF device UUID an authenticated read actually proved.
+
+`CONF_DEVICE_KEY` is a registry key, resolved through a fallback chain
+(`/oic/d`'s `di` -> `/oic/p`'s `pi` -> serialNum -> host), so it is not proof
+of the OCF identity: on the boards that fall past the first branch it holds a
+platform UUID shared by every logical device on one board, a vendor serial,
+or an address. Anything that needs to know *which device answered* -- the
+credential profiles in issue #435 -- needs the narrower value, so it is
+stored separately.
+
+Store-only for now. What a *changed* `di` should mean is the profiles'
+decision; these tests fix the recording so that decision arrives with real
+values already on entries.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.localthings.const import (
+    CONF_DEVICE_KEY,
+    CONF_HOST,
+    CONF_OCF_DEVICE_ID,
+    CONF_SERIAL,
+    DOMAIN,
+)
+from custom_components.localthings.registry.identity import (
+    DeviceIdentity,
+    ocf_device_key,
+    proven_ocf_device_id,
+)
+
+from .conftest import LEGACY_ENTRY_DATA, MOCK_HOST, MOCK_SERIAL
+from .test_identity_migration import UUID_A, UUID_B, _reachable, _unreachable
+
+_COORD = "custom_components.localthings.coordinator.LocalThingsCoordinator"
+# OCF's nil UUID: firmware that never had one assigned reports it on every
+# unit of the family, so it identifies nothing (issue #189).
+NIL_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def _identity(*, device_id: str | None = None, platform_id: str | None = None) -> DeviceIdentity:
+    return DeviceIdentity(
+        manufacturer="Samsung Electronics",
+        model="AVT-WW-TP1-23-AXX500",
+        name="Samsung AirPurifier",
+        serial=None,
+        device_id=device_id,
+        platform_id=platform_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The helper: `di` only, never the rest of the key's chain
+# ---------------------------------------------------------------------------
+
+
+def test_reports_the_device_uuid_normalized() -> None:
+    """Firmware that changes case between reads must not look like a
+    different appliance -- same normalization the key already applies."""
+    assert proven_ocf_device_id(_identity(device_id=UUID_A.upper())) == UUID_A
+
+
+def test_does_not_fall_back_to_the_platform_uuid() -> None:
+    """The load-bearing difference from `ocf_device_key`.
+
+    `pi` is platform-scoped and shared by every logical device on one board,
+    so it is a fine last resort for a stable registry key and no answer at
+    all to "which device answered". A board reporting only `pi` must record
+    no proven device id rather than record its platform's.
+    """
+    identity = _identity(platform_id=UUID_B)
+
+    assert ocf_device_key(identity) == UUID_B
+    assert proven_ocf_device_id(identity) is None
+
+
+def test_rejects_the_nil_uuid() -> None:
+    assert proven_ocf_device_id(_identity(device_id=NIL_UUID)) is None
+
+
+def test_rejects_a_known_junk_identity_field() -> None:
+    """A board flashed with 'Nothing(SVC)' in one identity field (issue #83)
+    is not one to trust in another."""
+    assert proven_ocf_device_id(_identity(device_id="Nothing(SVC)")) is None
+
+
+def test_no_identity_at_all_is_not_an_answer() -> None:
+    assert proven_ocf_device_id(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Where it gets written
+# ---------------------------------------------------------------------------
+
+
+async def test_the_config_flow_records_it_when_the_probe_proved_one(
+    hass: HomeAssistant, mock_probe, mock_coordinator_session
+) -> None:
+    """The probe already reads /oic/d, so a new entry starts with the value
+    rather than waiting for its first poll to backfill it."""
+    from custom_components.localthings.const import CONF_CA_CERT_PEM, CONF_CA_KEY_PEM
+
+    from .conftest import MOCK_CA_CERT_PEM, MOCK_CA_KEY_PEM, MOCK_DEVICE_KEY
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: MOCK_HOST,
+            CONF_CA_CERT_PEM: MOCK_CA_CERT_PEM,
+            CONF_CA_KEY_PEM: MOCK_CA_KEY_PEM,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["data"][CONF_OCF_DEVICE_ID] == MOCK_DEVICE_KEY
+
+
+async def test_a_probe_that_proved_nothing_leaves_the_key_absent(
+    hass: HomeAssistant, mock_coordinator_session
+) -> None:
+    """A board answering with no usable `di` still gets a registry key from
+    further down the chain, but records no proven device id -- absent is the
+    honest state, not a placeholder."""
+    from custom_components.localthings.const import CONF_CA_CERT_PEM, CONF_CA_KEY_PEM
+
+    from .conftest import MOCK_CA_CERT_PEM, MOCK_CA_KEY_PEM, _probe_result
+
+    unproven = {**_probe_result(recognized=True), "ocf_device_id": None}
+    with patch(
+        "custom_components.localthings.config_flow._probe_and_validate",
+        return_value=unproven,
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_CA_CERT_PEM: MOCK_CA_CERT_PEM,
+                CONF_CA_KEY_PEM: MOCK_CA_KEY_PEM,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert CONF_DEVICE_KEY in result["data"]
+    assert CONF_OCF_DEVICE_ID not in result["data"]
+
+
+def _entry_without_it(hass: HomeAssistant, **extra) -> MockConfigEntry:
+    """An entry from before this field existed: keyed, but with nothing
+    recorded about what the device proved."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **LEGACY_ENTRY_DATA,
+            CONF_HOST: MOCK_HOST,
+            CONF_SERIAL: MOCK_SERIAL,
+            CONF_DEVICE_KEY: UUID_A,
+            **extra,
+        },
+        unique_id=f"{DOMAIN}_{UUID_A}",
+        version=4,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_an_existing_entry_backfills_it_on_the_first_poll(
+    hass: HomeAssistant, fridge_resources
+) -> None:
+    """No migration writes this -- only the device can report it, and an
+    entry can load entirely from its snapshot while the appliance is off
+    (issue #295). The first authenticated read is where it lands."""
+    entry = _entry_without_it(hass)
+
+    with _reachable(fridge_resources, UUID_A):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.data[CONF_OCF_DEVICE_ID] == UUID_A
+
+
+async def test_a_poll_reporting_no_usable_uuid_does_not_erase_a_stored_one(
+    hass: HomeAssistant, fridge_resources
+) -> None:
+    """One read that comes back without a usable `di` is a gap in this
+    poll's evidence, not a retraction of what an earlier authenticated read
+    established."""
+    entry = _entry_without_it(hass, **{CONF_OCF_DEVICE_ID: UUID_A})
+
+    with _reachable(fridge_resources, None):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.data[CONF_OCF_DEVICE_ID] == UUID_A
+
+
+async def test_a_snapshot_replay_proves_nothing_and_writes_nothing(
+    hass: HomeAssistant, fridge_resources, hass_storage
+) -> None:
+    """Replaying a stored snapshot never reached the device, so it has no
+    standing to say which one answered -- the same reason it must not write
+    a device key (issue #295).
+
+    The snapshot restores `_identity`, `di` included, so a value is sitting
+    right there for an unguarded replay to write as though a live read had
+    proved it. Clearing the field after banking the snapshot is what makes
+    the guard, rather than the leftover value, the thing under test.
+    """
+    entry = _entry_without_it(hass)
+
+    with _reachable(fridge_resources, UUID_A):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert entry.data[CONF_OCF_DEVICE_ID] == UUID_A
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    hass.config_entries.async_update_entry(
+        entry, data={k: v for k, v in entry.data.items() if k != CONF_OCF_DEVICE_ID}
+    )
+
+    with _unreachable():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert CONF_OCF_DEVICE_ID not in entry.data
+
+
+async def test_it_is_recorded_without_being_used_as_the_registry_key(
+    hass: HomeAssistant, fridge_resources
+) -> None:
+    """Store-only: recording what the device proved must not disturb the key
+    the user's entities and history already hang off."""
+    entry = _entry_without_it(hass)
+
+    with _reachable(fridge_resources, UUID_A):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    assert entry.data[CONF_DEVICE_KEY] == UUID_A
+    assert coordinator.device_key == UUID_A
+    assert entry.unique_id == f"{DOMAIN}_{UUID_A}"

--- a/tests/localthings/test_ocf_device_id.py
+++ b/tests/localthings/test_ocf_device_id.py
@@ -199,6 +199,33 @@ async def test_a_poll_reporting_no_usable_uuid_does_not_erase_a_stored_one(
     assert entry.data[CONF_OCF_DEVICE_ID] == UUID_A
 
 
+async def test_an_uncorroborated_appliance_does_not_get_its_di_recorded(
+    hass: HomeAssistant, fridge_resources
+) -> None:
+    """A different appliance answering at this address proves which device
+    *it* is, not which device this entry is.
+
+    `_resolve_identity` already refuses to re-key here, and deliberately
+    withholds the intruder's serial too -- writing it would hand over the
+    corroboration needed to win the next poll. The proven `di` has to be
+    withheld on the same terms: it is the field issue #435's credential
+    binding compares an authenticated session against, so recording an
+    unadopted appliance's UUID would turn the mismatch it exists to catch
+    into a match.
+    """
+    entry = _entry_without_it(
+        hass,
+        **{CONF_SERIAL: "SOME-OTHER-APPLIANCE", CONF_OCF_DEVICE_ID: UUID_A},
+    )
+
+    with _reachable(fridge_resources, UUID_B):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.data[CONF_DEVICE_KEY] == UUID_A
+    assert entry.data[CONF_OCF_DEVICE_ID] == UUID_A
+
+
 async def test_a_snapshot_replay_proves_nothing_and_writes_nothing(
     hass: HomeAssistant, fridge_resources, hass_storage
 ) -> None:


### PR DESCRIPTION
CONF_DEVICE_KEY is what devices and entities are keyed on, resolved
through a fallback chain -- /oic/d's `di`, then /oic/p's `pi`, then the
serialNum, then the host. Three of those four branches exist because
firmware families have shipped unusable identity fields (#83, #189,
#381), and none of them below the first is proof of the OCF identity:
`pi` is platform-scoped and shared by every logical device on one board,
and a serial or an address identifies nothing about which OCF device
answered.

Nothing needs that distinction today. The credential profiles in #435 do:
binding a PSK session to the device it was issued for means comparing an
authenticated /oic/d.di against a stored one, and comparing it against a
platform UUID or a serial instead produces a device-mismatch failure on a
correctly configured appliance.

So record what an authenticated read actually proved, in its own field,
and leave the key alone. `proven_ocf_device_id` is deliberately narrower
than `ocf_device_key`: `di` or nothing, no fallback. The config flow's
probe already reads /oic/d, so a new entry starts with the value; an
existing entry backfills on its first live poll. A read that reports no
usable `di` leaves a stored value alone rather than erasing it, and a
snapshot replay writes nothing at all -- it never reached the device, the
same reason it must not write a key (#295).

No config-entry migration: absent is a legitimate state for an entry that
has never polled, so this backfills rather than migrates.

Store-only. What a *changed* di means is the profiles' decision; this
only has to have recorded the value by the time they land.