### PR TITLE
Narrow the dryer's dry time to the selected course

### DIFF
--- a/custom_components/localthings/registry/capabilities/dryer.py
+++ b/custom_components/localthings/registry/capabilities/dryer.py
@@ -14,6 +14,7 @@ from ..entities import SelectDesc, SensorDesc, SwitchDesc
 from .common import diagnosis_status
 from .laundry import (
     OPTION_KIND_DRY,
+    OPTION_KIND_DRY_TIME,
     course_narrowed_options,
     cycle_select,
     drum_clean_cycles_remaining,
@@ -74,12 +75,22 @@ DRYER_SETTINGS = Capability(
             ),
             write_fn=_setting_write("x.com.samsung.da.dryLevel"),
         ),
+        # Narrowed on 0xE, which pairs with dry_level's 0xD rather than
+        # duplicating it: on the DV6800N no course carries values for both,
+        # so a dry-level course collapses this dropdown to its live value and
+        # a timed course collapses dry_level's. The four boards reporting
+        # supportedDryTime without a 0xE group decode to "no opinion" and
+        # keep the full list.
         SelectDesc(
             key="dry_time",
             field="x.com.samsung.da.dryTime",
             icon="mdi:timer",
             entity_category="config",
-            options_field="x.com.samsung.da.supportedDryTime",
+            options=course_narrowed_options(
+                OPTION_KIND_DRY_TIME,
+                "x.com.samsung.da.dryTime",
+                "x.com.samsung.da.supportedDryTime",
+            ),
             exists_fn=lambda rep, resources: bool(rep.get("x.com.samsung.da.supportedDryTime")),
             write_fn=_setting_write("x.com.samsung.da.dryTime"),
         ),

--- a/custom_components/localthings/registry/capabilities/laundry.py
+++ b/custom_components/localthings/registry/capabilities/laundry.py
@@ -266,15 +266,17 @@ def drum_clean_last_cleaned(rep):
 # The mask indexes that option's own supported<Option> list, and so does
 # the default nibble -- but into the list, not into the mask: a dishwasher
 # reports default 0 with a mask allowing only index 1. It is one byte, so
-# it cannot address past index 7: three boards carry an 11- or 13-entry
+# it cannot address past index 7: four boards carry an 11- or 13-entry
 # supportedDryTime, and none of them carries a group for it.
 #
-# Four kinds are named: 0x8 water temperature, 0x9 rinse and 0xA spin from a
+# Five kinds are named: 0x8 water temperature, 0x9 rinse and 0xA spin from a
 # WW6500 panel reading plus a list-length argument (the reading alone cannot
-# separate rinse from spin), 0xD dry from a DV5000T's. The rest stay unnamed,
-# 0xB included -- but 0xB, not 0xD, is the dry dial on the WW6600R combo,
-# which carries no 0xD at all, so a gate keyed on 0xD alone silently no-ops
-# there. Evidence for all of it in docs/investigations/course-option-groups.md.
+# separate rinse from spin), 0xD dry from a DV5000T's, and 0xE dry time from
+# the DV6800N, where it complements 0xD course for course. The rest stay
+# unnamed, 0xB included -- but 0xB, not 0xD, is the dry dial on the WW6600R
+# combo, which carries no 0xD at all, so a gate keyed on 0xD alone silently
+# no-ops there. Evidence for all of it in
+# docs/investigations/course-option-groups.md.
 #
 # A kind is not an entity name: dishwashers carry 0xD with no
 # supportedDryLevel at all (their dry setting is heated_dry), so callers key
@@ -297,11 +299,20 @@ OPTION_KIND_RINSE = 0x9
 OPTION_KIND_SPIN = 0xA
 OPTION_KIND_DRY = 0xD
 
+# Named on one board, but not on "it decodes against supportedDryTime"
+# alone: on the DV6800N -- the only dump carrying both -- every record holds
+# a 0xD and a 0xE group, no course carries values for both, and the only
+# one carrying values for neither is Quick Dry, which takes no dry setting
+# at all. A kind that was not the dry dial's timed counterpart would not
+# complement it that precisely. See the investigation doc; a second board
+# carrying 0xE would settle it outright.
+OPTION_KIND_DRY_TIME = 0xE
+
 # A mask is one byte, so it can only speak about the first eight entries of
-# the supported<Option> list it indexes. Three boards carry an 11- or
-# 13-entry supportedDryTime; none of them carries a group for it today, so
-# nothing currently relies on this, but a list longer than this is one the
-# mask only partially describes.
+# the supported<Option> list it indexes. Four boards carry an 11- or
+# 13-entry supportedDryTime and no group for it, so their dry time is not
+# narrowed at all; where a board carries both, this keeps the unaddressable
+# tail rather than reading its absence from the mask as a refusal.
 MASK_ADDRESSABLE = 8
 
 

