### PR TITLE
Stop the oven's finish_time sensor from changing on every push

### DIFF
--- a/custom_components/localthings/registry/capabilities/oven.py
+++ b/custom_components/localthings/registry/capabilities/oven.py
@@ -85,17 +85,31 @@ def _int(v):
         return None
 
 
-def _finish_time(remaining_str):
-    if not remaining_str:
+def _finish_time(rep):
+    """now() + remainingTime while a cook is running, rounded to the minute.
+
+    Same treatment as operational.py's _finish_time, for the same reason:
+    a range pushes /operational/state/vs/0 every few seconds during a cook
+    (progressPercentage ticks about once per 7-10 s), and its remainingTime
+    only has minute resolution with the seconds parked at ':59', so the
+    unrounded sum drifted by a few seconds per push and crossed the minute
+    boundary back and forth. That was one logbook entry per push (NX60T8311SS,
+    a 15-minute bake). The state gate covers boards that leave a stale
+    remainingTime after the cook ends; this one reports 00:00:00 there."""
+    if _to_ocf(rep.get("x.com.samsung.da.state")) != "active":
+        return None
+    remaining = rep.get("x.com.samsung.da.remainingTime")
+    if not remaining:
         return None
     try:
-        h, m, s = remaining_str.split(":")
+        h, m, s = remaining.split(":")
         total_s = int(h) * 3600 + int(m) * 60 + int(s)
-        if total_s == 0:
-            return None
-        return datetime.now(UTC) + timedelta(seconds=total_s)
-    except Exception:
+    except (AttributeError, ValueError):
         return None
+    if total_s == 0:
+        return None
+    finish = datetime.now(UTC) + timedelta(seconds=total_s)
+    return finish.replace(second=0, microsecond=0)
 
 
 def _op_minutes(op_time):
@@ -324,9 +338,9 @@ OVEN_OPERATIONAL_STATE = Capability(
         ),
         SensorDesc(
             key="finish_time",
-            field="x.com.samsung.da.remainingTime",
             device_class="timestamp",
-            value_fn=_finish_time,
+            hysteresis=True,
+            rep_fn=_finish_time,
         ),
         NumberDesc(
             key="cook_time",

--- a/tests/test_oven_capabilities.py
+++ b/tests/test_oven_capabilities.py
@@ -214,6 +214,53 @@ def test_oven_mode_options_prepends_idle_token_when_live_list_omits_it():
     assert desc.options(resources) == ["NoOperation", "Bake", "Broil", "KeepWarm"]
 
 
+def _finish_desc():
+    return next(e for e in oven.OVEN_OPERATIONAL_STATE.entities if e.key == "finish_time")
+
+
+class TestOvenFinishTime:
+    """A range pushes /operational/state/vs/0 every few seconds during a
+    cook (progressPercentage ticks) and its remainingTime seconds sit at
+    ':59', so an unrounded now()+remaining produced one logbook entry per
+    push and flipped across the minute boundary (NX60T8311SS, 15-minute
+    bake). Same fix operational.py already carries: round to the minute,
+    hysteresis on the descriptor, and nothing while the cook isn't active."""
+
+    def test_rounded_to_the_minute_and_stable_across_polls(self):
+        desc = _finish_desc()
+        assert desc.hysteresis is True
+        rep = {
+            "x.com.samsung.da.state": "Run",
+            "x.com.samsung.da.remainingTime": "00:14:59",
+        }
+        first = desc.rep_fn(rep)
+        second = desc.rep_fn(rep)
+        assert first.second == 0 and first.microsecond == 0
+        assert first == second
+
+    def test_nothing_unless_a_cook_is_running(self):
+        desc = _finish_desc()
+        # Ready with a leftover remainingTime (boards that don't zero it).
+        assert (
+            desc.rep_fn(
+                {"x.com.samsung.da.state": "Ready", "x.com.samsung.da.remainingTime": "00:01:00"}
+            )
+            is None
+        )
+        # Running with no cook time set: the range reports 00:00:00.
+        assert (
+            desc.rep_fn(
+                {"x.com.samsung.da.state": "Run", "x.com.samsung.da.remainingTime": "00:00:00"}
+            )
+            is None
+        )
+        assert desc.rep_fn({"x.com.samsung.da.state": "Run"}) is None
+        assert (
+            desc.rep_fn({"x.com.samsung.da.state": "Run", "x.com.samsung.da.remainingTime": "soon"})
+            is None
+        )
+
+
 def test_oven_mode_validate_rejects_idle_token_with_user_facing_key():
     """Listing NoOperation made it selectable (#445 review). Picking it
     must surface a translated error rather than write_fn's silent None."""


### PR DESCRIPTION
## What this changes

The oven's `finish_time` sensor produced one logbook entry every 4 to 7 seconds during a 15-minute bake on an NX60T8311SS (TP2X range), flipping between 7:07 and 7:08 PM. Cause: the range pushes `/operational/state/vs/0` each time `progressPercentage` ticks, and its `remainingTime` only has minute resolution with the seconds parked at `:59`, so `oven.py`'s `now() + remaining` drifted a few seconds per push and crossed the minute boundary back and forth.

`operational.py`'s shared `_finish_time` already rounds to the minute and its descriptor carries `hysteresis=True` for exactly this reason (the 3-minute deadband from the options flow). The oven's older copy had neither. It now:

- rounds to the minute the same way,
- sets `hysteresis=True` on the descriptor,
- reports nothing unless the cook is active, so a board that leaves a stale `remainingTime` after Finish reads no phantom time. This range reports `00:00:00` there, so it doesn't change on this unit; it's the same guard the shared version has.

The descriptor moves from `field`/`value_fn` to `rep_fn` so it can see the state. State keys are unchanged, goldens untouched.

Observed on the same cook, for the record: `remainingTime` ticks by whole minutes (`14:59`, `13:59`, ...), `progressPercentage` climbs about one point per 7-10 s, and `/oven/vs/0` goes `Preheat`, `Cooking`, `Finish`. Full notes on #183.

## Validation

- `tests/test_oven_capabilities.py`: rounded and stable across polls with `hysteresis` set; nothing while Ready with a leftover time, while running with `00:00:00`, with the field missing, or unparseable
- `ruff format --check`, `ruff check`, `ty check`, `pytest tests/ -q`: 1925 passed
