### PR TITLE
Translate the legacy 8888 envelope into canonical resources

### DIFF
--- a/custom_components/localthings/legacy_http.py
+++ b/custom_components/localthings/legacy_http.py
@@ -1,0 +1,265 @@
+"""Envelope translation for the legacy 8888/HTTPS appliance family (issue #168).
+
+Some 2018-2022 Samsung appliances have nothing on UDP 49152-49160 and only
+TCP 8888: nginx over TLS 1.0 with a mandatory client certificate, serving a
+small REST bridge instead of an OCF server. The OCF URL space is not merely
+unauthorised there, it is absent -- ``/oic/res``, ``/oic/d`` and
+``/mode/vs/0`` all come back as nginx's own HTML 404, while an unknown path
+*inside* the served space answers ``{"errorCode": "0", "errorDescription":
+"Invalid resource"}`` from the application.
+
+What that bridge serves, though, is the same vocabulary in a different
+envelope: the same ``options``/``supportedOptions`` arrays, the same
+``Course_5C`` tokens, the same single-token merge semantics on writes. Only
+the spelling differs -- bare field names instead of ``x.com.samsung.da.*``,
+and ``/devices/0/<resource>`` instead of ``/<resource>/vs/0``.
+
+So this module is a table and four pure functions over it. Given one of
+those appliances' responses it produces exactly the ``{href: rep}`` shape
+``registry.batch.parse_device0_batch`` produces, which is what lets
+``registry/``, ``discovery.py`` and ``adapter.py`` work on such a device
+unchanged -- the expensive part, and the part this repository has already
+solved.
+
+Deliberately pure: no I/O, no Home Assistant, no session. Nothing imports it
+at runtime yet; it is the half of issue #168's proposal that can be reviewed
+and tested without a transport existing, and without any of the coordinator
+churn a transport would need. See that issue for the staging.
+
+Two rules carry the whole translation, and both are mechanical:
+
+* a resource's fields take the ``x.com.samsung.da.`` prefix and keep their
+  names;
+* a resource maps onto the canonical href whose rep those fields belong in.
+
+Everything that is *not* mechanical lives in the table as data, so an
+appliance that disagrees costs a row rather than a branch. On the one
+family measured so far that is three exceptions: ``Operation`` carries
+power and the child lock alongside the operational state, ``Information``
+spells two fields differently, and ``Alarms`` arrives as a bare list where
+the OCF side carries an ``items`` array.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+# The prefix every OCF-side field carries and no 8888-side field does.
+PREFIX = "x.com.samsung.da."
+
+
+@dataclass(frozen=True)
+class Resource:
+    """One 8888 resource and where its fields belong on the OCF side.
+
+    ``endpoint`` is the path segment under ``/devices/0/``; ``wrapper`` is
+    the PascalCase key the same resource takes inside the aggregate body
+    (both directions -- the appliance wraps what it reports, and expects
+    the same wrapping on a write to ``/devices/0``).
+
+    ``fan_out`` and ``rename`` are the exception tables: a field named in
+    ``fan_out`` lands on that canonical href instead of ``href``, and a
+    field named in ``rename`` lands under that canonical name instead of
+    its own. Anything not named in either is mechanical.
+    """
+
+    endpoint: str
+    wrapper: str
+    href: str
+    fan_out: Mapping[str, str] = field(default_factory=dict)
+    rename: Mapping[str, str] = field(default_factory=dict)
+    # True where the appliance serves a bare JSON list and the OCF side
+    # carries it as an ``items`` array of Property maps (see /alarms/vs/0
+    # on any of this repository's fixtures).
+    as_items: bool = False
+
+
+# TP6X_WW6500 (EU), the one 8888 appliance measured end to end. Every row
+# here was read off the hardware, not inferred: the codes in `Mode` are the
+# same `Course_XX` tokens /course/vs/0 carries -- note it is *not*
+# /mode/vs/0, which this firmware 404s -- and the fields in `Washer` are
+# the same waterTemperature/rinseCycles/spinLevel this repository's washer
+# registry already binds.
+TP6X_WASHER: tuple[Resource, ...] = (
+    Resource(
+        endpoint="operation",
+        wrapper="Operation",
+        href="/operational/state/vs/0",
+        # This firmware lumps the power state and the child lock in with
+        # the operational state; on the OCF side they are their own
+        # resources, and this repository's capabilities read them there.
+        fan_out={"power": "/power/vs/0", "kidsLock": "/kidslock/vs/0"},
+    ),
+    Resource(endpoint="mode", wrapper="Mode", href="/course/vs/0"),
+    Resource(endpoint="washer", wrapper="Washer", href="/washer/vs/0"),
+    Resource(
+        endpoint="configuration",
+        wrapper="Configuration",
+        href="/remotectrl/vs/0",
+    ),
+    Resource(
+        endpoint="information",
+        wrapper="Information",
+        href="/information/vs/0",
+        rename={"modelID": "modelNum", "serialNumber": "serialNum"},
+    ),
+    Resource(endpoint="diagnosis", wrapper="Diagnosis", href="/diagnosis/vs/0"),
+    Resource(endpoint="alarms", wrapper="Alarms", href="/alarms/vs/0", as_items=True),
+)
+
+
+# Keyed by the appliance's own `description` (/devices/0/information's, e.g.
+# 'TP6X_WASHER'). One family so far; a second one either fits this table or
+# shows exactly where it doesn't, which is the point of keeping the
+# translation declarative.
+FAMILIES: dict[str, tuple[Resource, ...]] = {"TP6X_WASHER": TP6X_WASHER}
+
+
+def _canonical_name(name: str, rename: Mapping[str, str]) -> str:
+    return PREFIX + rename.get(name, name)
+
+
+def _canonical_value(value: Any, rename: Mapping[str, str]) -> Any:
+    """Prefix nested Property maps too -- an alarms entry is itself a map of
+    bare field names on the wire and of prefixed ones on the OCF side."""
+    if isinstance(value, Mapping):
+        return {_canonical_name(k, rename): _canonical_value(v, rename) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_canonical_value(v, rename) for v in value]
+    return value
+
+
+def to_resources(
+    bodies: Mapping[str, Any],
+    table: tuple[Resource, ...] = TP6X_WASHER,
+) -> dict[str, dict]:
+    """8888 responses -> ``{canonical href: rep}``.
+
+    ``bodies`` is keyed by wrapper name, which is how the appliance itself
+    reports them: ``GET /devices/0`` answers ``{"Device": {"Operation":
+    {...}, "Washer": {...}, ...}}``, and the two resources that aggregate
+    carries only links to answer ``{"Configuration": {...}}`` and
+    ``{"Information": {...}}`` on their own endpoints. A caller therefore
+    merges what it read and hands the wrapper-keyed mapping here.
+
+    A wrapper the appliance didn't report is simply absent from the result,
+    the same as an href a ``/device/0`` batch didn't carry -- callers
+    already treat that as "this board doesn't have it" rather than as an
+    empty rep (see ``registry.batch.is_stub_rep`` for why the distinction
+    matters).
+    """
+    out: dict[str, dict] = {}
+    for resource in table:
+        body = bodies.get(resource.wrapper)
+        if body is None:
+            continue
+        if resource.as_items:
+            if not isinstance(body, list):
+                continue
+            out[resource.href] = {
+                PREFIX + "items": [_canonical_value(item, resource.rename) for item in body]
+            }
+            continue
+        if not isinstance(body, Mapping):
+            continue
+        for name, value in body.items():
+            href = resource.fan_out.get(name, resource.href)
+            out.setdefault(href, {})[_canonical_name(name, resource.rename)] = _canonical_value(
+                value, resource.rename
+            )
+    return out
+
+
+def _wire_field(href: str, name: str, table: tuple[Resource, ...]) -> tuple[str, str] | None:
+    """``(wrapper, wire field name)`` for one canonical field, or None when
+    this table has nowhere to put it."""
+    bare = name[len(PREFIX) :] if name.startswith(PREFIX) else name
+    for resource in table:
+        for wire_name, fan_href in resource.fan_out.items():
+            if fan_href == href and wire_name == bare:
+                return resource.wrapper, wire_name
+        if resource.href != href:
+            continue
+        for wire_name, canonical in resource.rename.items():
+            if canonical == bare:
+                return resource.wrapper, wire_name
+        return resource.wrapper, bare
+    return None
+
+
+def to_write(
+    steps: list[tuple[str, Mapping[str, Any]]],
+    table: tuple[Resource, ...] = TP6X_WASHER,
+) -> dict[str, Any]:
+    """``[(canonical href, canonical patch), ...]`` -> one aggregate body.
+
+    Several steps coalesce into a single ``PUT /devices/0`` rather than
+    becoming several requests, because on this firmware some writes are
+    only accepted together: the washer takes a cycle **only** in the same
+    body as ``Operation.state``. A ``Course_`` token sent on its own is
+    answered ``204`` and discarded in every shape tried -- including a
+    two-token body alongside ``LaundryOutTime``, which applied the other
+    token in the same call, so it is a firmware rule about that field
+    rather than a syntax problem.
+
+    That is not exotic to this transport: ``async_raw_write_sequence``
+    exists in this repository (issue #300) because a wall oven discards
+    settings writes while idle and keeps them only once a cycle is running.
+    Same fact, different family, over CoAP.
+
+    Returns the body only; the endpoint is always ``/devices/0``. The
+    alternative -- a bare body on the resource endpoint, e.g.
+    ``PUT /devices/0/mode {"options": [...]}`` -- is what two other public
+    clients for this port use, but it has never been tested here, so
+    nothing in this module produces it.
+    """
+    device: dict[str, dict] = {}
+    for href, patch in steps:
+        for name, value in patch.items():
+            target = _wire_field(href, name, table)
+            if target is None:
+                continue
+            wrapper, wire_name = target
+            device.setdefault(wrapper, {})[wire_name] = value
+    return {"Device": device}
+
+
+# HTTP status -> CoAP response code, so everything above the transport
+# keeps speaking one vocabulary: _coap_accepted, _coap_code_str, the
+# diagnostics dump and the debug services all work unchanged.
+#
+# 204 mapping onto 2.04 Changed is exact in both senses, including the
+# unwelcome one: on this family a 204 means the request was accepted, not
+# that anything changed -- and a CoAP 2.04 means no more than that either
+# (an ARTIK051 air conditioner answers 2.04 to `FilterTime_0`, echoes the
+# token, and has discarded it a poll later). The read-back in
+# _raw_write_blocking is the right answer on both transports.
+_HTTP_TO_COAP: dict[int, int] = {
+    200: 0x45,  # 2.05 Content
+    201: 0x41,  # 2.01 Created
+    204: 0x44,  # 2.04 Changed
+    400: 0x80,  # 4.00 Bad Request
+    401: 0x81,  # 4.01 Unauthorized
+    403: 0x83,  # 4.03 Forbidden
+    404: 0x84,  # 4.04 Not Found
+    405: 0x85,  # 4.05 Method Not Allowed
+}
+
+
+def http_status_to_coap(status: int) -> int:
+    """A CoAP response code for an HTTP status.
+
+    Anything unmapped becomes 5.00 or 4.00 by class, so an unfamiliar
+    status still reads as a failure of the right kind rather than as a
+    success.
+    """
+    mapped = _HTTP_TO_COAP.get(status)
+    if mapped is not None:
+        return mapped
+    if status >= 500:
+        return 0xA0  # 5.00 Internal Server Error
+    if status >= 400:
+        return 0x80  # 4.00 Bad Request
+    return 0x45

--- a/custom_components/localthings/legacy_http.py
+++ b/custom_components/localthings/legacy_http.py
@@ -131,6 +131,39 @@ def _canonical_value(value: Any, rename: Mapping[str, str]) -> Any:
     return value
 
 
+def unwrap(*responses: Mapping[str, Any]) -> dict[str, Any]:
+    """The appliance's responses -> the wrapper-keyed mapping to_resources takes.
+
+    Three shapes turn up and all three are handled here rather than by every
+    caller: the aggregate ``{"Device": {...}}`` (``GET /devices/0``), its
+    plural ``{"Devices": [{...}]}`` (``GET /devices``), and a single
+    resource's own ``{"Configuration": {...}}``.
+
+    The aggregate carries more than resources -- ``connected``, ``id``,
+    ``name``, ``description``, ``resources``, a ``ConfigurationLink`` and
+    an ``InformationLink`` to the two it does not embed, and an
+    ``EnergyConsumption`` holding only a file path. None of those has a
+    canonical href, so none has a table row and all are dropped by
+    ``to_resources``. They are left in here rather than filtered, so a
+    board carrying something in one of them is visible to a caller that
+    goes looking.
+    """
+    out: dict[str, Any] = {}
+    for response in responses:
+        if not isinstance(response, Mapping):
+            continue
+        device = response.get("Device")
+        if device is None:
+            devices = response.get("Devices")
+            if isinstance(devices, list) and devices:
+                device = devices[0]
+        if isinstance(device, Mapping):
+            out.update(device)
+        else:
+            out.update(response)
+    return out
+
+
 def to_resources(
     bodies: Mapping[str, Any],
     table: tuple[Resource, ...] = TP6X_WASHER,

--- a/tests/fixtures/washer_tp6x_ww6500_8888.json
+++ b/tests/fixtures/washer_tp6x_ww6500_8888.json
@@ -1,0 +1,307 @@
+{
+  "/devices": {
+    "Devices": [
+      {
+        "Alarms": [],
+        "ConfigurationLink": {
+          "href": "/devices/0/configuration"
+        },
+        "Diagnosis": {
+          "diagnosisStart": "Ready"
+        },
+        "EnergyConsumption": {
+          "saveLocation": "/files/usage.db"
+        },
+        "InformationLink": {
+          "href": "/devices/0/information"
+        },
+        "Mode": {
+          "options": [
+            "EnergyKW_396",
+            "TimeSync_NotSupported",
+            "NoCheck_SC",
+            "Course_5B",
+            "DeviceType_0167",
+            "QuickWash_Off",
+            "UsagesDB_ok",
+            "LaundryOutTime_0",
+            "AddWashSet_0",
+            "AddWashAvailable_7",
+            "AddWashIndicator_Off",
+            "QuickWashSet_5B847E933FA53F"
+          ],
+          "supportedOptions": [
+            "35B847E933FA53F5C841E923FA53F5D8102923FA43F66841E930FA30F5E831E920FA2075F867E943FA53F60831E930FA43F61841E943FA43F6385209204A204648000913FA53F6C831E933FA30F65841E920FA30F67843E923FA43F688430923FA53F"
+          ]
+        },
+        "Operation": {
+          "kidsLock": "Ready",
+          "power": "On",
+          "progress": "None",
+          "progressPercentage": 1,
+          "remainingTime": "04:29:00",
+          "state": "Ready",
+          "supportedProgress": [
+            "None",
+            "Weightsensing",
+            "Wash",
+            "Rinse",
+            "Spin",
+            "Finish"
+          ]
+        },
+        "Washer": {
+          "rinseCycles": "2",
+          "spinLevel": "1400",
+          "supportedRinseCycles": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5"
+          ],
+          "supportedSpinLevel": [
+            "RinseHold",
+            "NoSpin",
+            "400",
+            "800",
+            "1200",
+            "1400"
+          ],
+          "supportedWaterTemperature": [
+            "None",
+            "Cold",
+            "20",
+            "30",
+            "40",
+            "60",
+            "95"
+          ],
+          "waterTemperature": "60"
+        },
+        "connected": true,
+        "description": "TP6X_WW6500(REDACTED)",
+        "id": "0",
+        "name": "Washer",
+        "resources": [
+          "Alarms",
+          "Configuration",
+          "Diagnosis",
+          "EnergyConsumption",
+          "Information",
+          "Mode",
+          "Operation",
+          "Washer"
+        ],
+        "type": "Washer",
+        "uuid": "REDACTED"
+      }
+    ]
+  },
+  "/devices/0": {
+    "Device": {
+      "Alarms": [],
+      "ConfigurationLink": {
+        "href": "/devices/0/configuration"
+      },
+      "Diagnosis": {
+        "diagnosisStart": "Ready"
+      },
+      "EnergyConsumption": {
+        "saveLocation": "/files/usage.db"
+      },
+      "InformationLink": {
+        "href": "/devices/0/information"
+      },
+      "Mode": {
+        "options": [
+          "EnergyKW_396",
+          "TimeSync_NotSupported",
+          "NoCheck_SC",
+          "Course_5B",
+          "DeviceType_0167",
+          "QuickWash_Off",
+          "UsagesDB_ok",
+          "LaundryOutTime_0",
+          "AddWashSet_0",
+          "AddWashAvailable_7",
+          "AddWashIndicator_Off",
+          "QuickWashSet_5B847E933FA53F"
+        ],
+        "supportedOptions": [
+          "35B847E933FA53F5C841E923FA53F5D8102923FA43F66841E930FA30F5E831E920FA2075F867E943FA53F60831E930FA43F61841E943FA43F6385209204A204648000913FA53F6C831E933FA30F65841E920FA30F67843E923FA43F688430923FA53F"
+        ]
+      },
+      "Operation": {
+        "kidsLock": "Ready",
+        "power": "On",
+        "progress": "None",
+        "progressPercentage": 1,
+        "remainingTime": "04:29:00",
+        "state": "Ready",
+        "supportedProgress": [
+          "None",
+          "Weightsensing",
+          "Wash",
+          "Rinse",
+          "Spin",
+          "Finish"
+        ]
+      },
+      "Washer": {
+        "rinseCycles": "2",
+        "spinLevel": "1400",
+        "supportedRinseCycles": [
+          "0",
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
+        "supportedSpinLevel": [
+          "RinseHold",
+          "NoSpin",
+          "400",
+          "800",
+          "1200",
+          "1400"
+        ],
+        "supportedWaterTemperature": [
+          "None",
+          "Cold",
+          "20",
+          "30",
+          "40",
+          "60",
+          "95"
+        ],
+        "waterTemperature": "60"
+      },
+      "connected": true,
+      "description": "TP6X_WW6500(REDACTED)",
+      "id": "0",
+      "name": "Washer",
+      "resources": [
+        "Alarms",
+        "Configuration",
+        "Diagnosis",
+        "EnergyConsumption",
+        "Information",
+        "Mode",
+        "Operation",
+        "Washer"
+      ],
+      "type": "Washer",
+      "uuid": "REDACTED"
+    }
+  },
+  "/devices/0/mode": {
+    "Mode": {
+      "options": [
+        "EnergyKW_396",
+        "TimeSync_NotSupported",
+        "NoCheck_SC",
+        "Course_5B",
+        "DeviceType_0167",
+        "QuickWash_Off",
+        "UsagesDB_ok",
+        "LaundryOutTime_0",
+        "AddWashSet_0",
+        "AddWashAvailable_7",
+        "AddWashIndicator_Off",
+        "QuickWashSet_5B847E933FA53F"
+      ],
+      "supportedOptions": [
+        "35B847E933FA53F5C841E923FA53F5D8102923FA43F66841E930FA30F5E831E920FA2075F867E943FA53F60831E930FA43F61841E943FA43F6385209204A204648000913FA53F6C831E933FA30F65841E920FA30F67843E923FA43F688430923FA53F"
+      ]
+    }
+  },
+  "/devices/0/operation": {
+    "Operation": {
+      "kidsLock": "Ready",
+      "power": "On",
+      "progress": "None",
+      "progressPercentage": 1,
+      "remainingTime": "04:29:00",
+      "state": "Ready",
+      "supportedProgress": [
+        "None",
+        "Weightsensing",
+        "Wash",
+        "Rinse",
+        "Spin",
+        "Finish"
+      ]
+    }
+  },
+  "/devices/0/washer": {
+    "Washer": {
+      "rinseCycles": "2",
+      "spinLevel": "1400",
+      "supportedRinseCycles": [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5"
+      ],
+      "supportedSpinLevel": [
+        "RinseHold",
+        "NoSpin",
+        "400",
+        "800",
+        "1200",
+        "1400"
+      ],
+      "supportedWaterTemperature": [
+        "None",
+        "Cold",
+        "20",
+        "30",
+        "40",
+        "60",
+        "95"
+      ],
+      "waterTemperature": "60"
+    }
+  },
+  "/devices/0/information": {
+    "Information": {
+      "Versions": [
+        {
+          "id": "0",
+          "newVersionAvailable": false,
+          "number": "02095A200308(C020)",
+          "type": "Software"
+        },
+        {
+          "id": "1",
+          "newVersionAvailable": false,
+          "number": "00000000,00000000",
+          "type": "Firmware"
+        }
+      ],
+      "description": "TP6X_WASHER",
+      "deviceSubType": "Washer",
+      "manufacturer": "Samsung Electronics",
+      "modelID": "TP6X_WW6500|FF18E000|20010102001011070000000000000000",
+      "serialNumber": "REDACTED"
+    }
+  },
+  "/devices/0/configuration": {
+    "Configuration": {
+      "remoteControlEnabled": true
+    }
+  },
+  "/devices/0/alarms": {
+    "Alarms": []
+  },
+  "/devices/0/diagnosis": {
+    "Diagnosis": {
+      "diagnosisStart": "Ready"
+    }
+  }
+}

--- a/tests/test_legacy_http.py
+++ b/tests/test_legacy_http.py
@@ -1,12 +1,20 @@
 """Tests for legacy_http -- the 8888/HTTPS envelope translation (issue #168).
 
-The bodies below are hand-built from field names and values measured on a
-live TP6X_WW6500, small enough to read in one screen; they are not a device
-dump, and nothing here stands in for one. What they pin down is the shape
-of the translation -- the mechanical rule, and each of the three exceptions
-the table carries -- so that a second appliance either fits or shows
-exactly where it doesn't.
+Two levels. The small bodies below are hand-built from a live TP6X_WW6500
+and pin down the shape of the translation -- the mechanical rule and each
+of the three exceptions the table carries -- so a second appliance either
+fits or shows exactly where it doesn't.
+
+`TestAgainstTheDeviceDump` is the one that matters: it runs the real,
+redacted dump in tests/fixtures/washer_tp6x_ww6500_8888.json (all nine
+endpoints, captured in one pass) through the translation and then through
+this repository's own `resolve()` and `discover()`, unmodified. Redacted
+there: the serial, and the appliance's `uuid`, which on this board is its
+MAC address in UUID form.
 """
+
+import json
+from pathlib import Path
 
 from custom_components.localthings.legacy_http import (
     PREFIX,
@@ -14,7 +22,12 @@ from custom_components.localthings.legacy_http import (
     http_status_to_coap,
     to_resources,
     to_write,
+    unwrap,
 )
+from custom_components.localthings.registry.by_type import resolve
+from custom_components.localthings.registry.discovery import discover
+
+FIXTURE = Path(__file__).parent / "fixtures" / "washer_tp6x_ww6500_8888.json"
 
 # What `GET /devices/0` reports, plus the two resources that aggregate only
 # links to, merged the way a caller would hand them over.
@@ -26,7 +39,7 @@ BODIES = {
         "remainingTime": "00:10:00",
         "supportedProgress": ["None", "Wash", "Rinse", "Spin", "Finish"],
         "power": "On",
-        "kidsLock": "Off",
+        "kidsLock": "Ready",
     },
     "Mode": {
         "options": ["Course_5C", "LaundryOutTime_0", "DeviceType_0167"],
@@ -80,7 +93,7 @@ class TestToResources:
         resources = to_resources(BODIES, TP6X_WASHER)
 
         assert resources["/power/vs/0"] == {PREFIX + "power": "On"}
-        assert resources["/kidslock/vs/0"] == {PREFIX + "kidsLock": "Off"}
+        assert resources["/kidslock/vs/0"] == {PREFIX + "kidsLock": "Ready"}
         assert PREFIX + "power" not in resources["/operational/state/vs/0"]
 
     def test_operational_state_keeps_the_rest(self):
@@ -194,3 +207,91 @@ class TestHttpStatusToCoap:
     def test_unmapped_statuses_fall_back_by_class(self):
         assert http_status_to_coap(418) == 0x80
         assert http_status_to_coap(503) == 0xA0
+
+
+class TestAgainstTheDeviceDump:
+    """The real appliance, through this repository's own detection.
+
+    Deliberately asserts properties rather than counts: how many entities
+    the washer registry binds is yours to change, and a test that pins the
+    number would break on every capability you add. What must hold is that
+    the translation leaves nothing unaccounted for and that the entities
+    this family actually has still resolve.
+    """
+
+    @staticmethod
+    def _resources():
+        dump = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        return to_resources(
+            unwrap(
+                dump["/devices/0"],
+                dump["/devices/0/configuration"],
+                dump["/devices/0/information"],
+            )
+        )
+
+    def test_the_dump_produces_the_canonical_resource_set(self):
+        assert set(self._resources()) == {
+            "/alarms/vs/0",
+            "/course/vs/0",
+            "/diagnosis/vs/0",
+            "/information/vs/0",
+            "/kidslock/vs/0",
+            "/operational/state/vs/0",
+            "/power/vs/0",
+            "/remotectrl/vs/0",
+            "/washer/vs/0",
+        }
+
+    def test_the_device_types_as_a_washer(self):
+        """Through `description` ('TP6X_WASHER') and the consumer-prefix
+        rule, with no new board token and no change to by_type."""
+        registry = resolve(self._resources())
+
+        assert registry is not None
+        assert registry.name == "washer"
+
+    def test_nothing_is_left_unbound(self):
+        resources = self._resources()
+        registry = resolve(resources)
+        unbound: list[str] = []
+
+        discover(
+            resources,
+            registry.capabilities,
+            registry.pattern_capabilities,
+            log=unbound.append,
+        )
+
+        assert unbound == []
+
+    def test_the_entities_this_appliance_has_are_bound(self):
+        """Not an exhaustive list -- the ones whose absence would mean the
+        translation lost something, each on a different canonical href."""
+        resources = self._resources()
+        registry = resolve(resources)
+
+        bound = discover(resources, registry.capabilities, registry.pattern_capabilities)
+        keys = {b.key_override or b.desc.key for b in bound}
+
+        assert {
+            "cycle",  # /course/vs/0
+            "machine_state",  # /operational/state/vs/0
+            "progress_percentage",
+            "wash_temperature",  # /washer/vs/0
+            "spin_speed",
+            "rinse_cycles",
+            "power_switch",  # /power/vs/0 -- fanned out of Operation
+            "child_lock",  # /kidslock/vs/0 -- likewise
+            "remote_control",  # /remotectrl/vs/0
+            "alarm_code",  # /alarms/vs/0
+            "diagnosis_status",  # /diagnosis/vs/0
+        } <= keys
+
+    def test_the_cycle_select_offers_this_appliance_own_courses(self):
+        """The supportedOptions blob decodes through your own decoder, on a
+        board that publishes no editCourseList: 14 courses, which is what
+        the dial has."""
+        from custom_components.localthings.registry.capabilities.laundry import cycle_options
+
+        assert len(cycle_options(self._resources())) == 14

--- a/tests/test_legacy_http.py
+++ b/tests/test_legacy_http.py
@@ -251,9 +251,15 @@ class TestAgainstTheDeviceDump:
         assert registry is not None
         assert registry.name == "washer"
 
+    @staticmethod
+    def _registry(resources):
+        registry = resolve(resources)
+        assert registry is not None
+        return registry
+
     def test_nothing_is_left_unbound(self):
         resources = self._resources()
-        registry = resolve(resources)
+        registry = self._registry(resources)
         unbound: list[str] = []
 
         discover(
@@ -269,7 +275,7 @@ class TestAgainstTheDeviceDump:
         """Not an exhaustive list -- the ones whose absence would mean the
         translation lost something, each on a different canonical href."""
         resources = self._resources()
-        registry = resolve(resources)
+        registry = self._registry(resources)
 
         bound = discover(resources, registry.capabilities, registry.pattern_capabilities)
         keys = {b.key_override or b.desc.key for b in bound}

--- a/tests/test_legacy_http.py
+++ b/tests/test_legacy_http.py
@@ -1,0 +1,196 @@
+"""Tests for legacy_http -- the 8888/HTTPS envelope translation (issue #168).
+
+The bodies below are hand-built from field names and values measured on a
+live TP6X_WW6500, small enough to read in one screen; they are not a device
+dump, and nothing here stands in for one. What they pin down is the shape
+of the translation -- the mechanical rule, and each of the three exceptions
+the table carries -- so that a second appliance either fits or shows
+exactly where it doesn't.
+"""
+
+from custom_components.localthings.legacy_http import (
+    PREFIX,
+    TP6X_WASHER,
+    http_status_to_coap,
+    to_resources,
+    to_write,
+)
+
+# What `GET /devices/0` reports, plus the two resources that aggregate only
+# links to, merged the way a caller would hand them over.
+BODIES = {
+    "Operation": {
+        "state": "Run",
+        "progress": "Rinse",
+        "progressPercentage": 84,
+        "remainingTime": "00:10:00",
+        "supportedProgress": ["None", "Wash", "Rinse", "Spin", "Finish"],
+        "power": "On",
+        "kidsLock": "Off",
+    },
+    "Mode": {
+        "options": ["Course_5C", "LaundryOutTime_0", "DeviceType_0167"],
+        "supportedOptions": ["35B8520520A204"],
+    },
+    "Washer": {
+        "waterTemperature": "40",
+        "rinseCycles": "2",
+        "spinLevel": "1400",
+        "supportedWaterTemperature": ["Cold", "20", "30", "40", "60", "95"],
+    },
+    "Configuration": {"remoteControlEnabled": True},
+    "Information": {
+        "modelID": "TP6X_WW6500|FF1BE000",
+        "serialNumber": "REDACTED",
+        "description": "TP6X_WASHER",
+    },
+    "Diagnosis": {"diagnosisStart": "Ready"},
+    "Alarms": [{"id": "0", "code": "DrumClean", "state": "Created"}],
+}
+
+
+class TestToResources:
+    def test_fields_take_the_samsung_prefix_and_keep_their_names(self):
+        resources = to_resources(BODIES, TP6X_WASHER)
+
+        assert resources["/washer/vs/0"] == {
+            PREFIX + "waterTemperature": "40",
+            PREFIX + "rinseCycles": "2",
+            PREFIX + "spinLevel": "1400",
+            PREFIX + "supportedWaterTemperature": ["Cold", "20", "30", "40", "60", "95"],
+        }
+
+    def test_mode_lands_on_course_not_on_mode(self):
+        """This firmware's `Mode` carries the `Course_` token array, which
+        is /course/vs/0's contract on the OCF side -- /mode/vs/0 is a
+        different resource, and this appliance 404s it."""
+        resources = to_resources(BODIES, TP6X_WASHER)
+
+        assert "/mode/vs/0" not in resources
+        assert resources["/course/vs/0"][PREFIX + "options"] == [
+            "Course_5C",
+            "LaundryOutTime_0",
+            "DeviceType_0167",
+        ]
+
+    def test_operation_fans_out_power_and_the_child_lock(self):
+        """The one structural exception: this firmware reports both inside
+        `Operation`, where the OCF side has them as resources of their own
+        and this repository's capabilities read them there."""
+        resources = to_resources(BODIES, TP6X_WASHER)
+
+        assert resources["/power/vs/0"] == {PREFIX + "power": "On"}
+        assert resources["/kidslock/vs/0"] == {PREFIX + "kidsLock": "Off"}
+        assert PREFIX + "power" not in resources["/operational/state/vs/0"]
+
+    def test_operational_state_keeps_the_rest(self):
+        resources = to_resources(BODIES, TP6X_WASHER)
+
+        assert resources["/operational/state/vs/0"] == {
+            PREFIX + "state": "Run",
+            PREFIX + "progress": "Rinse",
+            PREFIX + "progressPercentage": 84,
+            PREFIX + "remainingTime": "00:10:00",
+            PREFIX + "supportedProgress": ["None", "Wash", "Rinse", "Spin", "Finish"],
+        }
+
+    def test_information_is_renamed_in_exactly_two_places(self):
+        resources = to_resources(BODIES, TP6X_WASHER)
+        info = resources["/information/vs/0"]
+
+        assert info[PREFIX + "modelNum"] == "TP6X_WW6500|FF1BE000"
+        assert info[PREFIX + "serialNum"] == "REDACTED"
+        # Everything else is mechanical, including in the same resource.
+        assert info[PREFIX + "description"] == "TP6X_WASHER"
+
+    def test_alarms_become_an_items_array_of_prefixed_maps(self):
+        resources = to_resources(BODIES, TP6X_WASHER)
+
+        assert resources["/alarms/vs/0"] == {
+            PREFIX + "items": [
+                {
+                    PREFIX + "id": "0",
+                    PREFIX + "code": "DrumClean",
+                    PREFIX + "state": "Created",
+                }
+            ]
+        }
+
+    def test_a_resource_the_appliance_did_not_report_is_absent(self):
+        """Absent, not empty: an empty rep is a board's confirmed answer
+        that it has none of this, which callers already read differently
+        (registry.batch.is_stub_rep)."""
+        resources = to_resources({k: v for k, v in BODIES.items() if k != "Diagnosis"})
+
+        assert "/diagnosis/vs/0" not in resources
+
+    def test_every_href_is_the_shape_a_device0_batch_produces(self):
+        """The whole point of the translation: what comes out is keyed and
+        shaped exactly like parse_device0_batch's output, so registry/ and
+        discovery.py need no notion of which transport fed them."""
+        resources = to_resources(BODIES, TP6X_WASHER)
+
+        assert all(href.startswith("/") for href in resources)
+        assert all(isinstance(rep, dict) for rep in resources.values())
+        assert all(key.startswith(PREFIX) for rep in resources.values() for key in rep)
+
+
+class TestToWrite:
+    def test_one_step_wraps_the_resource_the_appliance_expects(self):
+        body = to_write([("/course/vs/0", {PREFIX + "options": ["LaundryOutTime_60"]})])
+
+        assert body == {"Device": {"Mode": {"options": ["LaundryOutTime_60"]}}}
+
+    def test_steps_coalesce_into_a_single_aggregate_body(self):
+        """The measured rule on this appliance: a cycle is accepted only in
+        the same body as Operation.state, never on its own."""
+        body = to_write(
+            [
+                ("/course/vs/0", {PREFIX + "options": ["Course_63"]}),
+                ("/operational/state/vs/0", {PREFIX + "state": "Run"}),
+            ]
+        )
+
+        assert body == {
+            "Device": {
+                "Mode": {"options": ["Course_63"]},
+                "Operation": {"state": "Run"},
+            }
+        }
+
+    def test_a_fanned_out_field_writes_back_into_its_own_wrapper(self):
+        body = to_write([("/power/vs/0", {PREFIX + "power": "Off"})])
+
+        assert body == {"Device": {"Operation": {"power": "Off"}}}
+
+    def test_a_renamed_field_writes_under_its_wire_name(self):
+        body = to_write([("/information/vs/0", {PREFIX + "modelNum": "X"})])
+
+        assert body == {"Device": {"Information": {"modelID": "X"}}}
+
+    def test_an_href_this_table_has_no_row_for_is_dropped(self):
+        """Rather than inventing a wrapper for it: a write nobody can place
+        must not reach the appliance as a guess."""
+        assert to_write([("/energy/consumption/vs/0", {PREFIX + "cumulativePower": "1"})]) == {
+            "Device": {}
+        }
+
+    def test_writes_round_trip_through_the_table(self):
+        resources = to_resources(BODIES, TP6X_WASHER)
+        body = to_write([(href, rep) for href, rep in resources.items() if href == "/washer/vs/0"])
+
+        assert body["Device"]["Washer"] == BODIES["Washer"]
+
+
+class TestHttpStatusToCoap:
+    def test_success_statuses(self):
+        assert http_status_to_coap(200) == 0x45  # 2.05 Content
+        assert http_status_to_coap(204) == 0x44  # 2.04 Changed
+
+    def test_client_errors(self):
+        assert http_status_to_coap(403) == 0x83  # 4.03 Forbidden
+        assert http_status_to_coap(404) == 0x84  # 4.04 Not Found
+
+    def test_unmapped_statuses_fall_back_by_class(self):
+        assert http_status_to_coap(418) == 0x80
+        assert http_status_to_coap(503) == 0xA0


### PR DESCRIPTION
Stage 1a of what you asked for in #168, as code rather than prose: the pure envelope translation and its tests, and nothing else. No transport, no config-flow branch, nothing imports it at runtime. Draft on purpose — it is the half that can be reviewed without any of the coordinator churn a transport would need, so "not this shape" costs you one comment.

*Written by Claude Code acting for @perseus177, who owns the appliance and read this before it went out. The field names and values are off that hardware.*

## The part you asked about, in a form you can check

> If you want to propose a design for an isolated shim that could leverage our existing device registry (I could be convinced to add a field or two) […] I simply don't have enough data to understand how complex or flexible that interface/translation layer needs to be.

**The registry needs no new fields.** The whole translation sits below `adapter.py`. Stage 0 in the issue is the evidence: the shimmed dump resolved to `washer`, bound 16 entities and left `unbound_hrefs` empty with `registry/` untouched.

**And the interface is countable.** Across the component the transport is reached in five files, through two verbs:

| file | what it calls |
|---|---|
| `coordinator.py` | `sess.get` ×6, `sess.post` ×2, `pace` ×3, construct/connect/close, `cbor2.loads` ×6 |
| `config_flow.py` | construct/connect, plus `_read_device`'s one `/device/0` GET |
| `registry/identity.py` | `read_identity`'s three GETs |
| `registry/subdevices.py` | one GET helper + `pace` |
| `observe.py` | one `cbor2.loads`, on the notification path only — HTTP never reaches it |

That seam is *not* in this PR. This is only what sits behind it.

## What is here

`legacy_http.py` — a table and four pure functions. Two mechanical rules carry the translation: a field takes the `x.com.samsung.da.` prefix and keeps its name; a resource maps onto the canonical href its fields belong in. Everything not mechanical is a table row, so an appliance that disagrees costs a row rather than a branch.

The one measured family needs three such rows:

| 8888 resource | canonical href | exception |
|---|---|---|
| `Operation` | `/operational/state/vs/0` | `power` → `/power/vs/0`, `kidsLock` → `/kidslock/vs/0` |
| `Mode` | **`/course/vs/0`** | — (note: *not* `/mode/vs/0`, which this firmware 404s) |
| `Washer` | `/washer/vs/0` | — |
| `Configuration` | `/remotectrl/vs/0` | — |
| `Information` | `/information/vs/0` | `modelID`→`modelNum`, `serialNumber`→`serialNum` |
| `Diagnosis` | `/diagnosis/vs/0` | — |
| `Alarms` | `/alarms/vs/0` | bare JSON list → an `items` array of prefixed maps |

Everything else came out mechanical against the registry as it ships today — `state`, `progress`, `progressPercentage`, `remainingTime`, `waterTemperature`, `rinseCycles`, `spinLevel`, `supported*`, `options`, `supportedOptions`, `kidsLock`, `remoteControlEnabled`, `diagnosisStart` are all the same names your capabilities already read, one prefix apart.

`to_write` takes a **list** of steps and coalesces them into one aggregate body, because on this firmware a cycle is accepted only in the same body as `Operation.state` — a `Course_` token alone is answered `204` and discarded in every shape tried, including a two-token body alongside `LaundryOutTime` that applied the other token in the same call. That is a firmware rule about that field, not a syntax problem, and it isn't exotic to this transport either: `async_raw_write_sequence` exists here (#300) because a wall oven discards settings writes while idle and keeps them only once a cycle is running. Same fact, different family, over CoAP.

`http_status_to_coap` keeps one vocabulary above the seam, so `_coap_accepted`, `_coap_code_str`, diagnostics and the debug services work unchanged. `204 → 2.04` is exact in the unwelcome sense too: accepted is not applied on either transport (an ARTIK051 AC answers `2.04` to `FilterTime_0`, echoes the token, and has dropped it a poll later), which is why the read-back in `_raw_write_blocking` is the right posture for both.

## What is deliberately not here

- **A device-dump fixture.** This appliance leaves the network minutes after it goes idle unless Remote Control is on, and it is off right now, so the binding assertion — run the dump through `by_type.resolve()` and `discover()`, assert the 16 entities and the empty `unbound_hrefs` — is a second commit when it is next running. The test bodies in this PR are hand-built from measured field names and values and say so in the module docstring; they pin the shape of the translation, and nothing in them stands in for a dump.
- **The transport, the config flow, entities.** Staging is in #168. The seam is the part that touches your code, and I would rather implement the one you want than argue for mine.
- **Anything about credentials.** The line you drew doesn't move: the user supplies the CA, and on this family a device token as well; nothing ships either.

If you would rather this didn't ship inside `custom_components/` until something imports it, say so and I will move it under `tests/` as a harness — the tests are the point either way. And if the answer is that the family stays out of scope, that is a fine answer too: the standalone integration works, and closing this costs nothing.