--- a/docs/investigations/course-option-groups.md
+++ b/docs/investigations/course-option-groups.md
@@ -38,13 +38,16 @@ written for (distinct course bytes, the selected course present, and any live
 
 **The mask is one byte**, so it cannot address past index 7. Most lists are
 comfortably shorter, but `supportedDryTime` is 11 entries on `dryer` and
-`dryer_tp1_21_drum_clean` and 13 on `washer_dryer_onebody_awm` (as is
-`washer_wa8000t`'s 12-entry `supportedWaterHeight`). None of those boards
+`dryer_tp1_21_drum_clean` and 13 on `dryer_dv80h` and
+`washer_dryer_onebody_awm` (as is `washer_wa8000t`'s 12-entry
+`supportedWaterHeight`). None of those four boards
 carries a group for it, so nothing here contradicts the format — but whatever
-encodes dry time on them is not an 8-bit-mask group of this shape, which is
-worth knowing before gating a dry-time entity on one.
+encodes dry time on them is not an 8-bit-mask group of this shape. The dryer's
+`dry_time` select is gated on `0xE` and so simply does not narrow there; a
+board that carried both a long list and a group for it would be the first to
+need more than a byte.
 
-## The four named kinds
+## The five named kinds
 
 | Kind | Named | Evidence |
 | --- | --- | --- |
@@ -52,6 +55,7 @@ worth knowing before gating a dry-time entity on one.
 | `0x9` | rinse | the same reading pins the set; `0xA` is ruled out as rinse below |
 | `0xA` | spin | as above — the only one of the two that can address index 6 |
 | `0xD` | dry | DV5000T owner's per-course panel report, corroborated by the DV6800N on a different board and code space |
+| `0xE` | dry time | the DV6800N again: it complements `0xD` course for course, and decodes against `supportedDryTime` |
 
 **`0xD`.** A DV5000T owner reported what their panel offers per course, and
 its fourteen records reproduce that exactly. The DV6800N (`dryer_dv6800n`) is
@@ -61,6 +65,33 @@ range on Cotton/Mixed/Synthetics, one fixed level on Wool and Iron Dry, a
 different one on Bedding and Delicates, a timed dry instead on Cool Air/Warm
 Air/Time Dry, neither on Quick Dry. It is also the only dump carrying both
 `0xD` and `0xE`, and no course offers both.
+
+**`0xE`.** Named on that one board, but on the complement rather than on
+"it decodes against `supportedDryTime`" — which on its own is weak, since a
+six-entry list absorbs most masks without complaint. Every one of the
+DV6800N's fourteen records carries *both* a `0xD` and a `0xE` group, and the
+exclusion above is carried by an empty mask rather than a missing group:
+
+| courses | `0xD` | `0xE` |
+| --- | --- | --- |
+| the ten level-dried ones (Cotton, Wool, Iron Dry, Bedding, Delicates, …) | values | `E000` |
+| the three timed ones (Cool Air, Warm Air, Time Dry) | `D000` | values |
+| Quick Dry 35 | `D000` | `E000` |
+
+A kind unrelated to the dry dial would not go quiet exactly where the dry
+dial speaks and speak exactly where it goes quiet, across fourteen courses.
+The one course offering neither is Quick Dry, which takes no dry setting at
+all — so the complement is total wherever there is anything to complement.
+
+Corroborated the same way the WW6500's record shape is: this dump's
+`/course/vs/0` options carry a `MostUsed_9AD20EE000` token, byte-identical
+to course `9A`'s record, which pins the 5-byte width and both groups
+independently of the header.
+
+A second board carrying `0xE` would settle it outright. Until then this is
+one board's structure, and the four boards reporting a `supportedDryTime`
+with no `0xE` group anywhere decode to "no opinion" and keep their full
+list — so naming it narrows nothing that was not described.
 
 **`0x8` / `0x9` / `0xA`.** A WW6500 owner read one course's three dials off
 the panel: Cold/20/30/40 with no "None", every rinse count, every spin
@@ -127,12 +158,7 @@ board whose `dry_level` select it would be narrowing.
 ## Unnamed
 
 `0x0`, `0x5`, `0x6`, `0x7`, `0xB` and `0xC` all occur, none pinned beyond the
-above. `0xE` behaves like dry time on the DV6800N — decodes against
-`supportedDryTime`, mutually exclusive with `0xD` — but one board is not a
-pin; name it in the change that consumes it. Note that the DV6800N's
-`supportedDryTime` is six entries, and the three boards with an 11- or
-13-entry one carry no `0xE` at all, so the mask width says nothing has been
-seen that a single byte could not address.
+above.
 
 `0x6` is the one kind that reaches bit 7 anywhere in the corpus
 (`washer_wa8000t`, mask `0xA1` on eight of its thirteen courses). No named

--- a/tests/test_dryer_capabilities.py
+++ b/tests/test_dryer_capabilities.py
@@ -185,3 +185,65 @@ def test_dv6800n_course_codes_read_from_dump():
     assert desc.translation_key(resources) == "dryer_cycle_table_00"
     confirmed = ["9A", "CA", "DB", "99", "93", "B5", "D7", "A5", "96", "97", "7F", "98", "EB", "B6"]
     assert desc.options(resources) == confirmed
+
+
+def _settings_desc(key):
+    return next(e for e in dryer.DRYER_SETTINGS.entities if e.key == key)
+
+
+def _on_course(resources, code):
+    """The same dump with a different course selected."""
+    rep = dict(resources["/course/vs/0"])
+    rep["x.com.samsung.da.options"] = [
+        f"Course_{code}" if o.startswith("Course_") else o for o in rep["x.com.samsung.da.options"]
+    ]
+    return {**resources, "/course/vs/0": rep}
+
+
+def test_dv6800n_dry_time_and_dry_level_narrow_to_complementary_courses():
+    """The two dials are mutually exclusive per course on this board (see
+    test_dv6800n_dry_policy_agrees_with_the_other_board_family), so narrowing
+    both collapses whichever one the selected course does not use down to its
+    live value -- rather than offering a dial the appliance will ignore.
+
+    Course 9A (Cotton) is a dry-level course and 7F (Time Dry) a timed one.
+    The live dryTime is 00:00:00 throughout this dump, which is why it
+    survives on 7F despite sitting outside that course's mask: the union
+    that keeps a live value addressable is what stops the entity reading as
+    unknown mid-course-change.
+    """
+    _, resources = _dv6800n()
+    level, timed = _settings_desc("dry_level"), _settings_desc("dry_time")
+
+    cotton = _on_course(resources, "9A")
+    assert level.options(cotton) == ["1", "2", "3"]
+    assert timed.options(cotton) == ["00:00:00"]
+
+    time_dry = _on_course(resources, "7F")
+    assert level.options(time_dry) == ["2"]
+    assert timed.options(time_dry) == [
+        "00:00:00",
+        "00:30:00",
+        "01:00:00",
+        "01:30:00",
+        "02:00:00",
+        "02:30:00",
+    ]
+
+
+def test_dry_time_keeps_its_full_list_where_the_board_carries_no_0xe_group():
+    """Every board here but the DV6800N reports a supportedDryTime with no
+    0xE group anywhere in supportedOptions. Absence there is not a refusal --
+    course_option_mask returns None and the full list stands, so naming 0xE
+    narrows nothing on a board that never spoke about it.
+
+    All four are checked rather than one, because they are also the boards
+    whose lists run past the eight entries a one-byte mask can address: if a
+    later dump pairs a long list with a 0xE group, this is where it surfaces.
+    """
+    desc = _settings_desc("dry_time")
+    for name in ("dryer", "dryer_dv80h", "dryer_tp1_21_drum_clean", "washer_dryer_onebody_awm"):
+        resources = _load_device(name)
+        supported = resources["/washer/vs/0"]["x.com.samsung.da.supportedDryTime"]
+        assert len(supported) >= 11, name
+        assert desc.options(resources) == supported, name

--- a/tests/test_laundry_capabilities.py
+++ b/tests/test_laundry_capabilities.py
@@ -632,15 +632,32 @@ class TestCourseOptionGroupsAcrossCorpus:
         policy = {}
         for code in laundry.cycle_options(resources):
             dry = laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY, course=code)
-            timed = laundry.course_option_mask(resources, 0xE, course=code)
+            timed = laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY_TIME, course=code)
             policy[code] = (
                 [levels[i] for i in dry[1]] if dry else [],
                 [times[i] for i in timed[1]] if timed else [],
             )
 
         # No course offers both -- the mutual exclusion the DV5000T owner
