### PR TITLE
Raise a user-facing error when NoOperation is picked as an oven mode

### DIFF
--- a/custom_components/localthings/coordinator.py
+++ b/custom_components/localthings/coordinator.py
@@ -2036,7 +2036,7 @@ class LocalThingsCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Write a value to the device. Retries once on a dead session
         (issue #294); raises HomeAssistantError if that retry fails too.
 
-        A description-level validate_fn (SwitchDesc only, currently) rejects
+        A description-level validate_fn (SwitchDesc and SelectDesc) rejects
         a write with a user-facing message ahead of write_fn's silent
         no-op. The remote-control check runs first, unconditionally, unless
         the user opted out via CONF_BYPASS_REMOTE_CONTROL (issue #54: some

--- a/custom_components/localthings/registry/capabilities/oven.py
+++ b/custom_components/localthings/registry/capabilities/oven.py
@@ -235,10 +235,23 @@ def _oven_mode_options(resources):
     # Ranges (every range fixture, plus #404's) and the #277 wall oven idle
     # in NoOperation but leave it out of supportedModes; HA's select drops a
     # current option that isn't in the list, so the idle state showed as
-    # Unknown. Not selectable in practice: _oven_mode_write rejects it.
+    # Unknown. Listing it makes it selectable too, which _oven_mode_validate
+    # turns into a user-facing error rather than a silent no-op.
     if "NoOperation" in live:
         return list(live)
     return ["NoOperation", *live]
+
+
+def _oven_mode_validate(p, rep, resources):
+    """NoOperation is what the oven reports while idle; it is in the select
+    so the idle state displays, not because the oven accepts it as a mode
+    (#445 review). Picking it used to fall through to _oven_mode_write's
+    None and the coordinator's warning-and-return, so the user saw nothing
+    happen. Every other option in the list came from supportedModes and
+    passes."""
+    if p == "NoOperation":
+        return "oven_mode_idle_not_selectable"
+    return None
 
 
 def _oven_mode_write(p, rep, href=None):
@@ -444,6 +457,7 @@ OVEN_MODE = Capability(
             options=_oven_mode_options,
             value_fn=lambda v: v[0] if v else None,
             write_fn=_oven_mode_write,
+            validate_fn=_oven_mode_validate,
         ),
         # No exists_fn on the NV7000BS-class board this was proven against
         # (UpperLamp_ is always in its options[]) -- but issue #300's

--- a/custom_components/localthings/registry/entities.py
+++ b/custom_components/localthings/registry/entities.py
@@ -100,6 +100,7 @@ class SelectDesc(SamsungEntityDescription):
     # identically to the current state and every option.
     display_fn: DisplayFn = None
     write_fn: WriteFn = None
+    validate_fn: ValidateFn = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/localthings/translations/cs.json
+++ b/custom_components/localthings/translations/cs.json
@@ -1729,6 +1729,9 @@
     "remote_control_disabled": {
       "message": "Dálkové ovládání je na tomto zařízení vypnuté. V návodu ke spotřebiči zjistěte, jak zapnout dálkové ovládání, než jej bude moci Home Assistant ovládat."
     },
+    "oven_mode_idle_not_selectable": {
+      "message": "NoOperation je stav, který trouba hlásí v nečinnosti. Nelze jej zvolit jako režim; zrušte pečení na ovládacím panelu trouby."
+    },
     "debug_payload_empty": {
       "message": "Obsah ladicího zápisu musí být neprázdný objekt."
     },

--- a/custom_components/localthings/translations/de.json
+++ b/custom_components/localthings/translations/de.json
@@ -1729,6 +1729,9 @@
     "remote_control_disabled": {
       "message": "Die Fernsteuerung ist bei diesem Gerät ausgeschaltet. Schauen Sie im Handbuch Ihres Geräts nach, wie Sie die Fernsteuerung aktivieren, bevor Home Assistant es steuern kann."
     },
+    "oven_mode_idle_not_selectable": {
+      "message": "NoOperation meldet der Backofen im Leerlauf. Es lässt sich nicht als Betriebsart auswählen; brechen Sie den Garvorgang stattdessen am Bedienfeld des Backofens ab."
+    },
     "debug_payload_empty": {
       "message": "Die Debug-Schreibdaten müssen ein nicht leeres Objekt sein."
     },

--- a/custom_components/localthings/translations/en.json
+++ b/custom_components/localthings/translations/en.json
@@ -1729,6 +1729,9 @@
     "remote_control_disabled": {
       "message": "Remote control is turned off on this device. Check your appliance's manual for how to enable remote control before Home Assistant can control it."
     },
+    "oven_mode_idle_not_selectable": {
+      "message": "NoOperation is what the oven reports while idle. It can't be selected as a mode; cancel the cook on the oven's panel instead."
+    },
     "debug_payload_empty": {
       "message": "Debug write payload must be a non-empty object."
     },

--- a/custom_components/localthings/translations/es.json
+++ b/custom_components/localthings/translations/es.json
@@ -156,6 +156,9 @@
     "remote_control_disabled": {
       "message": "El control remoto está desactivado en este dispositivo. Consulta el manual de tu electrodoméstico para saber cómo activar el control remoto antes de que Home Assistant pueda controlarlo."
     },
+    "oven_mode_idle_not_selectable": {
+      "message": "NoOperation es lo que indica el horno cuando está inactivo. No se puede seleccionar como modo; cancela la cocción desde el panel del horno."
+    },
     "debug_payload_empty": {
       "message": "El contenido de la escritura de depuración debe ser un objeto no vacío."
     },

--- a/custom_components/localthings/translations/it.json
+++ b/custom_components/localthings/translations/it.json
@@ -1729,6 +1729,9 @@
     "remote_control_disabled": {
       "message": "Smart Control è disattivato su questo dispositivo. Verificare sul manuale utente come abilitarlo prima che Home Assistant possa controllarlo."
     },
+    "oven_mode_idle_not_selectable": {
+      "message": "NoOperation è lo stato che il forno riporta quando è inattivo. Non può essere selezionato come modalità; annullare la cottura dal pannello del forno."
+    },
     "debug_payload_empty": {
       "message": "Il payload di scrittura di debug deve essere un oggetto non vuoto."
     },

--- a/custom_components/localthings/translations/ko.json
+++ b/custom_components/localthings/translations/ko.json
@@ -1729,6 +1729,9 @@
     "remote_control_disabled": {
       "message": "이 기기의 스마트 컨트롤이 꺼져 있습니다. Home Assistant에서 기기를 제어하려면 가전제품 설명서에서 스마트 컨트롤을 활성화하는 방법을 확인하세요."
     },
+    "oven_mode_idle_not_selectable": {
+      "message": "NoOperation은 오븐이 대기 중일 때 보고하는 상태입니다. 모드로 선택할 수 없으며, 대신 오븐 조작부에서 조리를 취소하세요."
+    },
     "debug_payload_empty": {
       "message": "디버그 쓰기 페이로드는 비어 있지 않은 객체여야 합니다."
     },

--- a/custom_components/localthings/translations/nl.json
+++ b/custom_components/localthings/translations/nl.json
@@ -1729,6 +1729,9 @@
     "remote_control_disabled": {
       "message": "Afstandsbediening is uitgeschakeld op dit apparaat. Raadpleeg de handleiding van je apparaat om afstandsbediening in te schakelen voordat Home Assistant het kan bedienen."
     },
+    "oven_mode_idle_not_selectable": {
+      "message": "NoOperation is wat de oven meldt als hij niets doet. Het kan niet als stand worden gekozen; annuleer het bakken op het bedieningspaneel van de oven."
+    },
     "debug_payload_empty": {
       "message": "De payload voor de schrijfbewerking voor foutopsporing moet een niet-leeg object zijn."
     },

--- a/tests/localthings/test_coordinator.py
+++ b/tests/localthings/test_coordinator.py
@@ -1777,6 +1777,54 @@ async def test_send_command_remote_control_check_precedes_validate_fn(
     assert exc_info.value.translation_key == "remote_control_disabled"
 
 
+async def test_send_command_select_validate_fn_rejects_idle_oven_mode(
+    hass: HomeAssistant, mock_entry, mock_coordinator_observe_session
+) -> None:
+    """The oven mode select lists NoOperation so the idle state displays
+    (#445). Selecting it must raise a ServiceValidationError with the
+    catalog key, and nothing may reach the device -- the same shape as the
+    remote-control gate, replacing write_fn's warning-and-return."""
+    from custom_components.localthings.registry.capabilities.oven import OVEN_MODE
+    from custom_components.localthings.registry.discovery import BoundEntity
+
+    fake = mock_coordinator_observe_session
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+    coordinator: LocalThingsCoordinator = hass.data[DOMAIN][mock_entry.entry_id]
+    coordinator._cache.apply_rep(
+        "/remotectrl/vs/0",
+        {"x.com.samsung.da.remoteControlEnabled": "true"},
+        source="test",
+    )
+    coordinator._cache.apply_rep(
+        "/mode/vs/0",
+        {
+            "x.com.samsung.da.supportedModes": ["Bake", "Broil"],
+            "x.com.samsung.da.modes": ["NoOperation"],
+        },
+        source="test",
+    )
+    desc = OVEN_MODE.entities[0]
+    bound = BoundEntity(href="/mode/vs/0", capability=OVEN_MODE, desc=desc)
+
+    posted = []
+
+    def _post(path_segs, body, *a, **k):
+        posted.append((path_segs, body))
+        return (0x44, b"")
+
+    with patch.object(fake, "subscribe"):
+        fake.post = _post
+        with pytest.raises(ServiceValidationError) as exc_info:
+            await coordinator.async_send_command(bound, "NoOperation")
+        assert exc_info.value.translation_domain == DOMAIN
+        assert exc_info.value.translation_key == "oven_mode_idle_not_selectable"
+        assert posted == []
+
+        await coordinator.async_send_command(bound, "Bake")
+    assert posted and posted[0][0] == ["mode", "vs", "0"]
+
+
 async def test_send_command_bypasses_remote_control_when_option_enabled(
     hass: HomeAssistant, mock_coordinator_observe_session
 ) -> None:

--- a/tests/test_oven_capabilities.py
+++ b/tests/test_oven_capabilities.py
@@ -214,6 +214,23 @@ def test_oven_mode_options_prepends_idle_token_when_live_list_omits_it():
     assert desc.options(resources) == ["NoOperation", "Bake", "Broil", "KeepWarm"]
 
 
+def test_oven_mode_validate_rejects_idle_token_with_user_facing_key():
+    """Listing NoOperation made it selectable (#445 review). Picking it
+    must surface a translated error rather than write_fn's silent None."""
+    desc = _oven_mode_desc()
+    rep = {"x.com.samsung.da.supportedModes": ["Bake", "Broil"]}
+    assert desc.validate_fn("NoOperation", rep, {}) == "oven_mode_idle_not_selectable"
+    assert oven._oven_mode_write("NoOperation", rep) is None
+
+
+def test_oven_mode_validate_passes_every_supported_mode():
+    desc = _oven_mode_desc()
+    rep = {"x.com.samsung.da.supportedModes": ["Bake", "Broil", "KeepWarm"]}
+    for mode in rep["x.com.samsung.da.supportedModes"]:
+        assert desc.validate_fn(mode, rep, {}) is None
+        assert oven._oven_mode_write(mode, rep) is not None
+
+
 def test_oven_mode_options_does_not_duplicate_idle_token():
     desc = _oven_mode_desc()
     resources = {"/mode/vs/0": {"x.com.samsung.da.supportedModes": ["NoOperation", "Bake"]}}


### PR DESCRIPTION
Follow-up to #445, from the review note there.

## What this changes

Listing `NoOperation` in the oven mode select fixed the Unknown-while-idle display but also made it selectable. Picking it hit `_oven_mode_write`'s `None` and the coordinator's `write_fn rejected payload` warning, so the user saw nothing happen.

`SelectDesc` now has the `validate_fn` hook `SwitchDesc` already had. The coordinator already ran it generically ahead of `write_fn`, so no dispatch change was needed. The oven select's `validate_fn` returns `oven_mode_idle_not_selectable` for `NoOperation`, and the coordinator raises `ServiceValidationError` with the translated message:

> NoOperation is what the oven reports while idle. It can't be selected as a mode; cancel the cook on the oven's panel instead.

Added to all seven translation catalogs. The registry stays free of HA imports. Every other option in the list comes from `supportedModes` and passes through unchanged.

## Validation

- `tests/test_oven_capabilities.py`: `validate_fn` returns the key for `NoOperation` and `None` for every supported mode
- `tests/localthings/test_coordinator.py`: selecting `NoOperation` on the real `OVEN_MODE` descriptor raises with domain and key and nothing is posted; `Bake` on the same entity still writes to `/mode/vs/0`
- `ruff format --check`, `ruff check`, `ty check`, `pytest tests/ -q`: 1923 passed
