### PR TITLE
Drop an unsupported claim from the burner-mask comment

### DIFF
--- a/custom_components/localthings/registry/capabilities/range.py
+++ b/custom_components/localthings/registry/capabilities/range.py
@@ -267,14 +267,13 @@ PROBE_STATUS = Capability(
 # `cooktopMonitoring` is a bitmask of lit burners, one bit per knob. Verified
 # on a gas NX60T8311SS/AA (TP2X -0101X) by lighting each burner alone: bits
 # 0-4 are front-left, back-left, center, back-right, front-right, and the
-# value is unaffected by flame level. Every -0101X/-0102X range dump carries
-# the field, but only gas boards have been seen non-zero (this unit, and
-# #404's TP1X NX6512A idling at 0), and both of those also carry a `Fuel_Gas`
-# token in /mode/vs/0 options[] that none of the electric NE boards report.
-# So the decoded entities (a count plus one binary sensor per bit) are gated
-# on that token, and every other board gets the raw value as a diagnostic
-# sensor instead -- an electric owner who lights two burners and sees 3 has
-# the evidence to lift the gate (issue #450).
+# value is unaffected by flame level. Only gas boards have been seen non-zero
+# (this unit, and #404's TP1X NX6512A idling at 0), and both of those also
+# carry a `Fuel_Gas` token in /mode/vs/0 options[] that none of the electric
+# NE boards report. So the decoded entities (a count plus one binary sensor
+# per bit) are gated on that token, and every other board gets the raw value
+# as a diagnostic sensor instead -- an electric owner who lights two burners
+# and sees 3 has the evidence to lift the gate (issue #450).
 #
 # The mask can't say how many burners exist (a four-burner board just never
 # sets bit 4), so the width is the layout it was verified on. A board that


### PR DESCRIPTION
Follow-up to #451, noted in review there.

The `cooktopMonitoring` comment claimed every -0101X/-0102X range dump carries the field. `range_device.json` is a `TP1X_DA-KS-RANGE-0102X` with no `/cooktopmonitoring/vs/0` resource at all — it's the board that publishes `burnerList` instead. Every dump that *has* the resource does carry the field, but the gate rests on the `Fuel_Gas` token rather than on resource coverage, so the sentence is doing no work and is cut instead of rephrased.

Comment only, no behavior change. `ruff format --check`, `ruff check`, `pytest tests/ -q`: 1945 passed.

https://claude.ai/code/session_01ABdmqZ4jsc7Kjx15hGBReF