-        # described, corroborated here on a board they have never seen.
+        # described, corroborated here on a board they have never seen. It is
+        # also what OPTION_KIND_DRY_TIME's naming rests on, so the complement
+        # is pinned too: every course but Quick Dry offers exactly one of the
+        # two, which a kind unrelated to the dry dial would not do.
         assert [c for c, (lv, tm) in policy.items() if lv and tm] == []
+        assert [c for c, (lv, tm) in policy.items() if not lv and not tm] == ["98"]
+
+        # Both groups are present on every record regardless -- the exclusion
+        # is carried by an empty mask, not by a missing group. That is what
+        # lets course_narrowed_options collapse the dial that does not apply
+        # instead of reading its absence as "no opinion".
+        records = laundry._course_records(resources["/course/vs/0"])
+        assert len(records) == 14
+        for code in records:
+            assert laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY, code) is not None
+            assert (
+                laundry.course_option_mask(resources, laundry.OPTION_KIND_DRY_TIME, code)
+                is not None
+            )
 
         assert policy["9A"][0] == ["1", "2", "3"]  # Cotton
         assert policy["B5"][0] == ["1"]  # Wool


### PR DESCRIPTION
First, an apology: I went quiet on #407 and #408 for the last two weeks. Work got very busy and I simply dropped the thread — sorry. Thank you for carrying the review fixes into #425 and the catalog into #442 rather than sitting waiting on me for a push. Picking the agreed sequence back up here.

