### PR TITLE
Only create an air-quality sensor the board actually lists

### DIFF
--- a/custom_components/localthings/registry/capabilities/air_monitor.py
+++ b/custom_components/localthings/registry/capabilities/air_monitor.py
@@ -37,7 +37,7 @@ from datetime import time as dt_time
 from ..capability import Capability
 from ..entities import BinarySensorDesc, SensorDesc, SwitchDesc, TimeDesc
 from .air_purifier import _AIR_QUALITY_SENSORS
-from .common import int_or_none, sensor_item_value
+from .common import has_sensor_type, int_or_none, sensor_item_value
 
 # device_class/unit are taken from the shared rows; state_class deliberately
 # is not. air_purifier leaves Odor/CleanLevel unstamped because they read as
@@ -60,6 +60,7 @@ SENSORS = Capability(
                 state_class="measurement",
                 device_class=device_class,
                 unit=unit,
+                exists_fn=has_sensor_type(sensor_type),  # issue #414
                 value_fn=lambda items, t=sensor_type: sensor_item_value(items, t),
             )
             for key, icon, sensor_type, _state_class, device_class, unit in _AIR_QUALITY_SENSORS
@@ -70,6 +71,7 @@ SENSORS = Capability(
             device_class="carbon_dioxide",
             state_class="measurement",
             unit="ppm",
+            exists_fn=has_sensor_type("CO2"),  # issue #414
             value_fn=lambda items: sensor_item_value(items, "CO2"),
         ),
     ),

--- a/custom_components/localthings/registry/capabilities/air_purifier.py
+++ b/custom_components/localthings/registry/capabilities/air_purifier.py
@@ -122,6 +122,13 @@ AIR_QUALITY = Capability(
                 state_class=state_class,
                 device_class=device_class,
                 unit=unit,
+                # Gated on the board listing the type: a purifier reporting
+                # only CleanLevel (AVT-WW-TP1-22-TOUCHOTN, issue #414) used
+                # to grow four permanently-unknown particulate sensors.
+                # Listing a type isn't proof the hardware is real (issue
+                # #166) -- that's a separate problem, and not one worth
+                # hiding a working reading over.
+                exists_fn=has_sensor_type(sensor_type),
                 value_fn=lambda items, t=sensor_type: sensor_item_value(items, t),
             )
             for key, icon, sensor_type, state_class, device_class, unit in _AIR_QUALITY_SENSORS

--- a/custom_components/localthings/registry/capabilities/range_hood.py
+++ b/custom_components/localthings/registry/capabilities/range_hood.py
@@ -17,7 +17,13 @@ from ..entities import (
     SensorDesc,
     SwitchDesc,
 )
-from .common import epoch_to_utc, filter_reset_button, int_or_none, sensor_item_value
+from .common import (
+    epoch_to_utc,
+    filter_reset_button,
+    has_sensor_type,
+    int_or_none,
+    sensor_item_value,
+)
 
 
 def _active_alarm_codes(items):
@@ -222,6 +228,10 @@ AFTER_RUN = Capability(
 )
 
 
+# Each reading is gated on the hood listing that sensor type, the same guard
+# air_purifier.AIR_QUALITY needed for a board that reports only some of them
+# (issue #414). No hood dump has been short one yet; this is the guard, not a
+# fix for anything observed here.
 AIR_QUALITY = Capability(
     href="/sensors/vs/0",
     poll_tier="warm",
@@ -230,22 +240,21 @@ AIR_QUALITY = Capability(
             key="clean_level",
             field="x.com.samsung.da.items",
             icon="mdi:air-filter",
+            exists_fn=has_sensor_type("CleanLevel"),
             value_fn=lambda items: sensor_item_value(items, "CleanLevel"),
         ),
-        SensorDesc(
-            key="dust",
-            field="x.com.samsung.da.items",
-            value_fn=lambda items: sensor_item_value(items, "Dust"),
-        ),
-        SensorDesc(
-            key="fine_dust",
-            field="x.com.samsung.da.items",
-            value_fn=lambda items: sensor_item_value(items, "FineDust"),
-        ),
-        SensorDesc(
-            key="super_fine_dust",
-            field="x.com.samsung.da.items",
-            value_fn=lambda items: sensor_item_value(items, "SuperFineDust"),
+        *(
+            SensorDesc(
+                key=key,
+                field="x.com.samsung.da.items",
+                exists_fn=has_sensor_type(type_),
+                value_fn=lambda items, t=type_: sensor_item_value(items, t),
+            )
+            for key, type_ in (
+                ("dust", "Dust"),
+                ("fine_dust", "FineDust"),
+                ("super_fine_dust", "SuperFineDust"),
+            )
         ),
     ),
 )

