### PR TITLE
Add a water-filter reset button

### DIFF
--- a/custom_components/localthings/registry/capabilities/common.py
+++ b/custom_components/localthings/registry/capabilities/common.py
@@ -618,6 +618,23 @@ WATER_FILTER = Capability(
             options=("normal", "wash", "replace"),
             value_fn=lambda value: value.lower() if isinstance(value, str) else value,
         ),
+        # filterReset 'On' (case-sensitive), measured on a TP1X_REF_21K:
+        # filterUsage 100 -> 0, filterStatus replace -> normal. A trigger the
+        # board never reports back, so it's gated on filterResetType -- the
+        # device's own claim that it supports a reset -- rather than on
+        # itself. See docs/investigations/fridge-water-filter-reset.md.
+        ButtonDesc(
+            key="filter_reset",
+            field="",
+            payload="On",
+            icon="mdi:restart",
+            entity_category="config",
+            exists_fn=lambda rep, resources: "x.com.samsung.da.filterResetType" in rep,
+            write_fn=lambda p, rep, href=None: (
+                ["filter", "waterfilter", "vs", "0"],
+                {"x.com.samsung.da.filterReset": p},
+            ),
+        ),
     ),
 )
 

--- a/custom_components/localthings/registry/capabilities/common.py
+++ b/custom_components/localthings/registry/capabilities/common.py
@@ -619,17 +619,28 @@ WATER_FILTER = Capability(
             value_fn=lambda value: value.lower() if isinstance(value, str) else value,
         ),
         # filterReset 'On' (case-sensitive), measured on a TP1X_REF_21K:
-        # filterUsage 100 -> 0, filterStatus replace -> normal. A trigger the
-        # board never reports back, so it's gated on filterResetType -- the
-        # device's own claim that it supports a reset -- rather than on
-        # itself. See docs/investigations/fridge-water-filter-reset.md.
+        # filterUsage 100 -> 0, filterStatus replace -> normal. A trigger this
+        # board never reports back, so it can't be gated on itself -- see
+        # docs/investigations/fridge-water-filter-reset.md.
+        #
+        # Gated on filterResetType naming a reset this device says it
+        # supports: the corpus also carries ['notresetable'], which a bare
+        # presence check would read as a yes. is_stub_rep keeps the stub
+        # carve-out an explicit exists_fn would otherwise bypass (same
+        # reasoning as ENERGY_METER above).
         ButtonDesc(
             key="filter_reset",
             field="",
             payload="On",
             icon="mdi:restart",
             entity_category="config",
-            exists_fn=lambda rep, resources: "x.com.samsung.da.filterResetType" in rep,
+            exists_fn=lambda rep, resources: (
+                is_stub_rep(rep)
+                or bool(
+                    {"replaceable", "washable"}
+                    & set(rep.get("x.com.samsung.da.filterResetType") or ())
+                )
+            ),
             write_fn=lambda p, rep, href=None: (
                 ["filter", "waterfilter", "vs", "0"],
                 {"x.com.samsung.da.filterReset": p},

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -129,6 +129,9 @@
       "auto_clean_stop": {
         "name": "Zastavit samočištění"
       },
+      "filter_reset": {
+        "name": "Resetovat vodní filtr"
+      },
       "filter_time_reset": {
         "name": "Vynulovat počítadlo filtru"
       },

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -129,6 +129,9 @@
       "auto_clean_stop": {
         "name": "Automatische Reinigung stoppen"
       },
+      "filter_reset": {
+        "name": "Wasserfilter zurücksetzen"
+      },
       "filter_time_reset": {
         "name": "Filterzeit zurücksetzen"
       },

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -129,6 +129,9 @@
       "auto_clean_stop": {
         "name": "Stop auto clean"
       },
+      "filter_reset": {
+        "name": "Reset water filter"
+      },
       "filter_time_reset": {
         "name": "Reset filter time"
       },

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -326,6 +326,9 @@
       "auto_clean_stop": {
         "name": "Detener la autolimpieza"
       },
+      "filter_reset": {
+        "name": "Restablecer el filtro de agua"
+      },
       "filter_time_reset": {
         "name": "Restablecer el contador del filtro"
       },

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -129,6 +129,9 @@
       "auto_clean_stop": {
         "name": "Arresta autopulizia"
       },
+      "filter_reset": {
+        "name": "Azzera il filtro dell'acqua"
+      },
       "filter_time_reset": {
         "name": "Azzera il contatore del filtro"
       },

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -129,6 +129,9 @@
       "auto_clean_stop": {
         "name": "자동 청소 정지"
       },
+      "filter_reset": {
+        "name": "정수 필터 초기화"
+      },
       "filter_time_reset": {
         "name": "필터 사용 시간 초기화"
       },

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -129,6 +129,9 @@
       "auto_clean_stop": {
         "name": "Zelfreiniging stoppen"
       },
+      "filter_reset": {
+        "name": "Waterfilter resetten"
+      },
       "filter_time_reset": {
         "name": "Filterteller op nul zetten"
       },

--- a/docs/investigations/fridge-water-filter-reset.md
+++ b/docs/investigations/fridge-water-filter-reset.md
@@ -16,10 +16,21 @@ the cause.
 
 ## Why this was hard to find
 
-`x.com.samsung.da.filterReset` appears **nowhere**: not in the device's
-reported rep, not in `/oic/res`, not in the `/device/0` batch, not in any
-fixture in this repo, and not in `smartthings-local`. The only thing that
-reveals it is the 5.00 it throws on a *wrong* string.
+`x.com.samsung.da.filterReset` is absent from *this* device: not in its
+reported rep, not in `/oic/res`, not in its `/device/0` batch, and not in
+`smartthings-local`. The only thing that reveals it here is the 5.00 it
+throws on a wrong string.
+
+It is not absent from the corpus, though, and that matters:
+`tests/fixtures/dishwasher_device.json` reports
+`"x.com.samsung.da.filterReset": "00"` on its own
+`/filter/waterfilter/vs/0`. So on at least one family the field is a
+*stored value* the board reports back, with a `"00"`-style grammar rather
+than `"On"` -- evidence that the accepted value varies by family, and a
+reason not to assume this token travels. `WATER_FILTER` is shared with
+dishwashers and water purifiers, so a board that advertises a reset type
+but wants a different token would fault 5.00, and the entity write path
+only logs the response code -- the user would see nothing.
 
 The decisive control was a near-miss field name. An unrecognised field is
 swallowed with 2.04; `filterResetZZZ: "zzz"` is swallowed, while
@@ -98,3 +109,26 @@ Note the counter only climbs in normal use, so once reset there is no
 cheap way to re-test a candidate write for months. Verification of a
 *wrong* value is still available at any time, though: junk strings return
 5.00 and `"On"` returns 2.04.
+
+## Known limitation of the button
+
+The write body carries only the trigger, so the optimistic cache entry
+sets `filterReset` and nothing else. The board's actual response lands on
+`filterUsage` and `filterStatus`, which the body doesn't set, and
+`mark_write_pending` suppresses non-optimistic updates for
+`_POST_TIMEOUT_S + _POLL_TIMEOUT_S` (43 s) -- so after a successful press
+the sensors keep reading the pre-reset values for up to that long before
+the next poll corrects them.
+
+Putting the expected post-reset values in the body would close that
+window, but the body is also what goes on the wire, and only
+`{"filterReset": "On"}` exactly is verified on hardware. Adding fields to
+a payload that cannot be re-tested (the counter only climbs, so there is
+no second reset to measure for months) trades a cosmetic delay for an
+unverified write. Left as-is deliberately.
+
+Related wart: because the cache merges and the board never echoes the
+trigger back, `"filterReset": "On"` stays in the cached rep for that
+resource and will appear in diagnostics dumps as though the device
+reported it. Anyone reading a dump from a unit whose button has been
+pressed should not treat that as a device-reported field.

--- a/docs/investigations/fridge-water-filter-reset.md
+++ b/docs/investigations/fridge-water-filter-reset.md
@@ -1,0 +1,100 @@
+# Fridge water-filter reset: solved
+
+`{"x.com.samsung.da.filterReset": "On"}` POSTed to
+`/filter/waterfilter/vs/0` resets the water-filter counter.
+
+Measured 2026-09-07 against a live `TP1X_REF_21K` (RF29DB9750QLAA, One UI
+7.0, firmware `A-RFWW-TP1-24-T4-COM_20260617`), integration v0.25.0 / HA
+2026.8.2. `filterUsage` `"100"` -> `"0"` and `filterStatus` `"replace"` ->
+`"normal"`, confirmed held on a fresh DTLS session afterwards.
+
+The value is **case-sensitive**: `"On"` works, `"on"` and `"ON"` both
+fault with 5.00. The field is a *trigger*, never stored and never echoed
+back in the resource's rep -- so, exactly as in `ac-filter-reset.md`, a
+before/after diff of reported state can only ever show the effect, never
+the cause.
+
+## Why this was hard to find
+
+`x.com.samsung.da.filterReset` appears **nowhere**: not in the device's
+reported rep, not in `/oic/res`, not in the `/device/0` batch, not in any
+fixture in this repo, and not in `smartthings-local`. The only thing that
+reveals it is the 5.00 it throws on a *wrong* string.
+
+The decisive control was a near-miss field name. An unrecognised field is
+swallowed with 2.04; `filterResetZZZ: "zzz"` is swallowed, while
+`filterReset: "zzz"` faults. That asymmetry is the entire signal that the
+field exists at all.
+
+## The inference that cracked it
+
+The first reading of the 5.00 was that the board type-checks the field
+and rejects strings -- because non-strings (`true`, `0`, `1`, `2`, `100`,
+`["replaceable"]`) all returned 2.04. That reading is **backwards**, and
+it is the trap worth remembering:
+
+- **non-string** -> `oc_rep_get_string()` fails, the handler never enters
+  the reset block -> 2.04, inert. The value was never looked at.
+- **string** -> the getter succeeds, the handler enters the dispatch,
+  fails to match the value, and errors out -> 5.00.
+
+So 5.00 was not rejection, it was *reaching the right code path and
+missing*. Under that reading, string is the correct type and the search
+collapses from an unbounded value space to a small vocabulary of command
+words -- which is how `"On"` was found on the eighth try.
+
+Generalisable: on this firmware a 5.00 is closer to a hit than a 2.04.
+The error means you are talking to real code.
+
+## Traps on this board
+
+1. **2.04 means nothing.** This firmware ACKs unknown field names rather
+   than rejecting them. 2.04 does not indicate a recognised field, a
+   parsed value, or a stored one. Only a live re-read is evidence. The
+   PRAC_20K's informative 4.00-vs-5.00 type split does not exist here.
+2. **The POST response body is a verbatim echo** -- the payload returned
+   unchanged, on 2.04 and 5.00 alike, with no `"Control fail, <...>"`
+   diagnostic like the laundry firmware. Worth stating because
+   `_raw_write_blocking` discards that body (`code, _ = sess.post(...)`)
+   and it is tempting to assume the answer is hiding there. It is not;
+   capturing it was tried and showed only the echo.
+3. **`changed` in `write_resource` output is not "something changed."**
+   It is `all(after.get(k) == v for k, v in payload.items())` -- "are the
+   payload's values present afterward." Writing a field its own existing
+   value reports `changed: true` having done nothing.
+4. **One CoAP/DTLS session per device.** A second session contends with
+   the integration's. Disable the config entry before probing directly,
+   or the two will disrupt each other and muddy every result.
+
+## Not the answer (ruled out)
+
+- Direct writes of `filterUsage` (`"0"` and `0`) and `filterStatus`
+  (`"normal"`), separately and combined: 2.04, inert.
+- `filterResetType: ["replaceable"]` is descriptive, not a command, as
+  `ac-filter-reset.md` says. But note its sharp edge: the adjacent,
+  unadvertised `filterReset` *is* real. "The reset-shaped field in the
+  rep is a decoy" and "there is no reset field" are different claims, and
+  only the first is true.
+- The AC's `/mode/vs/0` single-token options merge. This board's mode
+  resource has `x.com.samsung.da.modes` and no `options` blob, and a
+  nonsense token there is discarded. Its `modes` carries
+  `WATERFILTER_ENABLE`; the corpus knows only that and
+  `WATERFILTER_DISABLE`, which are capability declarations, not commands.
+- An unenumerated resource. `/oic/res` carries only 14 platform links
+  here; the functional resources come from the `/device/0` batch, which
+  has no reset href. No `/actions/vs/0` on this board.
+- An explicit `?if=oic.if.a` interface query: no different from baseline.
+
+## Reproducing
+
+Probed with a direct DTLS/CoAP session outside HA (integration disabled
+first, per trap 4), using `certs/ab0b0ac4_fullchain.pem` and
+`smartthings_local.protocol.dtls_session.DtlsCoapSession`, POSTing to
+`["filter","waterfilter","vs","0"]`. The integration's own write path
+cannot show the POST response body; that is why the probe was built
+outside it.
+
+Note the counter only climbs in normal use, so once reset there is no
+cheap way to re-test a candidate write for months. Verification of a
+*wrong* value is still available at any time, though: junk strings return
+5.00 and `"On"` returns 2.04.

--- a/tests/test_common_capabilities.py
+++ b/tests/test_common_capabilities.py
@@ -703,6 +703,7 @@ def _reset_gate(rep):
     or an unfetched stub), so the gate would never actually be called.
     """
     desc = next(e for e in common.WATER_FILTER.entities if e.key == "filter_reset")
+    assert desc.exists_fn is not None, "filter_reset must stay gated"
     return desc.exists_fn(rep, {})
 
 

--- a/tests/test_common_capabilities.py
+++ b/tests/test_common_capabilities.py
@@ -661,3 +661,58 @@ class TestUniversalAndPowerBundles:
         bound_caps = {c for caps in airconditioner.REGISTRY.capabilities.values() for c in caps}
         assert common.POWER_GENERIC not in bound_caps
         assert common.POWER_VS_FALLBACK not in bound_caps
+
+
+def _water_filter_desc(fixture, key):
+    """The bound descriptor for `key`, or None when its exists_fn declines it.
+
+    Same shape as the per-family helpers: flatten() yields values, not
+    descriptors, so this is how a test reaches write_fn without standing up
+    an HA entity.
+    """
+    resources = _load_device(fixture)
+    for item in discover(resources, _reg()):
+        if item.desc.key == key and (
+            item.desc.exists_fn is None
+            or item.desc.exists_fn(resources.get(item.href) or {}, resources)
+        ):
+            return item.desc
+    return None
+
+
+def test_water_filter_reset_writes_the_boards_trigger_value():
+    """filterReset 'On', measured on a TP1X_REF_21K: filterUsage 100 -> 0 and
+    filterStatus replace -> normal, still zero on a fresh DTLS session. The
+    value is case-sensitive ('on'/'ON' fault with 5.00) and the field is a
+    trigger the board never reports back, so it can't be gated on itself --
+    see docs/investigations/fridge-water-filter-reset.md."""
+    desc = _water_filter_desc("refrigerator_tp1x_ref_21k_us", "filter_reset")
+    assert desc is not None
+    assert desc.write_fn(desc.payload, {}) == (
+        ["filter", "waterfilter", "vs", "0"],
+        {"x.com.samsung.da.filterReset": "On"},
+    )
+
+
+def test_water_filter_reset_stays_off_boards_without_a_reset_type():
+    """A board that doesn't advertise filterResetType gets the sensors without
+    the button. Both dishwasher fixtures are the case in the corpus today."""
+    assert _water_filter_desc("dishwasher", "filter_reset") is None
+    assert _water_filter_desc("dishwasher_dw5000c_cloud", "filter_reset") is None
+
+
+def test_water_filter_reset_follows_the_devices_own_reset_claim():
+    """The gate is filterResetType, so the button reaches every family that
+    advertises one -- four fridges and three water purifiers here, of which
+    only TP1X_REF_21K is hardware-verified. Pinned deliberately: the blast
+    radius of trusting the device's claim should fail this test if it grows,
+    rather than widening unnoticed."""
+    for fixture in (
+        "refrigerator_artik051_ref_17k",
+        "refrigerator",
+        "refrigerator_tp2x_ref_20k",
+        "water_purifier",
+        "water_purifier_coffee",
+        "water_purifier_ailite_25k",
+    ):
+        assert _water_filter_desc(fixture, "filter_reset") is not None, fixture

--- a/tests/test_common_capabilities.py
+++ b/tests/test_common_capabilities.py
@@ -694,11 +694,38 @@ def test_water_filter_reset_writes_the_boards_trigger_value():
     )
 
 
-def test_water_filter_reset_stays_off_boards_without_a_reset_type():
-    """A board that doesn't advertise filterResetType gets the sensors without
-    the button. Both dishwasher fixtures are the case in the corpus today."""
-    assert _water_filter_desc("dishwasher", "filter_reset") is None
-    assert _water_filter_desc("dishwasher_dw5000c_cloud", "filter_reset") is None
+def _reset_gate(rep):
+    """The filter_reset button's own exists_fn, against a synthetic rep.
+
+    Fixture-driven here would be vacuous: no fixture pairs a populated
+    waterfilter rep with a missing filterResetType (the dishwashers are
+    filterStatus 'notused', which WATER_FILTER.match_fn rejects outright,
+    or an unfetched stub), so the gate would never actually be called.
+    """
+    desc = next(e for e in common.WATER_FILTER.entities if e.key == "filter_reset")
+    return desc.exists_fn(rep, {})
+
+
+def test_water_filter_reset_needs_a_reset_the_device_says_it_supports():
+    """filterResetType names which resets exist, and the corpus carries
+    ['notresetable'] as well -- a presence check would read that as a yes."""
+    assert _reset_gate({"x.com.samsung.da.filterResetType": ["replaceable"]})
+    assert _reset_gate({"x.com.samsung.da.filterResetType": ["washable"]})
+    assert not _reset_gate({"x.com.samsung.da.filterResetType": ["notresetable"]})
+    assert not _reset_gate({"x.com.samsung.da.filterResetType": []})
+    assert not _reset_gate({"x.com.samsung.da.filterUsage": "40"})
+
+
+def test_water_filter_reset_survives_an_unfetched_stub():
+    """An explicit exists_fn bypasses entity._is_included's stub carve-out,
+    which would otherwise drop the button for the life of the config entry
+    when /device/0 answers a not-yet-fetched {"href": ...} stub.
+
+    A genuinely empty {} rep is the opposite case and must stay excluded --
+    the device's confirmed answer that this resource will never populate,
+    which issue #127 exists to keep distinct from a stub."""
+    assert _reset_gate({"href": "/filter/waterfilter/vs/0"})
+    assert not _reset_gate({})
 
 
 def test_water_filter_reset_follows_the_devices_own_reset_claim():


### PR DESCRIPTION
## What this changes

Adds a `filter_reset` button to `common.WATER_FILTER`. Pressing it POSTs
`{"x.com.samsung.da.filterReset": "On"}` to `/filter/waterfilter/vs/0`.

Measured on a TP1X_REF_21K (RF29DB9750QLAA, firmware
`A-RFWW-TP1-24-T4-COM_20260617`): `filterUsage` `"100"` → `"0"`,
`filterStatus` `"replace"` → `"normal"`, still zero on a fresh DTLS session
and on the integration's own poll afterwards. The value is case-sensitive —
`"on"` and `"ON"` both fault 5.00.

## How it was found

The field appears nowhere on this device: not in its rep, `/oic/res`, its
`/device/0` batch, or `smartthings-local`. The control that proves it exists
is a near-miss name — `filterResetZZZ` is swallowed with 2.04 like any
unrecognised field, while `filterReset` faults.

The trick is that the 5.00 means the opposite of what it looks like. Every
non-string (`true`, `0`, `1`, `["replaceable"]`) returns 2.04 because
`oc_rep_get_string` fails and the handler never enters the reset block — not
because it was accepted. A string gets in and then misses on the value. So
**5.00 means the right code path was reached**, which turns an unbounded
value space into a short vocabulary of command words.

`docs/investigations/fridge-water-filter-reset.md` records this alongside the
traps: 2.04 is meaningless on this firmware (it ACKs unknown field names), the
POST response body is a verbatim echo with no diagnostic, and
`write_resource`'s `changed` flag only means "payload values present after".

## Scope, and what is not verified

Gated on `filterResetType` naming a reset the device says it supports
(`replaceable`/`washable`; the corpus also carries `notresetable`). That
reaches **four fridge families and three water purifiers**, of which only
TP1X_REF_21K is verified on hardware — the other six are trusted on their own
advertised claim. The full list is pinned in a test so the reach fails visibly
rather than widening unnoticed.

One caveat worth reading before merge: `dishwasher_device.json` reports
`filterReset` as a stored `"00"` on its own `/filter/waterfilter/vs/0`, so the
accepted value evidently varies by family and `"On"` should not be assumed to
travel. No dishwasher gets the button today (`filterStatus` is `notused`, which
`match_fn` rejects, or the rep is empty), but a wrong token would fault 5.00
with nothing surfaced to the user. Narrowing this to the fridge registry is a
reasonable call if you'd rather not ship on an advertised claim alone.

Also documented rather than fixed: the write body carries only the trigger, so
the sensors keep reading pre-reset values for up to 43 s after a press.
Closing that means adding fields to the body, and the body is what goes on the
wire, where only `{"filterReset": "On"}` exactly is verified — and the counter
only climbs, so there is no second reset to re-measure for months.

## Validation

- exact write-payload coverage, and gate coverage against `replaceable` /
  `washable` / `notresetable` / empty / absent
- stub-rep coverage: an explicit `exists_fn` bypasses `entity._is_included`'s
  carve-out, which would drop the button for the life of a config entry
  (#127); a genuinely empty `{}` rep stays excluded
- blast radius pinned across all seven families that advertise a reset
- full suite: 1787 passed. Three `test_config_flow` failures and two
  collection errors under `tests/localthings/` are pre-existing on `main`
  (stale `smartthings-local` missing `smartthings_local.errors`), confirmed by
  stashing this branch
- Ruff check + format clean

## Related

@Jason-Morcos — this closes the question you left open in #429. Your negative
result reproduces exactly here (`filterUsage: "0"` → 2.04, reverted on
readback), and your conclusion was right: `filterResetType` alone does *not*
establish a working reset. What it couldn't show is that an unadvertised
`filterReset` field exists next to it. Worth a look since #429 documents the
opposite guidance and we should land one story — and note the `"00"` value on
the dishwasher fixture above, which supports your caution about generalising.

@jayrage887 — #449 asks for this on air conditioners, which this PR does not
address. But it may be directly testable: `ac-filter-reset.md`'s negative
result for boards that keep the counter in `/filter/airdustfilter/vs/0` only
ever tried `filterUsage` writes and the `/mode/vs/0` token — never a
`filterReset` field, because nobody knew it existed. If you can try
`{"x.com.samsung.da.filterReset": "On"}` against `/filter/airdustfilter/vs/0`
via `localthings.write_resource` and re-read, that would settle it. A 5.00
rather than 2.04 is the encouraging answer, for the reason described above.


https://claude.ai/code/session_01ABdmqZ4jsc7Kjx15hGBReF