## Summary

`dry_time` offered every duration its board supports on every course. A write outside what the running course accepts is silently ignored by the appliance — no error, no state change, nothing the user can see. This narrows it with `course_narrowed_options`, the factory #442 was written as so the follow-ups could reuse it.

No new mechanism was needed: the dry-level/dry-time exclusivity falls out of the existing factory.

## Naming `0xE`

Named here rather than in #425, per that PR's own framing — name it in the change that consumes it.

The evidence is the **complement**, not "it decodes against `supportedDryTime`", which on its own is weak since a six-entry list absorbs most masks without complaint. On the DV6800N, the only dump carrying both, every one of the fourteen records holds *both* a `0xD` and a `0xE` group, and the exclusion is carried by an empty mask rather than a missing group:

| courses | `0xD` | `0xE` |
| --- | --- | --- |
| the ten level-dried ones (Cotton, Wool, Iron Dry, Bedding, Delicates, …) | values | `E000` |
| the three timed ones (Cool Air, Warm Air, Time Dry) | `D000` | values |
| Quick Dry 35 | `D000` | `E000` |

A kind unrelated to the dry dial would not go quiet exactly where the dry dial speaks and speak exactly where it goes quiet, across fourteen courses. The one course offering neither is Quick Dry, which takes no dry setting at all — so the complement is total wherever there is anything to complement.

Corroborated the same way the WW6500's record shape was: this dump's `/course/vs/0` options carry a `MostUsed_9AD20EE000` token, byte-identical to course `9A`'s record, which pins the 5-byte width and both groups independently of the header.

A second board carrying `0xE` would settle it outright. Until then this is one board's structure, and the write-up says so rather than claiming more.

## Effect

On the DV6800N, Cotton gives `dry_level = ["1", "2", "3"]` and `dry_time = ["00:00:00"]`; Time Dry inverts it. The dial the selected course does not use collapses to its live value instead of offering settings the appliance will ignore.

Everywhere else nothing changes. The four boards reporting a `supportedDryTime` with no `0xE` group anywhere decode to "no opinion" and keep their full list, and `dryer_dve50a8600` (no `supportedDryTime` at all) stays suppressed by its `exists_fn`.

> [!IMPORTANT]
> Same behaviour change as #442: an automation that was quietly no-opping on a duration the running course refuses will now raise a visible `ServiceValidationError` instead. That is the win, but users will notice it.

## A count correction

The module comment and the investigation doc both said three boards carry an 11- or 13-entry `supportedDryTime` with no group for it. It is four — `dryer_dv80h`'s 13-entry list landed after that count was written, and the doc's enumeration never picked it up. Corrected in both, and the new test loops all four rather than asserting on one, so the claim is pinned rather than restated. If a later dump ever pairs a long list with a `0xE` group, that test is where it surfaces.

## Validation

- 2005 tests pass; `ruff check`, `ruff format --check` and `ty check custom_components tests` all clean
- No golden changes — goldens carry `state_keys`, and narrowing only touches `options`
- Both new tests confirmed to fail when the descriptor wiring is reverted, and to pass when it is restored
- `test_dv6800n_dry_policy_agrees_with_the_other_board_family` extended to pin the complement, and that both groups are structurally present on every record — the exclusion has to stay an empty-mask fact, since that is what lets the factory collapse the unused dial rather than read it as "no opinion"

## Not included

The washer's spin/rinse/temperature, which is the rest of the sequence we agreed. #465 looks to be covering that ground already, so I have left it alone rather than duplicate the work — happy to help there instead if it is useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