--- a/tests/fixtures/air_purifier_avt_ww_touchotn_device.json
+++ b/tests/fixtures/air_purifier_avt_ww_touchotn_device.json
@@ -1,0 +1,329 @@
+{
+  "device0": [
+    {
+      "rt": [
+        "x.com.samsung.devcol",
+        "oic.wk.col"
+      ],
+      "if": [
+        "oic.if.baseline",
+        "oic.if.ll",
+        "oic.if.b"
+      ]
+    },
+    {
+      "href": "/airlevelcheck/vs/0",
+      "rep": {
+        "x.com.samsung.da.periodicSensingInterval": "600",
+        "x.com.samsung.da.startSensingOnce": "On",
+        "x.com.samsung.da.sensingState": "NonProcessing",
+        "x.com.samsung.da.lastSensingTime": "1787646840",
+        "x.com.samsung.da.lastSensingLevel": "Kr1",
+        "x.com.samsung.da.supportedAutoExeState": [
+          "Off",
+          "Airpurify",
+          "Alarm"
+        ],
+        "x.com.samsung.da.periodicSensingSkipStatus": "Off",
+        "x.com.samsung.da.periodicSensingSkipTime": "00000000"
+      }
+    },
+    {
+      "href": "/alarms/vs/0",
+      "rep": {
+        "x.com.samsung.da.items": [
+          {
+            "x.com.samsung.da.id": "0",
+            "x.com.samsung.da.description": "Alarm",
+            "x.com.samsung.da.alarmType": "Device",
+            "x.com.samsung.da.code": "ErrorCode_OFF",
+            "x.com.samsung.da.triggeredTime": "2026-08-25T11:59:57",
+            "x.com.samsung.da.state": "Deleted"
+          }
+        ]
+      }
+    },
+    {
+      "href": "/availablecontrolsets/vs/0",
+      "rep": {
+        "x.com.samsung.da.sets": "021D010000000000000000000000",
+        "x.com.samsung.da.id": "VTL",
+        "x.com.samsung.da.version": "1.0"
+      }
+    },
+    {
+      "href": "/configuration/vs/0",
+      "rep": {
+        "x.com.samsung.da.region": "4817000000",
+        "x.com.samsung.da.countryCode": ""
+      }
+    },
+    {
+      "href": "/connectionconfig/vs/0",
+      "rep": {
+        "autoReconnectionMinVersion": "1.0",
+        "autoReconnection": "true",
+        "autoReconnectionProtocolType": [
+          "helper_hotspot",
+          "ble_ocf"
+        ],
+        "supportedWiFiAuthType": [
+          "OPEN",
+          "WEP",
+          "WPA-PSK",
+          "WPA2-PSK",
+          "SAE"
+        ],
+        "supportedWiFiCryptoType": [
+          "TKIP",
+          "AES",
+          "WEP-64",
+          "WEP-128"
+        ],
+        "supportedWiFiFreq": [
+          "2.4G"
+        ],
+        "calmConnectionCare": {
+          "version": "1.0",
+          "role": [
+            "things"
+          ]
+        }
+      }
+    },
+    {
+      "href": "/da/softreset/vs/0",
+      "rep": {
+        "x.com.samsung.da.softwarereset": "false"
+      }
+    },
+    {
+      "href": "/devicespecificinfo/vs/0",
+      "rep": {
+        "x.com.samsung.da.deviceActive": true
+      }
+    },
+    {
+      "href": "/dnd/autosleep/vs/0",
+      "rep": {
+        "x.com.samsung.da.startTime": "00:00:00",
+        "x.com.samsung.da.endTime": "00:00:00",
+        "x.com.samsung.da.visible": "false",
+        "x.com.samsung.da.useTimeSetting": "false",
+        "x.com.samsung.da.functionState": "false"
+      }
+    },
+    {
+      "href": "/energy/consumption/0",
+      "rep": {}
+    },
+    {
+      "href": "/energy/consumption/vs/0",
+      "rep": {
+        "x.com.samsung.da.cumulativePower": "12691",
+        "x.com.samsung.da.cumulativeDate": "1787691583",
+        "x.com.samsung.da.cumulativeDateUTC": "1787659183",
+        "x.com.samsung.da.cumulativeUnit": "Wh"
+      }
+    },
+    {
+      "href": "/file/information/vs/0",
+      "rep": {
+        "x.com.samsung.timeoffset": "+09:00"
+      }
+    },
+    {
+      "href": "/filter/hepafilter/vs/0",
+      "rep": {
+        "x.com.samsung.da.filterUsage": "9",
+        "x.com.samsung.da.filterUsageResolution": "1",
+        "x.com.samsung.da.filterStatus": "normal",
+        "x.com.samsung.da.filterCapacity": "8760",
+        "x.com.samsung.da.filterCapacityUnit": "Hour",
+        "x.com.samsung.da.filterResetType": [
+          "replaceable"
+        ]
+      }
+    },
+    {
+      "href": "/humidity/0",
+      "rep": {}
+    },
+    {
+      "href": "/humidity/vs/0",
+      "rep": {}
+    },
+    {
+      "href": "/information/vs/0",
+      "rep": {
+        "x.com.samsung.da.modelNum": "AVT-WW-TP1-22-TOUCHOTN|10241841|70000621001610000D000800000A0000",
+        "x.com.samsung.da.description": "AVT-WW-TP1-22-TOUCHOTN",
+        "x.com.samsung.da.serialNum": "**REDACTED**",
+        "x.com.samsung.da.otnDUID": "**REDACTED**",
+        "x.com.samsung.da.diagProtocolType": "WIFI_HTTPS",
+        "x.com.samsung.da.diagLogType": [
+          "errCode",
+          "dump"
+        ],
+        "x.com.samsung.da.diagDumpType": "file",
+        "x.com.samsung.da.diagEndPoint": "SSM",
+        "x.com.samsung.da.diagMnid": "0AJT",
+        "x.com.samsung.da.diagSetupid": "AP1",
+        "x.com.samsung.da.diagMinVersion": "1.0",
+        "x.com.samsung.da.diagTsId": "DA01",
+        "x.com.samsung.da.items": [
+          {
+            "x.com.samsung.da.id": "0",
+            "x.com.samsung.da.description": "Version",
+            "x.com.samsung.da.type": "Software",
+            "x.com.samsung.da.number": "02425A260327",
+            "x.com.samsung.da.newVersionAvailable": "0"
+          },
+          {
+            "x.com.samsung.da.id": "1",
+            "x.com.samsung.da.description": "Version",
+            "x.com.samsung.da.type": "Firmware",
+            "x.com.samsung.da.number": "23090502,ffffffff",
+            "x.com.samsung.da.newVersionAvailable": "0"
+          },
+          {
+            "x.com.samsung.da.id": "2",
+            "x.com.samsung.da.description": "Version",
+            "x.com.samsung.da.type": "Firmware",
+            "x.com.samsung.da.number": "22020200",
+            "x.com.samsung.da.newVersionAvailable": "0"
+          }
+        ]
+      }
+    },
+    {
+      "href": "/mode/convenient/vs/0",
+      "rep": {
+        "x.com.samsung.da.supportedModes": [
+          "Off"
+        ]
+      }
+    },
+    {
+      "href": "/mode/vs/0",
+      "rep": {
+        "x.com.samsung.da.options": [
+          "OptionCode_16970"
+        ]
+      }
+    },
+    {
+      "href": "/otninformation/vs/0",
+      "rep": {
+        "x.com.samsung.da.target": "",
+        "x.com.samsung.da.newVersionAvailable": "false",
+        "x.com.samsung.da.newVersionNo": "00000000",
+        "x.com.samsung.da.currentVersionInfo": "00000000",
+        "otnStatus": "None",
+        "flashingProgress": "",
+        "otnTarget": "main",
+        "otnCompleteDate": "noHistory",
+        "otnList": [
+          {
+            "type": "WIFI",
+            "modelId": "AVT-WW-TP1-22-TOUCHOTN",
+            "versions": [
+              "12260327"
+            ],
+            "visVersion": "260327"
+          },
+          {
+            "type": "Micom",
+            "modelId": "095010241841FFFFFFFF",
+            "versions": [
+              "23090502",
+              "FFFFFFFF"
+            ],
+            "visVersion": "230905"
+          },
+          {
+            "type": "Micom",
+            "modelId": "095010239541FFFFFFFF",
+            "versions": [
+              "22020200",
+              "FFFFFFFF"
+            ],
+            "visVersion": "220202"
+          }
+        ]
+      }
+    },
+    {
+      "href": "/power/0",
+      "rep": {
+        "value": true
+      }
+    },
+    {
+      "href": "/power/vs/0",
+      "rep": {
+        "x.com.samsung.da.power": "On"
+      }
+    },
+    {
+      "href": "/realtimenotiforclient/vs/0",
+      "rep": {
+        "x.com.samsung.da.timeforshortnoti": "0",
+        "x.com.samsung.da.longnotisubscription": "true",
+        "x.com.samsung.da.periodicnotisubscription": "true"
+      }
+    },
+    {
+      "href": "/sensors/vs/0",
+      "rep": {
+        "x.com.samsung.da.items": [
+          {
+            "x.com.samsung.da.id": "3",
+            "x.com.samsung.da.description": "Sensor for CleanLevel",
+            "x.com.samsung.da.type": "CleanLevel",
+            "x.com.samsung.da.value": [
+              "1"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "href": "/timezone/vs/0",
+      "rep": {
+        "timezoneid": "Asia/Seoul",
+        "offset": "+09:00",
+        "DST": "OFF"
+      }
+    },
+    {
+      "href": "/wind/strength/vs/0",
+      "rep": {
+        "x.com.samsung.da.modes": "91",
+        "x.com.samsung.da.supportedModes": [
+          "0",
+          "2",
+          "3",
+          "4",
+          "91"
+        ],
+        "x.com.samsung.da.modesName": [
+          "Auto",
+          "Mid",
+          "High",
+          "Turbo",
+          "Sleep"
+        ]
+      }
+    },
+    {
+      "href": "/wirelessinfo/vs/0",
+      "rep": {
+        "macaddressWiFi": "**REDACTED**",
+        "macaddressBLE": "**REDACTED**",
+        "connectedApSsid": "**REDACTED**"
+      }
+    }
+  ],
+  "seeds_note": "Verbatim /device/0 capture from an AVT-WW-TP1-22-TOUCHOTN air purifier (reported in issue #414 as an AP70F03102RVD), powered on and running. Its /sensors/vs/0 lists a single CleanLevel item -- no Dust/FineDust/SuperFineDust/Odor -- which is the only thing that distinguishes it from the other AVT/VTWW purifier fixtures and the reason it's in the corpus. Serial, DUID and MACs redacted by the diagnostics download; the WiFi SSID by hand, since that build predates redact.py's ssid rule. Devcol head constructed."
+}

--- a/tests/fixtures/golden/air_purifier_avt_ww_touchotn.json
+++ b/tests/fixtures/golden/air_purifier_avt_ww_touchotn.json
@@ -1,0 +1,22 @@
+{
+  "state_keys": [
+    "air_sensing_state",
+    "alarm_code",
+    "clean_level",
+    "device_active",
+    "energy_kwh",
+    "firmware_update",
+    "hepa_filter_status",
+    "hepa_filter_usage",
+    "last_air_sensing_level",
+    "last_air_sensing_time",
+    "periodic_air_sensing",
+    "periodic_sensing_skip_status",
+    "power_switch",
+    "sensing_interval",
+    "sensing_mode",
+    "sensing_skip_end",
+    "sensing_skip_start",
+    "wind_strength_fan"
+  ]
+}

--- a/tests/test_air_quality_sensor_gating.py
+++ b/tests/test_air_quality_sensor_gating.py
@@ -1,0 +1,88 @@
+"""Air-quality readings are gated on the board listing that sensor type.
+
+Issue #414: an AVT-WW-TP1-22-TOUCHOTN purifier reports a single CleanLevel
+item in /sensors/vs/0 and grew four permanently-unknown particulate sensors
+next to it. `common.has_sensor_type` was already doing this job for the AC
+family and for CO2; these tests pin it across the three families that read
+the same items[] shape.
+"""
+
+import pytest
+
+from custom_components.localthings.registry.adapter import flatten
+from custom_components.localthings.registry.by_type import resolve
+from custom_components.localthings.registry.capabilities import (
+    air_monitor,
+    air_purifier,
+    range_hood,
+)
+from custom_components.localthings.registry.discovery import discover
+from tests.conftest import _load_device
+
+_PARTICULATE = ("dust", "fine_dust", "super_fine_dust", "odor")
+
+
+def _state(fixture, device_types=()):
+    resources = _load_device(fixture)
+    reg = resolve(resources, device_types=device_types)
+    assert reg is not None, fixture
+    bound = discover(resources, reg.capabilities, reg.pattern_capabilities)
+    return flatten(bound, resources)
+
+
+def test_touchotn_fixture_has_no_unbound_hrefs():
+    resources = _load_device("air_purifier_avt_ww_touchotn")
+    reg = resolve(resources, device_types=("oic.wk.d", "oic.d.airpurifier"))
+    assert reg is not None and reg.name == "air_purifier"
+    unbound = []
+    discover(resources, reg.capabilities, reg.pattern_capabilities, log=unbound.append)
+    assert unbound == []
+
+
+def test_board_listing_only_clean_level_gets_only_clean_level():
+    """The reported board (issue #414). It's powered on and running in this
+    capture, so the short items[] is what it reports, not an idle artifact."""
+    state = _state("air_purifier_avt_ww_touchotn", ("oic.wk.d", "oic.d.airpurifier"))
+    assert state["clean_level"] == 1
+    for key in _PARTICULATE:
+        assert key not in state, key
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    ["air_purifier", "air_purifier_vtww", "air_purifier_avt_ww", "air_purifier_tp1x_da_ac_air"],
+)
+def test_boards_listing_every_type_keep_every_reading(fixture):
+    """The other side of the gate: it must not cost a reading on any board
+    that does report one."""
+    state = _state(fixture)
+    for key in (*_PARTICULATE, "clean_level"):
+        assert key in state, key
+
+
+def test_air_monitor_keeps_its_full_set():
+    state = _state("air_monitor")
+    for key in (*_PARTICULATE, "clean_level", "co2"):
+        assert key in state, key
+
+
+def _air_quality_descs():
+    """Every descriptor across the three families that reads items[]."""
+    for capability in (air_purifier.AIR_QUALITY, air_monitor.SENSORS, range_hood.AIR_QUALITY):
+        for desc in capability.entities:
+            yield capability, desc
+
+
+def test_every_items_reader_is_gated():
+    """A new reading added to any of these without a gate is the bug again."""
+    for capability, desc in _air_quality_descs():
+        assert desc.exists_fn is not None, f"{capability.href}:{desc.key}"
+
+
+def test_gate_keeps_the_not_yet_fetched_stub_carve_out():
+    """A /device/0 stub means "no data yet", not "no sensor" -- dropping the
+    entity there would leave a board with no air-quality sensors at all
+    whenever discovery raced the first sub-poll (issue #127)."""
+    stub = {"href": "/sensors/vs/0"}
+    for _capability, desc in _air_quality_descs():
+        assert desc.exists_fn(stub, {"/sensors/vs/0": stub}) is True

--- a/tests/test_golden_regression.py
+++ b/tests/test_golden_regression.py
@@ -1659,3 +1659,24 @@ def test_registry_reproduces_golden_state_keys_for_air_purifier_ax100db900edd():
         f"  extra:   {sorted(set(state_keys) - set(golden['state_keys']))}\n"
         f"  missing: {sorted(set(golden['state_keys']) - set(state_keys))}"
     )
+
+
+def test_registry_reproduces_golden_state_keys_for_air_purifier_avt_ww_touchotn():
+    """AVT-WW-TP1-22-TOUCHOTN (issue #414), the first purifier in the corpus
+    whose /sensors/vs/0 lists only CleanLevel. Its golden is the other AVT/
+    VTWW purifiers' minus dust/fine_dust/super_fine_dust/odor, which is the
+    point: those four used to be created here and read unknown forever."""
+    from tests.conftest import _load_device
+
+    resources = _load_device("air_purifier_avt_ww_touchotn")
+    golden = json.loads((GOLDEN / "air_purifier_avt_ww_touchotn.json").read_text())
+    state_keys = _new_state_keys(
+        "air_purifier_avt_ww_touchotn",
+        resources,
+        device_types=("oic.wk.d", "oic.d.airpurifier"),
+    )
+    assert set(state_keys) == set(golden["state_keys"]), (
+        f"state_keys mismatch:\n"
+        f"  extra:   {sorted(set(state_keys) - set(golden['state_keys']))}\n"
+        f"  missing: {sorted(set(golden['state_keys']) - set(state_keys))}"
+    )


### PR DESCRIPTION
Closes #414.

## What the dumps show

Two dumps on the issue. They route fine and bind with zero unbound hrefs, so this was never a coverage gap — it's a phantom-entity bug.

- **`A-VTWW-TP2-21-COMMON`** (the AX123A9970GD) lists all five sensor items and works. Its href set is identical to the existing `air_purifier_vtww` fixture, so it adds nothing to the corpus and isn't included here.
- **`AVT-WW-TP1-22-TOUCHOTN`** (reported as the AP70F03102RVD) lists exactly one item in `/sensors/vs/0`:

```json
{"x.com.samsung.da.items": [
  {"x.com.samsung.da.id": "3", "x.com.samsung.da.type": "CleanLevel",
   "x.com.samsung.da.value": ["1"]}]}
```

No Dust, FineDust, SuperFineDust or Odor — and the unit is powered **on** and running (`power: On`, fan on Sleep), so this isn't an idle-state truncation. It still got all four entities, each reading unknown forever. That's what the reporter saw.

## The fix

`common.has_sensor_type` already does this job and is already applied to every reading in the AC family and to CO2 on the purifier — the five main purifier rows just never got it. Extended to:

- `air_purifier.AIR_QUALITY`'s five shared rows
- `air_monitor.SENSORS`' same five, plus its CO2
- `range_hood.AIR_QUALITY`'s four

**No fixture in the corpus loses an entity.** I checked every dump that binds `/sensors/vs/0`: all four purifier fixtures and the monitor list every type they read, and the hood lists all four of its. Not one golden changes — the gate only ever removes a reading the device never mentions. A test pins that from both sides, so this can't quietly start dropping real readings.

`has_sensor_type` keeps the `is_stub_rep` carve-out, so a `/device/0` that hasn't populated yet still gets its sensors rather than losing them to a discovery race (issue #127). Also pinned.

## What this deliberately doesn't do

Listing a type still isn't proof the hardware exists — issue #166's board lists all five with permanent zeros on units the reporter confirmed have no such sensor. That's a different failure, it needs different evidence to act on, and it isn't worth hiding a working reading over. This gate only acts on what the device declines to mention at all.

## Validation

- New fixture `air_purifier_avt_ww_touchotn` + golden; `tests/test_air_quality_sensor_gating.py` covers the gated board, the four boards that keep everything, the monitor's full set, every items[] reader being gated, and the stub carve-out
- `ruff format --check`, `ruff check`, `ty check`, `pytest tests/ -q`: 1974 passed

https://claude.ai/code/session_01ABdmqZ4jsc7Kjx15hGBReF